### PR TITLE
feat(ble_elm327): switch defaults to vLinker and harden init sequence

### DIFF
--- a/components/ble_elm327/README.md
+++ b/components/ble_elm327/README.md
@@ -15,6 +15,7 @@ The component registers as a node under ESPHome's standard `ble_client:` compone
 
 - [Installation](#installation)
 - [Quick Start](#quick-start)
+- [Real-world Example (Colorado Tab5 + vLinker)](#real-world-example-colorado-tab5--vlinker)
 - [Configuration Reference](#configuration-reference)
   - [Core Component](#core-component)
   - [Device Schema](#device-schema)
@@ -76,6 +77,27 @@ sensor:
 
 ---
 
+## Real-world Example (Colorado Tab5 + vLinker)
+
+A production setup for **M5Stack Tab5** + **vLinker MC+** on a Chevrolet Colorado is maintained in this repo:
+
+- Package: [`packages/display/colorado/colorado-ble-elm327.yaml`](../../packages/display/colorado/colorado-ble-elm327.yaml)
+- Full dashboard: [`packages/display/colorado/colorado-tab5.yaml`](../../packages/display/colorado/colorado-tab5.yaml)
+- Docs: [`packages/display/colorado/README.md`](../../packages/display/colorado/README.md#ble_elm327-setup-vlinker-obd2)
+
+Production configuration used in Colorado setup:
+
+```yaml
+ble_elm327:
+  service_uuid: "18F0"
+  rx_char_uuid: "2AF0"
+  tx_char_uuid: "2AF1"
+  init_commands:
+    - "ATSP6"
+```
+
+---
+
 ## Configuration Reference
 
 ### Core Component
@@ -88,14 +110,11 @@ ble_client:
 ble_elm327:
   id: elm
   ble_client_id: obd_client
-  service_uuid: "FFF0"
-  rx_char_uuid: "FFF1"
-  tx_char_uuid: "FFF2"
+  service_uuid: "18F0"
+  rx_char_uuid: "2AF0"
+  tx_char_uuid: "2AF1"
   init_commands:
-    - "ATZ"
-    - "ATE0"
-    - "ATL0"
-    - "ATSP0"
+    - "ATSP6"
   tx_delay: 50
 ```
 
@@ -104,10 +123,10 @@ ble_elm327:
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `ble_client_id` | ID | **Required** | The ID of the parent `ble_client` component |
-| `service_uuid` | UUID | `FFF0` | BLE service UUID of the ELM327 adapter |
-| `rx_char_uuid` | UUID | `FFF1` | BLE notify characteristic UUID (adapter → ESP32) |
-| `tx_char_uuid` | UUID | `FFF2` | BLE write characteristic UUID (ESP32 → adapter) |
-| `init_commands` | list | `[ATZ, ATE0, ATL0, ATSP0]` | AT commands sent on connection. Use `[]` to skip. |
+| `service_uuid` | UUID | `18F0` | BLE service UUID of the ELM327 adapter |
+| `rx_char_uuid` | UUID | `2AF0` | BLE notify characteristic UUID (adapter → ESP32) |
+| `tx_char_uuid` | UUID | `2AF1` | BLE write characteristic UUID (ESP32 → adapter) |
+| `init_commands` | list | *(none)* | Extra AT commands queued **after** the mandatory base sequence (see below). |
 | `tx_delay` | int (ms) | `50` | Minimum delay between consecutive BLE writes |
 
 #### UUID Formats
@@ -115,49 +134,42 @@ ble_elm327:
 All UUID fields accept 16-bit, 32-bit, or 128-bit formats:
 
 ```yaml
-service_uuid: "FFF0"                                    # 16-bit
-service_uuid: "0000FFF0"                                # 32-bit
-service_uuid: "0000fff0-0000-1000-8000-00805f9b34fb"   # 128-bit
+service_uuid: "18F0"                                    # 16-bit
+service_uuid: "000018F0"                                # 32-bit
+service_uuid: "000018f0-0000-1000-8000-00805f9b34fb"   # 128-bit
 ```
 
 #### Init Commands
 
-The default sequence resets the adapter and configures it for silent operation:
+On every BLE connect, the firmware **always** sends this base sequence first (hardcoded in C++, not configurable):
 
-| Command | Effect |
-|---------|--------|
-| `ATZ` | Reset ELM327 |
-| `ATE0` | Echo off |
-| `ATL0` | Linefeeds off |
-| `ATS0` | Spaces off — compact hex responses (`"41051A"` instead of `"41 05 1A"`) |
-| `ATSP0` | Auto-detect OBD protocol |
+| Order | Command | Effect |
+|-------|---------|--------|
+| 1 | `ATZ` | Reset ELM327 |
+| 2 | `ATE0` | Echo off |
+| 3 | `ATL0` | Linefeeds off |
+| 4 | `ATS0` | Spaces off — compact hex responses |
+| 5 | `ATH0` | Headers off |
+| 6 | `ATSP0` | Auto-detect OBD protocol |
 
-To skip initialisation entirely (e.g. adapter is already configured):
+`init_commands` in YAML adds **extra** commands after the base sequence. Omit the key or use `init_commands: []` if you only need the base sequence.
 
-```yaml
-ble_elm327:
-  ble_client_id: obd_client
-  init_commands: []
-```
-
-Custom init sequence example (CAN 500 kbps, headers on):
+Example — CAN 500 kbps and headers off (Colorado / vLinker):
 
 ```yaml
 ble_elm327:
   ble_client_id: obd_client
   init_commands:
-    - "ATZ"
-    - "ATE0"
-    - "ATL0"
-    - "ATSP6"    # ISO 15765-4 CAN (11-bit, 500 kbps)
-    - "ATH0"     # Headers off
+    - "ATSP6"    # ISO 15765-4 CAN (11-bit, 500 kbps) — overrides base ATSP0
 ```
+
+Do not repeat `ATZ`, `ATE0`, `ATL0`, `ATS0`, or `ATH0` in YAML unless you intentionally want them sent twice.
 
 #### Internal State Machine
 
 ```
 IDLE → (BLE connect + service discovery + notify registered)
-     → CONNECTED: init_commands queued into tx_queue
+     → CONNECTED: base init + extra init_commands queued into tx_queue
      → loop() drains tx_queue at tx_delay intervals
      → READY
 ```
@@ -490,11 +502,6 @@ ble_client:
 ble_elm327:
   ble_client_id: obd_client
   init_commands:
-    - "ATZ"
-    - "ATE0"
-    - "ATL0"
-    - "ATS0"
-    - "ATH0"
     - "ATSP6"
 
 sensor:
@@ -824,7 +831,7 @@ sensor:
 | Connects but no data | Wrong service / characteristic UUID | Scan the adapter's BLE services and update `service_uuid`, `rx_char_uuid`, `tx_char_uuid` |
 | `RX characteristic not found` | UUID mismatch | Some adapters use 128-bit UUIDs — use the full form in config |
 | Sensor never updates | PID/mode mismatch or ECU doesn't support it | Enable DEBUG logs and confirm the response byte matches `0x40 + mode`; check `ATDP` to verify protocol |
-| Sensors never update after connect | Adapter slow to respond to init commands | Increase `tx_delay` or set `init_commands: []` |
+| Sensors never update after connect | Adapter slow to respond to init commands | Increase `tx_delay` |
 | Data wrong / garbled | Wrong `formula` | Check raw response in DEBUG logs and adjust formula |
 | Sensors update too fast / slow | Per-sensor `update_interval` | Tune each sensor's `update_interval` independently |
 

--- a/components/ble_elm327/__init__.py
+++ b/components/ble_elm327/__init__.py
@@ -38,11 +38,10 @@ CONFIG_SCHEMA = cv.Schema(
     {
         cv.GenerateID(): cv.declare_id(BleElm327Component),
         cv.Required(CONF_BLE_CLIENT_ID): cv.use_id(ble_client.BLEClient),
-        cv.Optional(CONF_SERVICE_UUID, default="FFF0"): esp32_ble_tracker.bt_uuid,
-        cv.Optional(CONF_RX_CHAR_UUID, default="FFF1"): esp32_ble_tracker.bt_uuid,
-        cv.Optional(CONF_TX_CHAR_UUID, default="FFF2"): esp32_ble_tracker.bt_uuid,
-        cv.Optional(CONF_INIT_COMMANDS, default=["ATZ", "ATE0", "ATL0", "ATS0", "ATSP0"]):
-            cv.ensure_list(cv.string_strict),
+        cv.Optional(CONF_SERVICE_UUID, default="18F0"): esp32_ble_tracker.bt_uuid,
+        cv.Optional(CONF_RX_CHAR_UUID, default="2AF0"): esp32_ble_tracker.bt_uuid,
+        cv.Optional(CONF_TX_CHAR_UUID, default="2AF1"): esp32_ble_tracker.bt_uuid,
+        cv.Optional(CONF_INIT_COMMANDS): cv.ensure_list(cv.string_strict),
         cv.Optional(CONF_TX_DELAY, default=50): cv.positive_int,           # ms
     }
 )
@@ -62,7 +61,7 @@ async def to_code(config):
     _add_uuid(var, config[CONF_TX_CHAR_UUID],
               "set_tx_char_uuid16", "set_tx_char_uuid32", "set_tx_char_uuid128")
 
-    for cmd in config[CONF_INIT_COMMANDS]:
+    for cmd in config.get(CONF_INIT_COMMANDS, []):
         cg.add(var.add_init_command(cmd))
 
     cg.add(var.set_tx_delay(config[CONF_TX_DELAY]))

--- a/components/ble_elm327/ble_elm327.cpp
+++ b/components/ble_elm327/ble_elm327.cpp
@@ -1,5 +1,6 @@
 #include "ble_elm327.h"
 #include "esphome/core/log.h"
+#include <cctype>
 
 #ifdef USE_ESP32
 
@@ -7,6 +8,18 @@ namespace esphome {
 namespace ble_elm327 {
 
 static const char *const TAG = "ble_elm327";
+// Always sent first on connect, in this order, before any YAML init_commands.
+static const char *const BASE_INIT_COMMANDS[] = {"ATZ", "ATE0", "ATL0", "ATS0", "ATH0", "ATSP0"};
+
+static std::string normalize_command(const std::string &cmd) {
+  std::string compact;
+  compact.reserve(cmd.size());
+  for (char c : cmd) {
+    if (std::isspace(static_cast<unsigned char>(c))) continue;  // remove internal spaces too
+    compact.push_back(static_cast<char>(std::tolower(static_cast<unsigned char>(c))));
+  }
+  return compact;
+}
 
 // ── BleElm327Device ─────────────────────────────────────────────────────────
 
@@ -42,6 +55,27 @@ float BleElm327Device::parse_float(const std::vector<uint8_t> &data) {
   float val = 0;
   for (size_t i = 0; i < data.size(); i++) val = val * 256.0f + data[i];
   return val;
+}
+
+void BleElm327Component::add_init_command(const std::string &cmd) {
+  const std::string normalized = normalize_command(cmd);
+  if (normalized.empty()) return;
+
+  for (const char *base_cmd : BASE_INIT_COMMANDS) {
+    if (normalized == normalize_command(base_cmd)) {
+      ESP_LOGD(TAG, "Skip duplicate init command (already in base): %s", normalized.c_str());
+      return;
+    }
+  }
+
+  for (const auto &extra_cmd : extra_init_commands_) {
+    if (normalized == normalize_command(extra_cmd)) {
+      ESP_LOGD(TAG, "Skip duplicate init command (already queued): %s", normalized.c_str());
+      return;
+    }
+  }
+
+  extra_init_commands_.push_back(normalized + "\r");
 }
 
 // ── BleElm327Component ──────────────────────────────────────────────────────
@@ -95,7 +129,8 @@ void BleElm327Component::dump_config() {
   ESP_LOGCONFIG(TAG, "  RX Char UUID       : %s", rx_char_uuid_.to_str(rx_char_uuid_str));
   ESP_LOGCONFIG(TAG, "  TX Char UUID       : %s", tx_char_uuid_.to_str(tx_char_uuid_str));
   ESP_LOGCONFIG(TAG, "  TX delay           : %ums", tx_delay_ms_);
-  ESP_LOGCONFIG(TAG, "  Init commands      : %u", (unsigned)init_commands_.size());
+  ESP_LOGCONFIG(TAG, "  Base init commands : ATZ, ATE0, ATL0, ATS0, ATH0, ATSP0");
+  ESP_LOGCONFIG(TAG, "  Extra init commands: %u", (unsigned)extra_init_commands_.size());
   ESP_LOGCONFIG(TAG, "  Devices            : %u", (unsigned)devices_.size());
   for (auto *d : devices_) d->dump_config();
 }
@@ -147,13 +182,14 @@ void BleElm327Component::gattc_event_handler(esp_gattc_cb_event_t event, esp_gat
       }
       last_tx_time_ = millis();
       elm_state_ = ElmState::CONNECTED;
-      for (const auto &cmd : init_commands_) tx_queue_.push({cmd, nullptr});
-      if (init_commands_.empty()) {
-        elm_state_ = ElmState::READY;
-        ESP_LOGI(TAG, "No init commands — ELM327 ready");
-      } else {
-        ESP_LOGI(TAG, "Queued %u init commands", (unsigned) init_commands_.size());
+      for (const char *cmd : BASE_INIT_COMMANDS) {
+        std::string framed = std::string(cmd) + "\r";
+        tx_queue_.push({framed, nullptr});
       }
+      for (const auto &cmd : extra_init_commands_) tx_queue_.push({cmd, nullptr});
+      ESP_LOGI(TAG, "Queued %u init commands (%u base + %u extra)", (unsigned) tx_queue_.size(),
+               (unsigned)(sizeof(BASE_INIT_COMMANDS) / sizeof(BASE_INIT_COMMANDS[0])),
+               (unsigned) extra_init_commands_.size());
       break;
 
     case ESP_GATTC_NOTIFY_EVT:

--- a/components/ble_elm327/ble_elm327.h
+++ b/components/ble_elm327/ble_elm327.h
@@ -91,7 +91,9 @@ class BleElm327Component : public Component, public ble_client::BLEClientNode {
   void set_tx_char_uuid128(uint8_t *uuid) { tx_char_uuid_ = espbt::ESPBTUUID::from_raw(uuid); }
 
   void add_device(BleElm327Device *d) { devices_.push_back(d); }
-  void add_init_command(const std::string &cmd) { init_commands_.push_back(cmd + "\r"); }
+  // Appends user-defined init commands after the mandatory base sequence (see ble_elm327.cpp).
+  // Duplicate commands (case-insensitive, trimmed) are ignored.
+  void add_init_command(const std::string &cmd);
   void set_tx_delay(uint32_t ms) { tx_delay_ms_ = ms; }
 
  protected:
@@ -118,7 +120,7 @@ class BleElm327Component : public Component, public ble_client::BLEClientNode {
 
   // State machine
   ElmState elm_state_{ElmState::IDLE};
-  std::vector<std::string> init_commands_;
+  std::vector<std::string> extra_init_commands_;
   // Tracks pre_commands currently applied on the ELM327 (e.g., last ATSH).
   // When a device's pre_commands differs, they are re-queued before its PID request.
   std::vector<std::string> current_pre_commands_;

--- a/packages/display/colorado/README.md
+++ b/packages/display/colorado/README.md
@@ -15,8 +15,8 @@ ESPHome configuration for a vehicle dashboard based on the ESP32-P4 EV Board (`e
 
 ## Features
 
-- **Vehicle Telemetry**: Integrates with the custom [ble_elm327](/components/ble_elm327) component to connect to a vLinker BLE OBD2 adapter, exposing Engine RPM, Coolant Temperature, Fuel Level, Engine Load, Speed, Odometer, Gear Position, and Runtime directly as native ESPHome sensors.
-- **Climate Monitoring**: Tracks cabin and bed temperature/humidity using the custom [jaalee_jht](/components/jaalee_jht) BLE component.
+- **Vehicle Telemetry**: Integrates with the custom [ble_elm327](/components/ble_elm327) component to connect to a vLinker BLE OBD2 adapter, exposing Engine RPM, Coolant Temperature, Fuel Level (% and GM liters), Engine Load, Speed, Odometer, Gear Position, PRND, and Runtime as native ESPHome sensors.
+- **Climate Monitoring**: Tracks cabin and cargo-bed (적재함) temperature/humidity using the custom [jaalee_jht](/components/jaalee_jht) BLE component.
 - **Air Quality**: Monitors CO2, eCO2, and TVOC using onboard SCD4x and SGP30 I2C sensors.
 - **Dynamic UI**: LVGL-based UI with dynamic color changes based on sensor values and pop-up alerts for critical conditions (e.g., Overheating, High RPM, Low Fuel, Speeding, Drowsiness Warning via High CO2).
 - **Power Management**: Monitors power consumption using INA226 and controls power peripherals (USB power, Quick Charge, Speakers, etc.) via PI4IOE5V6408 I2C GPIO expanders.
@@ -29,7 +29,7 @@ Add the following to your ESPHome configuration:
 substitutions:
   name: "esp-colorado-tab5"
   friendly_name: "ESP Colorado TAB5"
-  version: "v260405 rev.1"
+  version: "v260602 rev.1"
   number: "12가 1234"
   mac_vlinker: "C0:25:E8:53:2C:90"
   mac_cabin_jht: "DA:E8:DD:E2:9A:47"
@@ -61,6 +61,85 @@ Make sure you have the following defined in your `secrets.yaml`:
 - `mqtt_password`
 
 
+## ble_elm327 Setup (vLinker OBD2)
+
+Production OBD configuration from the Colorado Tab5 dashboard. Tested with a **vLinker MC+** BLE adapter on a **Chevrolet Colorado Z71** (ISO 15765-4 CAN 500 kbps).
+
+### Package include (OBD sensors only)
+
+Add `mac_vlinker` to your substitutions, then include the OBD package. The parent config must already define `esp32`, `esp32_hosted`, and `esp32_ble_tracker` (see `colorado-tab5.yaml` for Tab5 pinout).
+
+```yaml
+substitutions:
+  mac_vlinker: "C0:25:E8:53:2C:90"   # replace with your adapter MAC
+
+packages:
+  remote:
+    refresh: always
+    url: https://github.com/eigger/espcomponents/
+    files:
+      - packages/display/colorado/colorado-ble-elm327.yaml
+```
+
+Source: [`colorado-ble-elm327.yaml`](colorado-ble-elm327.yaml)
+
+### Minimal standalone example
+
+For a new ESP32 board (non-Tab5: omit `esp32_hosted` and use the board’s native BLE):
+
+```yaml
+substitutions:
+  mac_vlinker: "AA:BB:CC:DD:EE:FF"
+
+external_components:
+  - source: github://eigger/espcomponents
+    components: [ ble_elm327 ]
+    refresh: always
+
+esp32_ble_tracker:
+
+ble_client:
+  - mac_address: ${mac_vlinker}
+    id: obd_client
+
+ble_elm327:
+  id: obd_elm
+  ble_client_id: obd_client
+  service_uuid: "18F0"    # vLinker MC+
+  rx_char_uuid: "2AF0"
+  tx_char_uuid: "2AF1"
+  init_commands:
+    - "ATSP6"
+  tx_delay: 50
+
+sensor:
+  - platform: ble_elm327
+    name: "Engine RPM"
+    preset: rpm
+    update_interval: 1s
+  - platform: ble_elm327
+    name: "Car Speed"
+    preset: speed
+    update_interval: 1s
+  - platform: ble_elm327
+    name: "Engine Coolant Temperature"
+    preset: coolant_temp
+    update_interval: 10s
+```
+
+| Setting | vLinker MC+ (Colorado) | Default (many adapters) |
+|---------|------------------------|-------------------------|
+| `service_uuid` | `18F0` | `FFF0` |
+| `rx_char_uuid` | `2AF0` | `FFF1` |
+| `tx_char_uuid` | `2AF1` | `FFF2` |
+| `init_commands` (extra, after base) | `ATSP6` | omit or `[]` (base only) |
+
+GM extended presets (`gm_fuel_level_liters`, `gm_current_gear`, `gm_prnd_status_alt`, `gm_oil_pressure`, `gm_trans_temp`, …) are vehicle-specific. See the [ble_elm327 component docs](/components/ble_elm327/README.md) for the full preset list and troubleshooting.
+
+### Tab5 BLE prerequisite
+
+M5Stack Tab5 routes BLE through an ESP32-C6 co-processor. Include `esp32_hosted` before `esp32_ble_tracker` — copy the block from [`colorado-tab5.yaml`](colorado-tab5.yaml) (lines 106–116).
+
 ## Hardware Configurations
 
 ### Main Board
@@ -72,7 +151,7 @@ Make sure you have the following defined in your `secrets.yaml`:
 Configure your device MAC addresses via `substitutions` variables as shown in the Configuration Usage.
 - **OBD2 BLE Adapter**: `vLinker` (`mac_vlinker`)
 - **Cabin Climate Sensor**: `Jaalee JHT` (`mac_cabin_jht`)
-- **Bed Climate Sensor**: `Jaalee JHT` (`mac_bed_jht`)
+- **Cargo Bed Climate Sensor**: `Jaalee JHT` (`mac_bed_jht`, UI label 적재함)
 - **External Sensors**: Parses `035D` Manufacturer Data (e.g., parking remote / sensors)
 
 ### Sensors & ICs

--- a/packages/display/colorado/colorado-ble-elm327.yaml
+++ b/packages/display/colorado/colorado-ble-elm327.yaml
@@ -1,0 +1,130 @@
+# ble_elm327 — Colorado Tab5 production OBD setup (vLinker MC+)
+#
+# Prerequisites (define in the parent config, see colorado-tab5.yaml):
+#   - esp32 + esp32_hosted (Tab5 BLE on ESP32-C6)
+#   - esp32_ble_tracker:
+#   - substitution: mac_vlinker (BLE MAC of your vLinker adapter)
+#
+# Include alone (OBD sensors only):
+#   packages:
+#     remote:
+#       url: https://github.com/eigger/espcomponents/
+#       files:
+#         - packages/display/colorado/colorado-ble-elm327.yaml
+#
+# Full dashboard: packages/display/colorado/colorado-tab5.yaml
+
+external_components:
+  - source: github://eigger/espcomponents@latest
+    components: [ ble_elm327 ]
+    refresh: always
+
+ble_client:
+  - mac_address: ${mac_vlinker}
+    id: obd_client
+
+ble_elm327:
+  id: obd_elm
+  ble_client_id: obd_client
+  # vLinker MC+ BLE UART service (not the default FFF0/FFF1/FFF2)
+  service_uuid: "18F0"
+  rx_char_uuid: "2AF0"
+  tx_char_uuid: "2AF1"
+  init_commands:
+    - "ATSP6"   # ISO 15765-4 CAN 11-bit 500 kbps (Chevrolet Colorado Z71)
+  tx_delay: 50
+
+sensor:
+  # ── Standard OBD-II (Mode 01) ──────────────────────────────────────────────
+  - platform: ble_elm327
+    name: "Engine Run Time"
+    preset: run_time
+    update_interval: 5s
+
+  - platform: ble_elm327
+    name: "Engine Coolant Temperature"
+    preset: coolant_temp
+    update_interval: 10s
+
+  - platform: ble_elm327
+    name: "Fuel Level"
+    preset: fuel_level
+    update_interval: 30s
+    filters:
+      - median:
+          window_size: 5
+          send_every: 1
+          send_first_at: 1
+      - delta: 0.5
+      - throttle: 60s
+
+  - platform: ble_elm327
+    name: "Fuel Level Liters"
+    preset: gm_fuel_level_liters
+    update_interval: 30s
+
+  - platform: ble_elm327
+    name: "Throttle Position"
+    preset: throttle
+    update_interval: 1s
+
+  - platform: ble_elm327
+    name: "Intake Air Temperature"
+    preset: intake_air_temp
+    update_interval: 10s
+
+  - platform: ble_elm327
+    name: "Ambient Air Temperature"
+    preset: ambient_temp
+    update_interval: 30s
+
+  - platform: ble_elm327
+    name: "Car Battery"
+    preset: battery_voltage
+    update_interval: 10s
+
+  - platform: ble_elm327
+    name: "Engine RPM"
+    preset: rpm
+    update_interval: 1s
+
+  - platform: ble_elm327
+    name: "Engine Load"
+    preset: engine_load
+    update_interval: 1s
+
+  - platform: ble_elm327
+    name: "Car Speed"
+    preset: speed
+    update_interval: 1s
+
+  - platform: ble_elm327
+    name: "Odometer"
+    preset: odometer
+    update_interval: 30s
+
+  # ── GM extended PIDs (Mode 22, Chevrolet Colorado) ─────────────────────────
+  - platform: ble_elm327
+    name: "Gear Position"
+    preset: gm_current_gear
+    update_interval: 1s
+
+  - platform: ble_elm327
+    name: "PRND Status"
+    preset: gm_prnd_status_alt
+    update_interval: 1s
+
+  - platform: ble_elm327
+    name: "Actual Torque"
+    preset: actual_torque
+    update_interval: 1s
+
+  - platform: ble_elm327
+    name: "Engine Oil Pressure"
+    preset: gm_oil_pressure
+    update_interval: 2s
+
+  - platform: ble_elm327
+    name: "Transmission Fluid Temperature"
+    preset: gm_trans_temp
+    update_interval: 10s

--- a/packages/display/colorado/colorado-tab5.yaml
+++ b/packages/display/colorado/colorado-tab5.yaml
@@ -192,11 +192,6 @@ ble_elm327:
   rx_char_uuid: "2AF0"
   tx_char_uuid: "2AF1"
   init_commands:
-    - "ATZ"
-    - "ATE0"
-    - "ATL0"
-    - "ATS0"
-    - "ATH0"
     - "ATSP6"
   tx_delay: 50
 
@@ -587,6 +582,11 @@ sensor:
         - lvgl.widget.update:
             id: widget_img_fuel
             image_recolor: !lambda return id(fn_state_color)(x, 6);
+  - platform: ble_elm327
+    id: "gm_fuel_level_liters"
+    name: "Fuel Level Liters"
+    preset: gm_fuel_level_liters
+    update_interval: 30s
   - platform: ble_elm327
     id: "throttle"
     name: "Throttle Position"
@@ -2227,11 +2227,11 @@ lvgl:
                   pad_all: 0
                   widgets:
                     - image: { src: img_thermometer_sm, align: left_mid, x: 20, y: -16, image_recolor: 0xF1C36C, image_recolor_opa: 100% }
-                    - label: { text: "실외온도", align: left_mid, x: 65, y: -16, text_color: 0x7F8EA3, text_font: notosans25 }
+                    - label: { text: "적재함온도", align: left_mid, x: 65, y: -16, text_color: 0x7F8EA3, text_font: notosans25 }
                     - label: { id: lbl_bed_temperature, text: "--", align: right_mid, x: -250, y: 15, text_color: 0xFFFFFF, text_font: notosans30 }
                     - label: { text: "°C", align: left_mid, x: 165, y: 18, text_color: 0x7F8EA3, text_font: notosans16 }
                     - image: { src: img_water_sm, align: left_mid, x: 220, y: -16, image_recolor: 0xF1C36C, image_recolor_opa: 100% }
-                    - label: { text: "실외습도", align: left_mid, x: 265, y: -16, text_color: 0x7F8EA3, text_font: notosans25 }
+                    - label: { text: "적재함습도", align: left_mid, x: 265, y: -16, text_color: 0x7F8EA3, text_font: notosans25 }
                     - label: { id: lbl_bed_humidity, text: "--", align: right_mid, x: -50, y: 15, text_color: 0xFFFFFF, text_font: notosans30 }
                     - label: { text: "%", align: left_mid, x: 365, y: 18, text_color: 0x7F8EA3, text_font: notosans16 }
               # 3. 공기질 (CO2, TVOC 병합)
@@ -2397,11 +2397,11 @@ font:
     id: notosans16
     size: 16
   - file: "gfonts://Noto+Sans+KR"
-    glyphs: '#()_-+@*/:;?!,.=0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuvwxyz°%실내외온습도기압가속냉각수부하배터리연료운행머버전번호판뚝엔진미션오일명주거[]력팬스템을재시작겠니까예아소모율류로틀개량흡토크화면밝울보정초그록지우'
+    glyphs: '#()_-+@*/:;?!,.=0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuvwxyz°%실내외온습도기압가속냉각수부하배터리연료운행머버전번호판뚝엔진미션오일명주거[]력팬스템을재시작겠니까예아소모율류로틀개량흡토크화면밝울보정초그록지우과의졸음경고환필요급감장치열유'
     id: notosans20
     size: 20
   - file: "gfonts://Noto+Sans+KR"
-    glyphs: '#()_-+@*/:;?!,.0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuvwxyz°%실내외온습도기압가속냉각수부하배터리연료운행머버전번호판뚝엔진미션오일명주거력팬화면밝울보정초로그록지우시스템재작'
+    glyphs: '#()_-+@*/:;?!,.0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuvwxyz°%실내외온습도기압가속냉각수부하배터리연료운행머버전번호판뚝엔진미션오일명주거력팬화면밝울보정초로그록지우시스템재작적'
     id: notosans25
     size: 25
   - file: "gfonts://Noto+Sans+KR"


### PR DESCRIPTION
Make ble_elm327 default UUIDs match vLinker and move the mandatory adapter bootstrap sequence into C++ so it always runs in stable order. Allow user init commands as deduplicated post-base overrides and sync Colorado examples/docs to the new behavior.