### PR TITLE
[uartex] Add match type to state and improve data validation

### DIFF
--- a/components/uartex/__init__.py
+++ b/components/uartex/__init__.py
@@ -10,7 +10,7 @@ from .const import CONF_RX_HEADER, CONF_RX_FOOTER, CONF_TX_HEADER, CONF_TX_FOOTE
     CONF_RX_CHECKSUM, CONF_TX_CHECKSUM, CONF_RX_CHECKSUM_2, CONF_TX_CHECKSUM_2, \
     CONF_UARTEX_ID, CONF_ERROR, CONF_LOG, CONF_ON_TX_TIMEOUT, CONF_RX_PRIORITY, \
     CONF_ACK, CONF_ON_WRITE, CONF_ON_READ, \
-    CONF_STATE, CONF_MASK, \
+    CONF_STATE, CONF_MASK, CONF_MATCH, \
     CONF_STATE_ON, CONF_STATE_OFF, CONF_COMMAND_ON, CONF_COMMAND_OFF, \
     CONF_COMMAND_UPDATE, CONF_RX_TIMEOUT, CONF_TX_TIMEOUT, CONF_TX_RETRY_CNT, CONF_TX_COMMAND_QUEUE_SIZE, \
     CONF_STATE_RESPONSE, CONF_LENGTH, CONF_PRECISION, CONF_RX_LENGTH, \
@@ -80,6 +80,17 @@ def validate_decode(value):
         return cv.enum(DECODES, upper=True)(value)
     raise cv.Invalid("data type error")
 
+Match = uartex_ns.enum("MATCH")
+MATCHES = {
+    "PREFIX": Match.MATCH_PREFIX,
+    "EXACT": Match.MATCH_EXACT
+}
+
+def validate_match(value):
+    if isinstance(value, str):
+        return cv.enum(MATCHES, upper=True)(value)
+    raise cv.Invalid("data type error")
+
 Priority = uartex_ns.enum("PRIORITY")
 PRIORITYS = {
     "DATA": Priority.PRIORITY_DATA,
@@ -105,7 +116,8 @@ STATE_SCHEMA = cv.Schema({
     cv.Required(CONF_DATA): validate_hex_data,
     cv.Optional(CONF_MASK, default=[]): validate_hex_data,
     cv.Optional(CONF_OFFSET, default=0): cv.int_range(min=0, max=128),
-    cv.Optional(CONF_INVERTED, default=False): cv.boolean
+    cv.Optional(CONF_INVERTED, default=False): cv.boolean,
+    cv.Optional(CONF_MATCH, default="PREFIX"): validate_match
 })
 
 def shorthand_state(value):
@@ -408,7 +420,8 @@ def state_hex_expression(conf):
     mask = conf[CONF_MASK]
     offset = conf[CONF_OFFSET]
     inverted = conf[CONF_INVERTED]
-    return state_t(data, mask, offset, inverted)
+    match = conf[CONF_MATCH]
+    return state_t(data, mask, offset, inverted, match)
 
 def state_num_hex_expression(conf):
     if conf is None:

--- a/components/uartex/const.py
+++ b/components/uartex/const.py
@@ -20,6 +20,7 @@ CONF_TX_CHECKSUM_2 = 'tx_checksum2'
 CONF_RX_PRIORITY = 'rx_priority'
 CONF_TX_COMMAND_QUEUE_SIZE = 'tx_command_queue_size'
 CONF_MASK = 'mask'
+CONF_MATCH = 'match'
 CONF_ERROR = 'error'
 CONF_LOG = 'log'
 CONF_DISABLED = "disabled"

--- a/components/uartex/parser.cpp
+++ b/components/uartex/parser.cpp
@@ -4,6 +4,7 @@ Parser::Parser()
 {
     checksum_len_ = 0;
     total_len_ = 0;
+    buffer_len_ = 256;
 }
 
 Parser::~Parser()

--- a/components/uartex/uartex.cpp
+++ b/components/uartex/uartex.cpp
@@ -128,8 +128,9 @@ bool UARTExComponent::verify_ack()
 void UARTExComponent::publish_data()
 {
     auto& data = this->rx_parser_.data();
-    this->read_callback_.call(&this->rx_parser_.buffer()[0], this->rx_parser_.buffer().size());
-    publish_rx_log(this->rx_parser_.buffer());
+    auto& buf = this->rx_parser_.buffer();
+    if (!buf.empty()) this->read_callback_.call(buf.data(), buf.size());
+    publish_rx_log(buf);
     for (UARTExDevice* device : this->devices_)
     {
         device->parse_data(data);
@@ -217,7 +218,7 @@ void UARTExComponent::write_tx_cmd()
     this->tx_retry_cnt_++;
     this->tx_time_ = get_time();
     if (current_tx_cmd()->ack.empty()) tx_cmd_result(true);
-    this->write_callback_.call(&command[0], command.size());
+    if (!command.empty()) this->write_callback_.call(command.data(), command.size());
     publish_tx_log(command);
 }
 

--- a/components/uartex/uartex_device.cpp
+++ b/components/uartex/uartex_device.cpp
@@ -63,7 +63,7 @@ std::vector<uint8_t> UARTExDevice::last_state()
 
 uint8_t UARTExDevice::last_state(const uint16_t index)
 {
-    if (index < 0 || index >= last_state_.size()) return 0;
+    if (index >= last_state_.size()) return 0;
     return last_state_[index];
 }
 
@@ -184,6 +184,10 @@ std::vector<uint8_t> apply_mask(const std::vector<uint8_t>& data, const state_t*
 bool verify_state(const std::vector<uint8_t>& data, const state_t* state)
 {
     if (state == nullptr) return false;
+    if (state->match == MATCH_EXACT)
+    {
+        if (data.size() != state->offset + state->data.size()) return false;
+    }
     return equal(apply_mask(data, state), state->data, state->offset) ? !state->inverted : state->inverted;
 }
 
@@ -272,7 +276,7 @@ std::string to_ascii_string(const uint8_t* data, const uint16_t len)
         std::snprintf(buf, sizeof(buf), "%c", data[i]);
         ascii_str.append(buf);
     }
-    if (len > 120) ascii_str.append("...");
+    if (len > 240) ascii_str.append("...");
     char size_buf[16] = {0};
     std::snprintf(size_buf, sizeof(size_buf), "(%u)", len);
     ascii_str.append(size_buf);
@@ -295,13 +299,13 @@ std::vector<std::string> split(const std::string& str, const std::string& delimi
 
 std::string get_token(const std::vector<std::string>& tokens, size_t index, const std::string& default_val) 
 {
-    if (index < 0 || index >= tokens.size()) return default_val;
+    if (index >= tokens.size()) return default_val;
     return tokens[index];
 }
 
 bool check_value(const uint16_t index, const uint8_t value, const uint8_t* data, const uint16_t len)
 {
-    if (index < 0 || index >= len) return false;
+    if (index >= len) return false;
     return data[index] == value;
 }
 

--- a/components/uartex/uartex_device.h
+++ b/components/uartex/uartex_device.h
@@ -27,6 +27,10 @@ enum DECODE {
     DECODE_ASCII
 };
 
+enum MATCH {
+    MATCH_PREFIX,
+    MATCH_EXACT
+};
 
 struct state_t
 {
@@ -34,13 +38,15 @@ struct state_t
     std::vector<uint8_t> mask;
     uint16_t offset;
     bool inverted;
-    state_t() = default;
+    MATCH match;
+    state_t() : offset(0), inverted(false), match(MATCH_PREFIX) {}
     state_t(
         std::initializer_list<uint8_t> data, 
         std::initializer_list<uint8_t> mask = {}, 
         uint16_t offset = 0, 
-        bool inverted = false)
-    : data(data), mask(mask), offset(offset), inverted(inverted) {}
+        bool inverted = false,
+        MATCH match = MATCH_PREFIX)
+    : data(data), mask(mask), offset(offset), inverted(inverted), match(match) {}
 };
 
 struct state_num_t

--- a/components/uartex/version.h
+++ b/components/uartex/version.h
@@ -1,2 +1,2 @@
 #pragma once
-#define UARTEX_VERSION "6.0.5-251217"
+#define UARTEX_VERSION "6.1.0-260107"


### PR DESCRIPTION
Introduces a 'match' option to state configuration, supporting PREFIX and EXACT match types, and updates related validation and C++ structures. Fixes out-of-bounds checks, increases ASCII string truncation threshold, and updates version to 6.1.0-260107.