### PR TITLE
fix(ws_bridge): send suggested_display_precision for sensor entities

### DIFF
--- a/components/ws_bridge/sensor/ws_bridge_sensor.cpp
+++ b/components/ws_bridge/sensor/ws_bridge_sensor.cpp
@@ -22,6 +22,7 @@ void WsBridgeSensor::ws_bridge_declare() {
         if (!uom.empty()) root["unit_of_measurement"] = uom.str();
         sensor::StateClass sc = this->get_state_class();
         if (sc != sensor::STATE_CLASS_NONE) root["state_class"] = LOG_STR_ARG(sensor::state_class_to_string(sc));
+        root["suggested_display_precision"] = this->get_accuracy_decimals();
       });
   if (this->has_state()) this->parent_->send_state_float(this->unique_id_, this->state);
 }

--- a/tests/components/ws_bridge/test.esp32-idf.yaml
+++ b/tests/components/ws_bridge/test.esp32-idf.yaml
@@ -36,6 +36,7 @@ sensor:
     device_class: temperature
     unit_of_measurement: "°C"
     state_class: measurement
+    accuracy_decimals: 1
     ws_device_id: sensor_hub_1
     ws_device_name: "Sensor Hub"
 


### PR DESCRIPTION
WsBridgeSensor never sent the sensor's accuracy_decimals over the wire, so Home Assistant had no rounding hint and displayed the raw float exactly as received (e.g. "48.85864%" instead of "48.9%"). Forward it as suggested_display_precision, matching what ESPHome's native API integration already does.