### PR TITLE
feat(uartex): expose last_state for multi-channel light TX

### DIFF
--- a/components/uartex/light/uartex_light_output.h
+++ b/components/uartex/light/uartex_light_output.h
@@ -32,6 +32,8 @@ class UARTExLightState : public light::LightState
 public:
     UARTExLightState(UARTExLightOutput *output) : LightState(output), Output(*output) {}
     UARTExLightOutput& Output;
+    bool has_last_state() { return this->Output.has_last_state(); }
+    uint8_t last_state(const uint16_t index) { return this->Output.last_state(index); }
 };
 
 }  // namespace uartex

--- a/components/uartex/uartex_device.h
+++ b/components/uartex/uartex_device.h
@@ -110,6 +110,7 @@ public:
     const cmd_t* dequeue_tx_cmd();
     const cmd_t* dequeue_tx_cmd_low_priority();
     bool parse_data(const std::vector<uint8_t>& data);
+    bool has_last_state() const { return !this->last_state_.empty(); }
     std::vector<uint8_t> last_state();
     uint8_t last_state(const uint16_t index);
 protected:

--- a/packages/wallpad/kocom/kocom_theart.yaml
+++ b/packages/wallpad/kocom/kocom_theart.yaml
@@ -86,13 +86,13 @@ light:
       data: [0x00]
     command_on: !lambda |-
       uint8_t light1 = 0xff;
-      uint8_t light2 = id(livingroom_light_2).current_values.is_on() ? 0xff : 0x00;
-      uint8_t light3 = id(livingroom_light_3).current_values.is_on() ? 0xff : 0x00;
+      uint8_t light2 = id(livingroom_light_1).last_state(9);
+      uint8_t light3 = id(livingroom_light_1).last_state(10);
       return {{0x30, 0xbc, 0x00, 0x0e, 0x00, 0x01, 0x00, 0x00, light1, light2, light3, 0x00, 0x00, 0x00, 0x00, 0x00}, {0x30, 0xdc, 0x00, 0x0e, 0x00}};
     command_off: !lambda |-
       uint8_t light1 = 0x00;
-      uint8_t light2 = id(livingroom_light_2).current_values.is_on() ? 0xff : 0x00;
-      uint8_t light3 = id(livingroom_light_3).current_values.is_on() ? 0xff : 0x00;
+      uint8_t light2 = id(livingroom_light_1).last_state(9);
+      uint8_t light3 = id(livingroom_light_1).last_state(10);
       return {{0x30, 0xbc, 0x00, 0x0e, 0x00, 0x01, 0x00, 0x00, light1, light2, light3, 0x00, 0x00, 0x00, 0x00, 0x00}, {0x30, 0xdc, 0x00, 0x0e, 0x00}};
     command_update: 
       data: [0x30, 0xbc, 0x00, 0x0e, 0x00, 0x01, 0x00, 0x3a, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]
@@ -113,14 +113,14 @@ light:
       offset: 9
       data: [0x00]
     command_on: !lambda |-
-      uint8_t light1 = id(livingroom_light_1).current_values.is_on() ? 0xff : 0x00;
+      uint8_t light1 = id(livingroom_light_2).last_state(8);
       uint8_t light2 = 0xff;
-      uint8_t light3 = id(livingroom_light_3).current_values.is_on() ? 0xff : 0x00;
+      uint8_t light3 = id(livingroom_light_2).last_state(10);
       return {{0x30, 0xbc, 0x00, 0x0e, 0x00, 0x01, 0x00, 0x00, light1, light2, light3, 0x00, 0x00, 0x00, 0x00, 0x00}, {0x30, 0xdc, 0x00, 0x0e, 0x00}};
     command_off: !lambda |-
-      uint8_t light1 = id(livingroom_light_1).current_values.is_on() ? 0xff : 0x00;
+      uint8_t light1 = id(livingroom_light_2).last_state(8);
       uint8_t light2 = 0x00;
-      uint8_t light3 = id(livingroom_light_3).current_values.is_on() ? 0xff : 0x00;
+      uint8_t light3 = id(livingroom_light_2).last_state(10);
       return {{0x30, 0xbc, 0x00, 0x0e, 0x00, 0x01, 0x00, 0x00, light1, light2, light3, 0x00, 0x00, 0x00, 0x00, 0x00}, {0x30, 0xdc, 0x00, 0x0e, 0x00}};
     device_id: device_livingroom
 
@@ -137,13 +137,13 @@ light:
       offset: 10
       data: [0x00]
     command_on: !lambda |-
-      uint8_t light1 = id(livingroom_light_1).current_values.is_on() ? 0xff : 0x00;
-      uint8_t light2 = id(livingroom_light_2).current_values.is_on() ? 0xff : 0x00;
+      uint8_t light1 = id(livingroom_light_3).last_state(8);
+      uint8_t light2 = id(livingroom_light_3).last_state(9);
       uint8_t light3 = 0xff;
       return {{0x30, 0xbc, 0x00, 0x0e, 0x00, 0x01, 0x00, 0x00, light1, light2, light3, 0x00, 0x00, 0x00, 0x00, 0x00}, {0x30, 0xdc, 0x00, 0x0e, 0x00}};
     command_off: !lambda |-
-      uint8_t light1 = id(livingroom_light_1).current_values.is_on() ? 0xff : 0x00;
-      uint8_t light2 = id(livingroom_light_2).current_values.is_on() ? 0xff : 0x00;
+      uint8_t light1 = id(livingroom_light_3).last_state(8);
+      uint8_t light2 = id(livingroom_light_3).last_state(9);
       uint8_t light3 = 0x00;
       return {{0x30, 0xbc, 0x00, 0x0e, 0x00, 0x01, 0x00, 0x00, light1, light2, light3, 0x00, 0x00, 0x00, 0x00, 0x00}, {0x30, 0xdc, 0x00, 0x0e, 0x00}};
     device_id: device_livingroom

--- a/tests/components/uartex/common.yaml
+++ b/tests/components/uartex/common.yaml
@@ -58,11 +58,11 @@ light:
       offset: 3
       length: 1
       precision: 0
-    command_on:
-      data: [0x02, 0x03, 0x01]
-      ack: [0x02, 0x13, 0x01]
+    command_on: !lambda |-
+      uint8_t ch = id(room_0_light_1).has_last_state() ? id(room_0_light_1).last_state(2) : 0x01;
+      return {{0x02, 0x03, ch}, {0x02, 0x13, 0x01}};
     command_off: !lambda |-
-      return {{0x02, 0x03, 0x00}, {0x02, 0x13, 0x00}};
+      return {{0x02, 0x03, id(room_0_light_1).last_state(2)}, {0x02, 0x13, 0x00}};
     command_brightness:
       data: [0x02, 0x03, 0x01]
       ack: [0x02, 0x13, 0x01]


### PR DESCRIPTION
Expose has_last_state() and last_state(index) on UARTExLightState so YAML lambdas can assemble TX from the last RX packet instead of cross-id current_values. Apply to kocom_theart livingroom lights.