### PR TITLE
feat(tca8418_keyboard): add TCA8418 keypad component (M5Cardputer ADV)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@
 **TCA8418 Keyboard Component**  
 - Supports TCA8418 I2C keypad scan IC (M5Cardputer ADV keyboard).
 - Product image:  
-  <img src="https://static-cdn.m5stack.com/resource/docs/products/core/Cardputer-Adv/img-bcc8b8e9-fee9-4239-a2d8-66708cf868de.webp" width="200">
+  <img src="https://m5stack-doc.oss-cn-shenzhen.aliyuncs.com/1178/Cardputer-Adv_02.webp" width="200">
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -61,4 +61,12 @@
   
 ---
 
+## [tca8418_keyboard](/components/tca8418_keyboard)
+**TCA8418 Keyboard Component**  
+- Supports TCA8418 I2C keypad scan IC (M5Cardputer ADV keyboard).
+- Product image:  
+  <img src="https://static-cdn.m5stack.com/resource/docs/products/core/Cardputer-Adv/img-bcc8b8e9-fee9-4239-a2d8-66708cf868de.webp" width="200">
+
+---
+
 

--- a/components/tca8418_keyboard/README.md
+++ b/components/tca8418_keyboard/README.md
@@ -1,0 +1,39 @@
+### TCA8418 Keyboard (M5Cardputer ADV)
+TCA8418 I2C keypad scan IC, mapped to the M5Cardputer ADV 4x14 keyboard layout.
+
+### add esphome *.yaml
+```yaml
+external_components:
+  - source: github://eigger/espcomponents@latest
+    components: [ tca8418_keyboard ]
+
+i2c:
+  sda: 8
+  scl: 9
+
+tca8418_keyboard:
+  address: 0x34
+  model: cardputer_adv   # key layout / scan remap (default)
+  irq_pin:
+    number: 11
+    mode: INPUT
+  # Automation triggers (the pressed key string is passed as `x`)
+  on_key_press:
+    - lambda: |-
+        ESP_LOGI("kb", "pressed: %s", x.c_str());
+  on_key_release:
+    - lambda: |-
+        ESP_LOGI("kb", "released: %s", x.c_str());
+  # Optional text sensors (e.g. to show the last key in Home Assistant)
+  press_key:
+    name: press key
+  release_key:
+    name: release key
+```
+- `model` selects the key map and the scan->layout remap. Currently `cardputer_adv` (M5Cardputer ADV) is supported.
+- The TCA8418 scans the matrix and debounces in hardware; this component only drains the chip's key-event FIFO, so the loop never blocks.
+- `irq_pin` is optional. Without it, the key event FIFO is polled over I2C every loop. With it, I2C traffic is skipped while no key event is pending.
+- `on_key_press` / `on_key_release` are the convenient way to react to keys in automations; `press_key` / `release_key` text sensors are optional and mainly for Home Assistant display. Modifier-only keys (`Fn`, `Shift`, `Ctrl`, `Opt`, `Alt`) do not fire events on their own — they shape the emitted key string (e.g. `Ctrl+c`, `F1`, `Up`).
+- `Fn` + key produces `Esc`, `F1`~`F12`, `Del` and arrow keys. `Ctrl` / `Opt` / `Alt` are added as prefixes (e.g. `Ctrl+c`).
+
+<img src="https://static-cdn.m5stack.com/resource/docs/products/core/Cardputer-Adv/img-bcc8b8e9-fee9-4239-a2d8-66708cf868de.webp" width="400">

--- a/components/tca8418_keyboard/README.md
+++ b/components/tca8418_keyboard/README.md
@@ -36,4 +36,4 @@ tca8418_keyboard:
 - `on_key_press` / `on_key_release` are the convenient way to react to keys in automations; `press_key` / `release_key` text sensors are optional and mainly for Home Assistant display. Modifier-only keys (`Fn`, `Shift`, `Ctrl`, `Opt`, `Alt`) do not fire events on their own — they shape the emitted key string (e.g. `Ctrl+c`, `F1`, `Up`).
 - `Fn` + key produces `Esc`, `F1`~`F12`, `Del` and arrow keys. `Ctrl` / `Opt` / `Alt` are added as prefixes (e.g. `Ctrl+c`).
 
-<img src="https://static-cdn.m5stack.com/resource/docs/products/core/Cardputer-Adv/img-bcc8b8e9-fee9-4239-a2d8-66708cf868de.webp" width="400">
+<img src="https://m5stack-doc.oss-cn-shenzhen.aliyuncs.com/1178/Cardputer-Adv_02.webp" width="400">

--- a/components/tca8418_keyboard/__init__.py
+++ b/components/tca8418_keyboard/__init__.py
@@ -1,0 +1,84 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome import automation, pins
+from esphome.components import i2c, text_sensor
+from esphome.const import (
+    CONF_ID,
+    CONF_TRIGGER_ID
+)
+
+CONF_PRESS_KEY = "press_key"
+CONF_RELEASE_KEY = "release_key"
+CONF_IRQ_PIN = "irq_pin"
+CONF_MODEL = "model"
+CONF_ON_KEY_PRESS = "on_key_press"
+CONF_ON_KEY_RELEASE = "on_key_release"
+AUTO_LOAD = ["text_sensor"]
+CODEOWNERS = ["@eigger"]
+DEPENDENCIES = ["i2c"]
+MULTI_CONF = True
+
+tca8418_keyboard_ns = cg.esphome_ns.namespace("tca8418_keyboard")
+
+Model = tca8418_keyboard_ns.enum("Model")
+MODELS = {
+    "cardputer_adv": Model.MODEL_CARDPUTER_ADV,
+}
+
+TCA8418Keyboard = tca8418_keyboard_ns.class_("TCA8418Keyboard", cg.Component, i2c.I2CDevice)
+KeyPressTrigger = tca8418_keyboard_ns.class_(
+    "KeyPressTrigger", automation.Trigger.template(cg.std_string)
+)
+KeyReleaseTrigger = tca8418_keyboard_ns.class_(
+    "KeyReleaseTrigger", automation.Trigger.template(cg.std_string)
+)
+
+CONFIG_SCHEMA = (
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(TCA8418Keyboard),
+            cv.Optional(CONF_MODEL, default="cardputer_adv"): cv.enum(MODELS, lower=True),
+            cv.Optional(CONF_PRESS_KEY): text_sensor.text_sensor_schema(
+                icon="mdi:keyboard"
+            ),
+            cv.Optional(CONF_RELEASE_KEY): text_sensor.text_sensor_schema(
+                icon="mdi:keyboard"
+            ),
+            cv.Optional(CONF_IRQ_PIN): pins.gpio_input_pin_schema,
+            cv.Optional(CONF_ON_KEY_PRESS): automation.validate_automation(
+                {
+                    cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(KeyPressTrigger),
+                }
+            ),
+            cv.Optional(CONF_ON_KEY_RELEASE): automation.validate_automation(
+                {
+                    cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(KeyReleaseTrigger),
+                }
+            ),
+        }
+    )
+    .extend(cv.COMPONENT_SCHEMA)
+    .extend(i2c.i2c_device_schema(0x34))
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await i2c.register_i2c_device(var, config)
+    cg.add(var.set_model(config[CONF_MODEL]))
+    if CONF_PRESS_KEY in config:
+        sens = await text_sensor.new_text_sensor(config[CONF_PRESS_KEY])
+        cg.add(var.set_press_key(sens))
+    if CONF_RELEASE_KEY in config:
+        sens = await text_sensor.new_text_sensor(config[CONF_RELEASE_KEY])
+        cg.add(var.set_release_key(sens))
+    if CONF_IRQ_PIN in config:
+        pin = await cg.gpio_pin_expression(config[CONF_IRQ_PIN])
+        cg.add(var.set_irq_pin(pin))
+    for conf in config.get(CONF_ON_KEY_PRESS, []):
+        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
+        await automation.build_automation(trigger, [(cg.std_string, "x")], conf)
+    for conf in config.get(CONF_ON_KEY_RELEASE, []):
+        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
+        await automation.build_automation(trigger, [(cg.std_string, "x")], conf)

--- a/components/tca8418_keyboard/tca8418_keyboard.cpp
+++ b/components/tca8418_keyboard/tca8418_keyboard.cpp
@@ -1,0 +1,233 @@
+#include "tca8418_keyboard.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace tca8418_keyboard {
+
+static const char *const TAG = "tca8418_keyboard";
+
+// TCA8418 registers
+static const uint8_t REG_CFG             = 0x01;
+static const uint8_t REG_INT_STAT        = 0x02;
+static const uint8_t REG_KEY_EVENT_A     = 0x04;
+static const uint8_t REG_GPIO_INT_STAT_1 = 0x11;
+static const uint8_t REG_GPIO_INT_EN_1   = 0x1A;
+static const uint8_t REG_KP_GPIO_1       = 0x1D;
+static const uint8_t REG_GPI_EM_1        = 0x20;
+static const uint8_t REG_GPIO_DIR_1      = 0x23;
+static const uint8_t REG_GPIO_INT_LVL_1  = 0x26;
+
+// CFG register bits
+static const uint8_t CFG_KE_IEN  = 0x01;
+static const uint8_t CFG_GPI_IEN = 0x02;
+
+// INT_STAT register bits
+static const uint8_t INT_STAT_K_INT   = 0x01;
+static const uint8_t INT_STAT_GPI_INT = 0x02;
+
+// TCA8418 key-event FIFO is 10 entries deep
+static const uint8_t FIFO_DEPTH = 10;
+
+// Modifier key positions on the Cardputer layout
+static const int FN_ROW = 2,    FN_COL = 0;
+static const int SHIFT_ROW = 2, SHIFT_COL = 1;
+static const int CTRL_ROW = 3,  CTRL_COL = 0;
+static const int OPT_ROW = 3,   OPT_COL = 1;
+static const int ALT_ROW = 3,   ALT_COL = 2;
+
+// M5Cardputer ADV 4x14 layout
+static const char *const KEYMAP[TCA8418Keyboard::ROWS][TCA8418Keyboard::COLS] = {
+    {"`", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "-", "=", "Backspace"},
+    {"Tab", "q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "[", "]", "\\"},
+    {"Fn", "Shift", "a", "s", "d", "f", "g", "h", "j", "k", "l", ";", "'", "Enter"},
+    {"Ctrl", "Opt", "Alt", "z", "x", "c", "v", "b", "n", "m", ",", ".", "/", "Space"},
+};
+
+static const char *const KEYMAP_SHIFT[TCA8418Keyboard::ROWS][TCA8418Keyboard::COLS] = {
+    {"~", "!", "@", "#", "$", "%", "^", "&", "*", "(", ")", "_", "+", "Backspace"},
+    {"Tab", "Q", "W", "E", "R", "T", "Y", "U", "I", "O", "P", "{", "}", "|"},
+    {"Fn", "Shift", "A", "S", "D", "F", "G", "H", "J", "K", "L", ":", "\"", "Enter"},
+    {"Ctrl", "Opt", "Alt", "Z", "X", "C", "V", "B", "N", "M", "<", ">", "?", "Space"},
+};
+
+static const char *const KEYMAP_FN[TCA8418Keyboard::ROWS][TCA8418Keyboard::COLS] = {
+    {"Esc", "F1", "F2", "F3", "F4", "F5", "F6", "F7", "F8", "F9", "F10", "F11", "F12", "Del"},
+    {nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr},
+    {nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, "Up", nullptr, nullptr},
+    {nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, "Left", "Down", "Right", nullptr},
+};
+
+void TCA8418Keyboard::setup()
+{
+    ESP_LOGCONFIG(TAG, "Setting up TCA8418Keyboard...");
+    if (this->irq_pin_ != nullptr)
+    {
+        this->irq_pin_->setup();
+    }
+
+    // all pins to GPIO input, key-event mode, falling-edge interrupts
+    for (uint8_t i = 0; i < 3; i++)
+    {
+        if (!write_reg_(REG_GPIO_DIR_1 + i, 0x00))
+        {
+            ESP_LOGE(TAG, "TCA8418 not responding");
+            this->mark_failed();
+            return;
+        }
+        write_reg_(REG_GPI_EM_1 + i, 0xFF);
+        write_reg_(REG_GPIO_INT_LVL_1 + i, 0x00);
+        write_reg_(REG_GPIO_INT_EN_1 + i, 0xFF);
+    }
+
+    // keypad matrix: 7 rows x 8 columns (M5Cardputer ADV)
+    write_reg_(REG_KP_GPIO_1, 0x7F);
+    write_reg_(REG_KP_GPIO_1 + 1, 0xFF);
+    write_reg_(REG_KP_GPIO_1 + 2, 0x00);
+
+    flush_events_();
+
+    // enable key-event + GPI interrupts (hardware debounce stays on by default)
+    uint8_t cfg = 0;
+    if (read_reg_(REG_CFG, &cfg))
+    {
+        write_reg_(REG_CFG, cfg | CFG_KE_IEN | CFG_GPI_IEN);
+    }
+
+    if (press_key_ != nullptr) press_key_->publish_state("None");
+    if (release_key_ != nullptr) release_key_->publish_state("None");
+}
+
+void TCA8418Keyboard::dump_config()
+{
+    ESP_LOGCONFIG(TAG, "TCA8418Keyboard");
+    ESP_LOGCONFIG(TAG, "  Model: cardputer_adv");
+    LOG_I2C_DEVICE(this);
+    if (this->irq_pin_ != nullptr)
+    {
+        LOG_PIN("  IRQ Pin: ", this->irq_pin_);
+    }
+}
+
+void TCA8418Keyboard::loop()
+{
+    // INT is active-low; while it is high there is nothing queued, so skip I2C
+    if (this->irq_pin_ != nullptr && this->irq_pin_->digital_read()) return;
+
+    // Drain the hardware key-event FIFO. Each entry is one press/release; an
+    // entry of 0 means the FIFO is empty. Bound the loop to the FIFO depth so a
+    // misbehaving chip can never hang the loop.
+    for (uint8_t i = 0; i < FIFO_DEPTH; i++)
+    {
+        uint8_t event = 0;
+        if (!read_reg_(REG_KEY_EVENT_A, &event) || event == 0) break;
+        process_event_(event);
+    }
+
+    // Clear the interrupt flags so the chip releases the INT line
+    write_reg_(REG_INT_STAT, INT_STAT_K_INT | INT_STAT_GPI_INT);
+}
+
+void TCA8418Keyboard::process_event_(uint8_t event)
+{
+    bool pressed = (event & 0x80) != 0;
+    uint8_t key = (event & 0x7F) - 1;
+    uint8_t raw_row = key / 10;
+    uint8_t raw_col = key % 10;
+
+    int row = 0, col = 0;
+    if (!remap_(raw_row, raw_col, &row, &col)) return;
+
+    if (pressed_[row][col] == pressed) return;
+    pressed_[row][col] = pressed;
+    if (pressed) on_press_key_(row, col);
+    else         on_release_key_(row, col);
+}
+
+// Convert the TCA8418 7x8 scan coordinate to the model's logical layout.
+bool TCA8418Keyboard::remap_(uint8_t raw_row, uint8_t raw_col, int *row, int *col)
+{
+    switch (model_)
+    {
+    case MODEL_CARDPUTER_ADV:
+    default:
+        *col = raw_row * 2 + (raw_col > 3 ? 1 : 0);
+        *row = (raw_col + 4) % 4;
+        break;
+    }
+    return (*row >= 0 && *row < ROWS && *col >= 0 && *col < COLS);
+}
+
+void TCA8418Keyboard::on_press_key_(int row, int col)
+{
+    ESP_LOGV(TAG, "press key (%d, %d)", row, col);
+    if (is_modifier_(row, col)) return;
+    std::string key = key_to_string_(row, col);
+    if (press_key_ != nullptr) press_key_->publish_state(key);
+    this->press_callback_.call(key);
+}
+
+void TCA8418Keyboard::on_release_key_(int row, int col)
+{
+    ESP_LOGV(TAG, "release key (%d, %d)", row, col);
+    if (is_modifier_(row, col)) return;
+    std::string key = key_to_string_(row, col);
+    if (release_key_ != nullptr) release_key_->publish_state(key);
+    this->release_callback_.call(key);
+}
+
+bool TCA8418Keyboard::is_modifier_(int row, int col)
+{
+    return (row == FN_ROW && col == FN_COL) ||
+           (row == SHIFT_ROW && col == SHIFT_COL) ||
+           (row == CTRL_ROW && col == CTRL_COL) ||
+           (row == OPT_ROW && col == OPT_COL) ||
+           (row == ALT_ROW && col == ALT_COL);
+}
+
+std::string TCA8418Keyboard::key_to_string_(int row, int col)
+{
+    const char *name = nullptr;
+    if (pressed_[FN_ROW][FN_COL])
+    {
+        name = KEYMAP_FN[row][col];
+    }
+    if (name == nullptr)
+    {
+        name = pressed_[SHIFT_ROW][SHIFT_COL] ? KEYMAP_SHIFT[row][col] : KEYMAP[row][col];
+    }
+    std::string str = name;
+    if (pressed_[ALT_ROW][ALT_COL])   str = "Alt+" + str;
+    if (pressed_[OPT_ROW][OPT_COL])   str = "Opt+" + str;
+    if (pressed_[CTRL_ROW][CTRL_COL]) str = "Ctrl+" + str;
+    return str;
+}
+
+void TCA8418Keyboard::flush_events_()
+{
+    uint8_t event = 0;
+    for (uint8_t i = 0; i < FIFO_DEPTH; i++)
+    {
+        if (!read_reg_(REG_KEY_EVENT_A, &event) || event == 0) break;
+    }
+    uint8_t value = 0;
+    for (uint8_t i = 0; i < 3; i++)
+    {
+        read_reg_(REG_GPIO_INT_STAT_1 + i, &value);
+    }
+    write_reg_(REG_INT_STAT, INT_STAT_K_INT | INT_STAT_GPI_INT);
+}
+
+bool TCA8418Keyboard::read_reg_(uint8_t reg, uint8_t *value)
+{
+    if (this->is_failed()) return false;
+    return this->read_byte(reg, value);
+}
+
+bool TCA8418Keyboard::write_reg_(uint8_t reg, uint8_t value)
+{
+    if (this->is_failed()) return false;
+    return this->write_byte(reg, value);
+}
+
+}  // namespace tca8418_keyboard
+}  // namespace esphome

--- a/components/tca8418_keyboard/tca8418_keyboard.h
+++ b/components/tca8418_keyboard/tca8418_keyboard.h
@@ -1,0 +1,71 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/core/hal.h"
+#include "esphome/core/automation.h"
+#include "esphome/components/i2c/i2c.h"
+#include "esphome/components/text_sensor/text_sensor.h"
+
+namespace esphome {
+namespace tca8418_keyboard {
+
+enum Model {
+    MODEL_CARDPUTER_ADV = 0,
+};
+
+// TCA8418 keypad scan IC. The chip handles matrix scanning and debounce in
+// hardware and queues press/release events in a FIFO; we only drain that FIFO.
+// The selected model defines the matrix size, the scan->layout remap and the
+// key map.
+class TCA8418Keyboard : public Component, public i2c::I2CDevice {
+public:
+    static const int ROWS = 4;
+    static const int COLS = 14;
+
+    TCA8418Keyboard() = default;
+    void setup() override;
+    void loop() override;
+    float get_setup_priority() const override { return setup_priority::HARDWARE; }
+    void dump_config() override;
+    void set_press_key(text_sensor::TextSensor *key) { press_key_ = key; }
+    void set_release_key(text_sensor::TextSensor *key) { release_key_ = key; }
+    void set_irq_pin(GPIOPin *pin) { irq_pin_ = pin; }
+    void set_model(Model model) { model_ = model; }
+    void add_on_key_press_callback(std::function<void(std::string)> &&cb) { this->press_callback_.add(std::move(cb)); }
+    void add_on_key_release_callback(std::function<void(std::string)> &&cb) { this->release_callback_.add(std::move(cb)); }
+protected:
+    bool read_reg_(uint8_t reg, uint8_t *value);
+    bool write_reg_(uint8_t reg, uint8_t value);
+    void flush_events_();
+    void process_event_(uint8_t event);
+    bool remap_(uint8_t raw_row, uint8_t raw_col, int *row, int *col);
+    void on_press_key_(int row, int col);
+    void on_release_key_(int row, int col);
+    bool is_modifier_(int row, int col);
+    std::string key_to_string_(int row, int col);
+
+    text_sensor::TextSensor *press_key_{nullptr};
+    text_sensor::TextSensor *release_key_{nullptr};
+    GPIOPin *irq_pin_{nullptr};
+    Model model_{MODEL_CARDPUTER_ADV};
+    bool pressed_[ROWS][COLS]{};
+    CallbackManager<void(std::string)> press_callback_{};
+    CallbackManager<void(std::string)> release_callback_{};
+};
+
+class KeyPressTrigger : public Trigger<std::string> {
+public:
+    explicit KeyPressTrigger(TCA8418Keyboard *parent) {
+        parent->add_on_key_press_callback([this](std::string key) { this->trigger(std::move(key)); });
+    }
+};
+
+class KeyReleaseTrigger : public Trigger<std::string> {
+public:
+    explicit KeyReleaseTrigger(TCA8418Keyboard *parent) {
+        parent->add_on_key_release_callback([this](std::string key) { this->trigger(std::move(key)); });
+    }
+};
+
+}  // namespace tca8418_keyboard
+}  // namespace esphome


### PR DESCRIPTION
Add an ESPHome external component for the TCA8418 I2C keypad scan IC, mapped to the M5Cardputer ADV 4x14 keyboard layout.

- Hardware FIFO + optional IRQ pin event handling (no software matrix scan, no loop blocking; I2C is skipped while INT is idle)
- model option (currently cardputer_adv) selects the key map and the 7x8 scan -> layout remap
- Shift / Fn layers and Ctrl+/Opt+/Alt+ modifier composition
- on_key_press / on_key_release automation triggers (key passed as x) plus optional press_key / release_key text sensors