### PR TITLE
fix(uartex): restore CHECKSUM_XOR_ADD low-byte (sum + XOR) behavior

### DIFF
--- a/components/uartex/README.md
+++ b/components/uartex/README.md
@@ -193,7 +193,7 @@ Total calculated: header(2) + offset(0) + length_field(1) + data(3) + adjust(0) 
 
 | Type | Description |
 |------|-------------|
-| `xor_add` | XOR + ADD combined (2 bytes) |
+| `xor_add` | High byte: XOR of all bytes; low byte: (sum + XOR) & 0xFF |
 | Lambda | Custom: `std::vector<uint8_t> lambda(uint8_t* data, uint16_t len)` |
 
 **Checksum Position**:

--- a/components/uartex/uartex.cpp
+++ b/components/uartex/uartex.cpp
@@ -594,7 +594,8 @@ uint16_t UARTExComponent::get_checksum(CHECKSUM checksum, const std::vector<uint
             crc += byte;
             temp ^= byte;
         }
-        // High byte = XOR of all bytes, low byte = ADD (sum) of all bytes.
+        // High byte = XOR of all bytes, low byte = (ADD + XOR) & 0xFF.
+        crc += temp;
         crc = ((uint16_t)temp << 8) | (crc & 0xFF);
         break;
     case CHECKSUM_NONE:

--- a/components/uartex/version.h
+++ b/components/uartex/version.h
@@ -1,2 +1,2 @@
 #pragma once
-#define UARTEX_VERSION "6.7.0-260613"
+#define UARTEX_VERSION "6.7.1-260618"


### PR DESCRIPTION
PR #248 dropped `crc += temp`, treating the low byte as sum-only. The ezville wallpad protocol expects low byte = (ADD + XOR) & 0xFF with XOR in the high byte. Restore that line and document the checksum layout.