### PR TITLE
feat(ws_bridge): add text_sensor platform

### DIFF
--- a/components/ws_bridge/README.md
+++ b/components/ws_bridge/README.md
@@ -65,6 +65,11 @@ binary_sensor:
     name: "Motion"
     device_class: motion
 
+text_sensor:
+  - platform: ws_bridge
+    unique_id: status1
+    name: "Status"
+
 switch:
   - platform: ws_bridge
     unique_id: relay1
@@ -104,7 +109,7 @@ button:
 | `name` | | device friendly name | Display name for the gateway device |
 | `keep_last_state_on_disconnect` | | `false` | If `true`, this gateway's entities keep their last state in HA instead of going `unavailable` when the connection drops (including an ungraceful disconnect) |
 
-### Platform options (all of `sensor`/`binary_sensor`/`switch`/`number`/`select`/`button`)
+### Platform options (all of `sensor`/`binary_sensor`/`text_sensor`/`switch`/`number`/`select`/`button`)
 
 | Option | Required | Description |
 |--------|:--------:|-------------|
@@ -181,8 +186,8 @@ build/dashboard tooling produces):
 
 ## Behavior / Limitations
 
-- **Read-only platforms** (`sensor`, `binary_sensor`) push their state to Home
-  Assistant automatically whenever it changes.
+- **Read-only platforms** (`sensor`, `binary_sensor`, `text_sensor`) push
+  their state to Home Assistant automatically whenever it changes.
 - **Controllable platforms** (`switch`, `number`, `select`, `button`) receive
   commands from Home Assistant and update their own state optimistically
   (`publish_state`/`this->state`) — hook `on_turn_on`/`lambda:`/etc. in your

--- a/components/ws_bridge/text_sensor/__init__.py
+++ b/components/ws_bridge/text_sensor/__init__.py
@@ -1,0 +1,22 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import text_sensor, ws_bridge
+
+from .. import ws_bridge_ns
+
+DEPENDENCIES = ["ws_bridge"]
+WsBridgeTextSensor = ws_bridge_ns.class_(
+    "WsBridgeTextSensor", text_sensor.TextSensor, cg.Component, ws_bridge.WsBridgeDevice
+)
+
+CONFIG_SCHEMA = (
+    text_sensor.text_sensor_schema(WsBridgeTextSensor)
+    .extend(ws_bridge.WS_BRIDGE_DEVICE_SCHEMA)
+    .extend(cv.COMPONENT_SCHEMA)
+)
+
+
+async def to_code(config):
+    var = await text_sensor.new_text_sensor(config)
+    await cg.register_component(var, config)
+    await ws_bridge.register_ws_bridge_device(var, config)

--- a/components/ws_bridge/text_sensor/ws_bridge_text_sensor.cpp
+++ b/components/ws_bridge/text_sensor/ws_bridge_text_sensor.cpp
@@ -1,0 +1,25 @@
+#include "ws_bridge_text_sensor.h"
+#include "../ws_bridge.h"
+#include "../ws_bridge_entity_json.h"
+
+namespace esphome {
+namespace ws_bridge {
+
+static const char *const TAG = "ws_bridge.text_sensor";
+
+void WsBridgeTextSensor::setup() {
+  this->add_on_state_callback(
+      [this](const std::string &state) { this->parent_->send_state_string(this->unique_id_, state); });
+}
+
+void WsBridgeTextSensor::dump_config() { LOG_TEXT_SENSOR("", "WS Bridge Text Sensor", this); }
+
+void WsBridgeTextSensor::ws_bridge_declare() {
+  this->parent_->send_entity_declare(this->unique_id_, "text_sensor", this->get_name().str(), this->device_id_,
+                                     this->device_name_,
+                                     [this](JsonObject root) { add_common_entity_fields(root, *this); });
+  if (this->has_state()) this->parent_->send_state_string(this->unique_id_, this->state);
+}
+
+}  // namespace ws_bridge
+}  // namespace esphome

--- a/components/ws_bridge/text_sensor/ws_bridge_text_sensor.h
+++ b/components/ws_bridge/text_sensor/ws_bridge_text_sensor.h
@@ -1,0 +1,17 @@
+#pragma once
+#include "esphome/components/text_sensor/text_sensor.h"
+#include "esphome/core/component.h"
+#include "../ws_bridge_device.h"
+
+namespace esphome {
+namespace ws_bridge {
+
+class WsBridgeTextSensor : public text_sensor::TextSensor, public Component, public WsBridgeDevice {
+ public:
+  void setup() override;
+  void dump_config() override;
+  void ws_bridge_declare() override;
+};
+
+}  // namespace ws_bridge
+}  // namespace esphome

--- a/tests/components/ws_bridge/test.esp32-idf.yaml
+++ b/tests/components/ws_bridge/test.esp32-idf.yaml
@@ -45,6 +45,11 @@ binary_sensor:
     name: "Motion"
     device_class: motion
 
+text_sensor:
+  - platform: ws_bridge
+    unique_id: status1
+    name: "Status"
+
 switch:
   - platform: ws_bridge
     unique_id: relay1


### PR DESCRIPTION
Mirrors the existing sensor/binary_sensor read-only platform pattern, reusing the already-present send_state_string/build_state_string wire protocol helpers. Adds the platform to the CI test config and README.