### PR TITLE
feat(ws_bridge): detect a dead HA connection with app-level ping/pong

### DIFF
--- a/components/ws_bridge/README.md
+++ b/components/ws_bridge/README.md
@@ -194,6 +194,15 @@ build/dashboard tooling produces):
   own YAML if you need to drive real hardware from the state.
 - On every (re)connect, all declared entities and their current state are
   re-sent, per the protocol's reconnection guidance.
+- While connected, an application-level `ping`/`pong` (HA's standard
+  websocket_api commands) is sent every 60s. If no `pong` arrives within 15s,
+  the connection is forced closed and reopened. This catches a dead
+  connection that the transport layer alone wouldn't notice — e.g. Home
+  Assistant restarting without a clean WebSocket close, which can otherwise
+  leave the device believing it's still connected indefinitely. The interval
+  is deliberately low-frequency (worst-case detection is up to ~75s) and the
+  timeout generous, so it won't misfire on a slow-but-alive WAN connection
+  (e.g. Nabu Casa remote UI, reverse proxy).
 - TLS uses ESP-IDF's built-in public CA bundle — this works out of the box
   with Nabu Casa or any certificate from a public CA. A custom CA
   certificate (for self-signed setups) is not supported yet.

--- a/components/ws_bridge/ws_bridge.cpp
+++ b/components/ws_bridge/ws_bridge.cpp
@@ -48,6 +48,33 @@ void WsBridgeComponent::loop() {
     this->handle_event_(*event);
     this->event_pool_.release(event);
   }
+
+  this->check_liveness_();
+}
+
+// Actively probes the connection with HA's standard "ping"/"pong" websocket_api
+// commands. Needed because a dead peer (e.g. HA killed without a clean WS
+// close — no FIN/RST ever reaches the socket) can otherwise leave the
+// underlying esp_websocket_client believing it's still connected indefinitely,
+// so is_connected() alone never reports the failure and auto-reconnect never
+// kicks in.
+void WsBridgeComponent::check_liveness_() {
+  if (!this->is_connected()) return;
+  uint32_t now = millis();
+  if (this->ping_outstanding_) {
+    if (now - this->last_ping_sent_ms_ > PONG_TIMEOUT_MS) {
+      ESP_LOGW(TAG, "No pong received within %u ms — forcing reconnect", PONG_TIMEOUT_MS);
+      this->ping_outstanding_ = false;
+      esp_websocket_client_stop(this->client_);
+      esp_websocket_client_start(this->client_);
+    }
+    return;
+  }
+  if (now - this->last_ping_sent_ms_ > PING_INTERVAL_MS) {
+    this->send_raw_(build_ping(this->next_id_()));
+    this->ping_outstanding_ = true;
+    this->last_ping_sent_ms_ = now;
+  }
 }
 
 void WsBridgeComponent::dump_config() {
@@ -138,10 +165,14 @@ void WsBridgeComponent::handle_message_(const std::string &raw) {
     this->send_raw_(
         build_connect(this->next_id_(), this->gateway_id_, this->gateway_name_, this->keep_last_state_on_disconnect_));
     this->set_state_(WS_BRIDGE_CONNECTED);
+    this->ping_outstanding_ = false;
+    this->last_ping_sent_ms_ = millis();
     this->declare_all_entities_();
     this->connected_cb_.call();
   } else if (msg.type == "auth_invalid") {
     ESP_LOGE(TAG, "Home Assistant rejected the access token");
+  } else if (msg.type == "pong") {
+    this->ping_outstanding_ = false;
   } else if (msg.type == "event") {
     if (!msg.command.unique_id.empty()) this->route_command_(msg.command);
   }

--- a/components/ws_bridge/ws_bridge.h
+++ b/components/ws_bridge/ws_bridge.h
@@ -70,6 +70,7 @@ class WsBridgeComponent : public Component {
   void send_raw_(const std::string &msg);
   uint32_t next_id_() { return ++this->msg_id_; }
   void set_state_(WsBridgeState s);
+  void check_liveness_();
 
   esp_websocket_client_handle_t client_{nullptr};
   bool started_{false};
@@ -85,6 +86,17 @@ class WsBridgeComponent : public Component {
   WsBridgeState state_{WS_BRIDGE_DISCONNECTED};
   uint32_t msg_id_{0};
   std::vector<WsBridgeDevice *> devices_{};
+
+  // App-level ping/pong keepalive (see check_liveness_()). Detects a dead
+  // connection that the transport layer doesn't notice on its own. Interval
+  // is kept low-frequency (one tiny JSON round-trip a minute) since this is
+  // just a dead-connection backstop, not a latency-sensitive heartbeat; the
+  // timeout leaves generous headroom for WAN paths (Nabu Casa remote UI,
+  // reverse proxy) where a multi-second round trip is normal, not a fault.
+  uint32_t last_ping_sent_ms_{0};
+  bool ping_outstanding_{false};
+  static constexpr uint32_t PING_INTERVAL_MS = 60000;
+  static constexpr uint32_t PONG_TIMEOUT_MS = 15000;
 
   // Producer-side (WS client task) fragment reassembly buffer. Only ever
   // touched from ws_event_handler_(), never from loop() — no locking needed.

--- a/components/ws_bridge/ws_protocol.cpp
+++ b/components/ws_bridge/ws_protocol.cpp
@@ -74,6 +74,13 @@ std::string build_entity_declare(uint32_t id, const std::string &unique_id, cons
   });
 }
 
+std::string build_ping(uint32_t id) {
+  return json::build_json([&](JsonObject root) {
+    root["id"] = id;
+    root["type"] = "ping";
+  });
+}
+
 std::string build_state_float(uint32_t id, const std::string &unique_id, float value) {
   return json::build_json([&](JsonObject root) {
     root["id"] = id;

--- a/components/ws_bridge/ws_protocol.h
+++ b/components/ws_bridge/ws_protocol.h
@@ -35,6 +35,12 @@ std::string build_auth(const std::string &access_token);
 std::string build_connect(uint32_t id, const std::string &gateway_id, const std::string &name,
                           bool keep_last_state_on_disconnect);
 
+// Application-level keepalive (HA's standard websocket_api "ping"/"pong"
+// commands) — used to actively detect a dead connection that the transport
+// layer itself doesn't notice (e.g. HA process killed without a clean WS
+// close, so the socket never sees a FIN/RST).
+std::string build_ping(uint32_t id);
+
 // `extra` (may be empty) is called with the message's root JsonObject to add
 // platform-specific declare fields (device_class, options, min/max/step, ...).
 std::string build_entity_declare(uint32_t id, const std::string &unique_id, const std::string &platform,


### PR DESCRIPTION
esp_websocket_client_is_connected() only reflects the client's own believed state, not whether the peer is actually reachable. If HA dies without a clean WebSocket close (e.g. a restart that kills the process outright, never sending a FIN/RST), the client can be left believing it's still connected indefinitely — send_raw_()'s is_connected() check never catches this, and auto-reconnect never kicks in until the device itself is power-cycled.

Add an application-level keepalive using HA's standard websocket_api ping/pong commands: while connected, ping every 60s; if no pong arrives within 15s, force-close and restart the client so the normal auth/reconnect flow runs again. Interval and timeout are kept low-frequency/generous on purpose — this is a dead-connection backstop, not a latency-sensitive heartbeat, and needs headroom for WAN paths (Nabu Casa remote UI, reverse proxy).