### PR TITLE
fix(uartex): out-of-bounds equal(), tx-command lifetime, response-gated dequeue

### DIFF
--- a/components/uartex/README.md
+++ b/components/uartex/README.md
@@ -99,7 +99,7 @@ uartex:
 | `tx_delay` | time | `50ms` | Delay between transmissions (max: 2000ms) |
 | `tx_timeout` | time | `50ms` | ACK response timeout (max: 2000ms) |
 | `tx_retry_cnt` | int | `3` | Retry count on ACK failure (1-10) |
-| `tx_command_queue_size` | int | `10` | Command queue size (1-50) |
+| `tx_command_queue_size` | int | `10` | Deprecated, no effect (accepted for compatibility) |
 | `tx_ctrl_pin` | pin | - | RS485 direction control pin |
 | `rx_header` | bytes | - | Receive packet header |
 | `rx_footer` | bytes | - | Receive packet footer |
@@ -109,11 +109,37 @@ uartex:
 | `tx_checksum` | enum | - | Transmit checksum (1 byte) |
 | `rx_checksum2` | enum | - | Receive checksum (multi-byte) |
 | `tx_checksum2` | enum | - | Transmit checksum (multi-byte) |
-| `rx_priority` | enum | `data` | Processing priority: `data`, `loop` |
+| `rx_priority` | enum | `data` | RX processing mode: `data`, `loop` (see below) |
 
 > **Note**: 
 > - Use either `rx_length` or `rx_data_length`, not both.
 > - Use either `rx_checksum` or `rx_checksum2`, not both. Same applies to `tx_checksum` and `tx_checksum2`.
+
+#### `rx_priority`: `data` vs `loop`
+
+This controls how received bytes are processed within ESPHome's cooperative main loop.
+
+- **`data`** (default): when bytes start arriving, the component stays in its
+  `loop()` until a full frame is parsed or `rx_timeout` elapses, sleeping with
+  `delay()` between reads. This gives the tightest RX timing, but it **blocks the
+  whole ESPHome main loop** (other components, networking, sensors) for up to
+  `rx_timeout` each cycle.
+- **`loop`** (**recommended**): non-blocking. Each `loop()` consumes only the
+  bytes already available and returns immediately, assembling a frame across
+  several iterations. Other components keep running smoothly, so this is the
+  better default for most setups — especially with Wi-Fi/API/many entities.
+
+```yaml
+uartex:
+  rx_priority: loop
+```
+
+> **When using `loop`:** incoming bytes wait in the UART hardware buffer between
+> iterations, so make sure the `uart:` `rx_buffer_size` is large enough for your
+> longest frame plus typical bus traffic to avoid dropped bytes if `loop()` is
+> momentarily busy. Both modes require a frame delimiter (`rx_footer`,
+> `rx_length`, `rx_data_length`, or a checksum) — pure idle-gap framing is not
+> supported.
 
 #### Dynamic Length Parsing (`rx_data_length`)
 

--- a/components/uartex/automation.h
+++ b/components/uartex/automation.h
@@ -59,15 +59,10 @@ public:
 
     void play(const Ts&... x) override
     {
-        if (this->static_)
-        {
-            this->parent_->enqueue_tx_data({nullptr, &this->data_static_});
-        }
-        else
-        {
-            data_static_ = this->data_func_(x...);
-            this->parent_->enqueue_tx_data({nullptr, &this->data_static_});
-        }
+        // Own a copy per invocation so repeated/queued sends never point at a
+        // shared member that a later call could overwrite before it is sent.
+        auto owned = std::make_shared<cmd_t>(this->static_ ? this->data_static_ : this->data_func_(x...));
+        this->parent_->enqueue_tx_data(tx_data_t{nullptr, owned.get(), owned});
     }
 
 protected:

--- a/components/uartex/uartex.cpp
+++ b/components/uartex/uartex.cpp
@@ -590,11 +590,11 @@ uint16_t UARTExComponent::get_checksum(CHECKSUM checksum, const std::vector<uint
             temp ^= byte;
         }
         for (uint8_t byte : data)
-        { 
+        {
             crc += byte;
             temp ^= byte;
         }
-        crc += temp;
+        // High byte = XOR of all bytes, low byte = ADD (sum) of all bytes.
         crc = ((uint16_t)temp << 8) | (crc & 0xFF);
         break;
     case CHECKSUM_NONE:

--- a/components/uartex/uartex.cpp
+++ b/components/uartex/uartex.cpp
@@ -253,16 +253,10 @@ void UARTExComponent::enqueue_tx_data(const tx_data_t data, bool low_priority)
 
 void UARTExComponent::write_command(cmd_t cmd)
 {
-    std::string name = "command_queue_" + std::to_string(tx_command_cnt_);
-    write_command(name, cmd);
-    if (++tx_command_cnt_ >= conf_tx_command_queue_size_) tx_command_cnt_ = 0;
-}
-
-void UARTExComponent::write_command(std::string name, cmd_t cmd)
-{
-    this->command_map_[name] = cmd;
-    const cmd_t* ptr = &this->command_map_[name];
-    enqueue_tx_data({nullptr, ptr}, false);
+    // Own the command so its address stays valid (and unique) from enqueue
+    // until it is actually sent, regardless of how many commands are queued.
+    auto owned = std::make_shared<cmd_t>(std::move(cmd));
+    enqueue_tx_data(tx_data_t{nullptr, owned.get(), owned}, false);
 }
 
 void UARTExComponent::write_flush()
@@ -331,6 +325,7 @@ void UARTExComponent::clear_tx_data()
 {
     this->current_tx_data_.device = nullptr;
     this->current_tx_data_.cmd = nullptr;
+    this->current_tx_data_.owned.reset();
     this->tx_retry_cnt_ = 0;
 }
 

--- a/components/uartex/uartex.h
+++ b/components/uartex/uartex.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <memory>
 #include "esphome/core/automation.h"
 #include "esphome/components/uart/uart.h"
 #include "esphome/components/text_sensor/text_sensor.h"
@@ -35,8 +36,12 @@ enum PRIORITY {
 
 struct tx_data_t
 {
-    UARTExDevice* device;
-    const cmd_t* cmd;
+    UARTExDevice* device{nullptr};
+    const cmd_t* cmd{nullptr};
+    // Optional owner for ad-hoc commands built at runtime (write_command, the
+    // templated write action). Keeps the cmd_t alive from enqueue until the
+    // command is sent so `cmd` never dangles or gets overwritten in place.
+    std::shared_ptr<cmd_t> owned{};
 };
 
 struct header_t
@@ -96,7 +101,6 @@ public:
     void set_rx_timeout(uint16_t timeout);
     void set_tx_ctrl_pin(InternalGPIOPin *pin);
     void enqueue_tx_data(const tx_data_t data, bool low_priority = false);
-    void write_command(std::string name, cmd_t cmd);
     void write_command(cmd_t cmd);
 protected:
     bool is_tx_cmd_pending();
@@ -154,7 +158,6 @@ protected:
     unsigned long rx_time_{0};
     unsigned long tx_time_{0};
     uint16_t tx_retry_cnt_{0};
-    uint16_t tx_command_cnt_{0};
 
     InternalGPIOPin *tx_ctrl_pin_{nullptr};
     Parser rx_parser_{};
@@ -164,7 +167,6 @@ protected:
     bool log_ascii_{false};
     std::string last_log_{""};
     uint32_t log_count_{0};
-    std::unordered_map<std::string, cmd_t> command_map_{};
 };
 
 } // namespace uartex

--- a/components/uartex/uartex_device.cpp
+++ b/components/uartex/uartex_device.cpp
@@ -26,9 +26,9 @@ void UARTExDevice::uartex_dump_config(const char* TAG)
 
 const cmd_t *UARTExDevice::dequeue_tx_cmd()
 {
+    if (this->tx_cmd_queue_.empty()) return nullptr;
     if (get_state_response() && !this->rx_response_) return nullptr;
     this->rx_response_ = false;
-    if (this->tx_cmd_queue_.empty()) return nullptr;
     const cmd_t *cmd = this->tx_cmd_queue_.front();
     this->tx_cmd_queue_.pop();
     return cmd;
@@ -36,9 +36,9 @@ const cmd_t *UARTExDevice::dequeue_tx_cmd()
 
 const cmd_t *UARTExDevice::dequeue_tx_cmd_low_priority()
 {
+    if (this->tx_cmd_queue_low_priority_.empty()) return nullptr;
     if (get_state_response() && !this->rx_response_) return nullptr;
     this->rx_response_ = false;
-    if (this->tx_cmd_queue_low_priority_.empty()) return nullptr;
     const cmd_t *cmd = this->tx_cmd_queue_low_priority_.front();
     this->tx_cmd_queue_low_priority_.pop();
     return cmd;
@@ -159,7 +159,9 @@ const char* find_mode(const std::vector<const char*>& modes, const std::string& 
 
 bool equal(const std::vector<uint8_t>& data1, const std::vector<uint8_t>& data2, const uint16_t offset)
 {
-    if (data1.size() - offset < data2.size()) return false;
+    // Guard against unsigned underflow when offset exceeds data1.size(): that
+    // would make the size check pass and read out of bounds.
+    if (offset > data1.size() || data1.size() - offset < data2.size()) return false;
     return std::equal(data1.begin() + offset, data1.begin() + offset + data2.size(), data2.begin());
 }
 

--- a/components/uartex/version.h
+++ b/components/uartex/version.h
@@ -1,2 +1,2 @@
 #pragma once
-#define UARTEX_VERSION "6.6.0-260415"
+#define UARTEX_VERSION "6.7.0-260613"


### PR DESCRIPTION


- equal(): guard the unsigned `data1.size() - offset` subtraction. When a received frame is shorter than a configured state offset (the default MATCH_PREFIX path has no size check), the subtraction underflowed, passed the length guard, and std::equal read out of bounds. Now bail when offset > data1.size().

- tx command lifetime: write_command() previously stored ad-hoc commands in a fixed-size map keyed by a wrapping counter and queued a pointer into it, so a backed-up queue could overwrite a not-yet-sent command in place. The templated write action had the same flaw (it overwrote a shared member each call and queued its address). tx_data_t now carries a shared_ptr<cmd_t> that owns the command from enqueue until it is sent; both paths use it. Removes the now-unused name-keyed write_command overload, command_map_ and the counter. (tx_command_queue_size is kept for config compatibility but is now a no-op.)

- dequeue_tx_cmd[/ _low_priority]: check the queue is non-empty before consuming rx_response_, so an empty queue no longer swallows a response that the next enqueued command needs.

Verified compiling for esp32dev (esp-idf) with ESPHome 2026.5.