### PR TITLE
Set supported modes in setters; fix sensor access

### DIFF
--- a/components/uartex/climate/uartex_climate.cpp
+++ b/components/uartex/climate/uartex_climate.cpp
@@ -86,9 +86,6 @@ climate::ClimateTraits UARTExClimate::traits()
     {
         traits.add_feature_flags(climate::CLIMATE_SUPPORTS_TARGET_HUMIDITY);
     }
-    if (!this->custom_fan_modes_.empty()) traits.set_supported_custom_fan_modes(this->custom_fan_modes_);
-    if (!this->custom_preset_modes_.empty()) traits.set_supported_custom_presets(this->custom_preset_modes_);
-
     if (get_command_cool() || get_state_cool()) traits.add_supported_mode(climate::CLIMATE_MODE_COOL);
     if (get_command_heat() || get_state_heat()) traits.add_supported_mode(climate::CLIMATE_MODE_HEAT);
     if (get_command_fan_only() || get_state_fan_only()) traits.add_supported_mode(climate::CLIMATE_MODE_FAN_ONLY);

--- a/components/uartex/climate/uartex_climate.h
+++ b/components/uartex/climate/uartex_climate.h
@@ -13,8 +13,14 @@ public:
     void dump_config() override;
     void setup() override;
     void set_sensor(sensor::Sensor* sensor) { this->sensor_ = sensor; }
-    void set_custom_fan_modes(std::initializer_list<const char *> modes) { this->custom_fan_modes_ = modes; }
-    void set_custom_preset_modes(std::initializer_list<const char *> modes) { this->custom_preset_modes_ = modes; }
+    void set_custom_fan_modes(std::initializer_list<const char *> modes) {
+        this->custom_fan_modes_ = modes;
+        this->set_supported_custom_fan_modes(this->custom_fan_modes_);
+    }
+    void set_custom_preset_modes(std::initializer_list<const char *> modes) {
+        this->custom_preset_modes_ = modes;
+        this->set_supported_custom_presets(this->custom_preset_modes_);
+    }
 
 protected:
     void publish(const std::vector<uint8_t>& data) override;

--- a/components/uartex/fan/uartex_fan.cpp
+++ b/components/uartex/fan/uartex_fan.cpp
@@ -22,7 +22,6 @@ fan::FanTraits UARTExFan::get_traits()
         traits.set_speed(true);
         traits.set_supported_speed_count(this->speed_count_);
     }
-    if (!this->preset_modes_.empty()) traits.set_supported_preset_modes(this->preset_modes_);
     return traits;
 }
 

--- a/components/uartex/fan/uartex_fan.h
+++ b/components/uartex/fan/uartex_fan.h
@@ -10,7 +10,10 @@ class UARTExFan : public fan::Fan, public UARTExDevice
 public:
     void dump_config() override;
     void set_speed_count(uint16_t count) { this->speed_count_ = count; }
-    void set_preset_modes(std::initializer_list<const char *> presets) { this->preset_modes_ = presets; }
+    void set_preset_modes(std::initializer_list<const char *> presets) {
+        this->preset_modes_ = presets;
+        this->set_supported_preset_modes(this->preset_modes_);
+    }
 protected:
     fan::FanTraits get_traits() override;
     void publish(const std::vector<uint8_t>& data) override;

--- a/components/uartex/sensor/uartex_sensor.cpp
+++ b/components/uartex/sensor/uartex_sensor.cpp
@@ -18,12 +18,12 @@ void UARTExSensor::publish(const std::vector<uint8_t>& data)
 {
     {
         optional<float> val = get_state_float("lambda", data);
-        if(val.has_value() && this->raw_state != val.value()) publish_state(val.value());
+        if(val.has_value() && this->get_raw_state() != val.value()) publish_state(val.value());
     }
 
     {
         optional<float> val = get_state_number(data);
-        if(val.has_value() && this->raw_state != val.value()) publish_state(val.value());
+        if(val.has_value() && this->get_raw_state() != val.value()) publish_state(val.value());
     }
 }
 


### PR DESCRIPTION
Move supported-mode registration into setter methods for climate and fan components so supported custom/preset modes are applied at configuration time (uartex_climate.h, uartex_fan.h) and remove checks from trait generation (uartex_climate.cpp, uartex_fan.cpp). Also replace direct raw_state access in the UARTEx sensor with the get_raw_state() accessor to respect encapsulation (uartex_sensor.cpp). These changes ensure supported modes are registered immediately when configured and improve state access safety.