### PR TITLE
fix(ws_bridge): make connection state transitions immune to queue drops

### DIFF
--- a/components/ws_bridge/ws_bridge.cpp
+++ b/components/ws_bridge/ws_bridge.cpp
@@ -65,6 +65,11 @@ void WsBridgeComponent::check_liveness_() {
     if (now - this->last_ping_sent_ms_ > PONG_TIMEOUT_MS) {
       ESP_LOGW(TAG, "No pong received within %u ms — forcing reconnect", PONG_TIMEOUT_MS);
       this->ping_outstanding_ = false;
+      // Drop out of WS_BRIDGE_CONNECTED before stop()/start() rather than
+      // waiting for the resulting WEBSOCKET_EVENT_DISCONNECTED to be queued
+      // and processed on a later loop() iteration — closes the same
+      // stale-is_connected() window described in ws_event_handler_.
+      this->set_state_(WS_BRIDGE_DISCONNECTED);
       esp_websocket_client_stop(this->client_);
       esp_websocket_client_start(this->client_);
     }
@@ -85,10 +90,13 @@ void WsBridgeComponent::dump_config() {
   ESP_LOGCONFIG(TAG, "  Keep last state on disconnect: %s", YESNO(this->keep_last_state_on_disconnect_));
 }
 
+// May be called from either the main loop task or the esp_websocket_client
+// task (see ws_event_handler_), so this must be a single atomic RMW rather
+// than a load-compare-store.
 void WsBridgeComponent::set_state_(WsBridgeState s) {
-  if (this->state_ != s) {
-    ESP_LOGD(TAG, "state %d -> %d", this->state_, s);
-    this->state_ = s;
+  WsBridgeState old = this->state_.exchange(s, std::memory_order_acq_rel);
+  if (old != s) {
+    ESP_LOGD(TAG, "state %d -> %d", old, s);
   }
 }
 
@@ -102,13 +110,30 @@ void WsBridgeComponent::ws_event_handler_(void *handler_args, esp_event_base_t b
   auto *data = static_cast<esp_websocket_event_data_t *>(event_data);
   auto ws_event_id = static_cast<esp_websocket_event_id_t>(event_id);
 
+  bool was_connected = false;
+
   // A (re)connect or drop always starts a fresh message stream: discard any
   // partial fragment left over from a message that never completed (e.g. the
   // socket dropped mid-fragment), so it can't get concatenated with data from
   // a later connection.
-  if (ws_event_id == WEBSOCKET_EVENT_CONNECTED || ws_event_id == WEBSOCKET_EVENT_DISCONNECTED ||
-      ws_event_id == WEBSOCKET_EVENT_ERROR || ws_event_id == WEBSOCKET_EVENT_CLOSED) {
+  //
+  // The state_ transition itself also happens right here, unconditionally,
+  // rather than being deferred to loop()'s consumption of the queued event.
+  // event_queue_ is bounded (EVENT_QUEUE_SIZE) and silently drops events when
+  // full (see below) — if a dropped event were the only place a disconnect
+  // got recorded, state_ could stay stuck at WS_BRIDGE_CONNECTED across a
+  // reconnect. is_connected() would then still report true on the fresh,
+  // not-yet-authenticated socket, so a state push could go out before HA even
+  // sends auth_required, which HA's auth handler correctly rejects. Doing the
+  // transition here means it can never be lost to a full queue; only the
+  // (non-critical) log line / callback in handle_event_ can be.
+  if (ws_event_id == WEBSOCKET_EVENT_CONNECTED) {
     self->rx_accum_.clear();
+    self->set_state_(WS_BRIDGE_WAIT_AUTH_REQUIRED);
+  } else if (ws_event_id == WEBSOCKET_EVENT_DISCONNECTED || ws_event_id == WEBSOCKET_EVENT_ERROR ||
+             ws_event_id == WEBSOCKET_EVENT_CLOSED) {
+    self->rx_accum_.clear();
+    was_connected = (self->state_.exchange(WS_BRIDGE_DISCONNECTED, std::memory_order_acq_rel) == WS_BRIDGE_CONNECTED);
   }
 
   if (ws_event_id == WEBSOCKET_EVENT_DATA) {
@@ -121,8 +146,9 @@ void WsBridgeComponent::ws_event_handler_(void *handler_args, esp_event_base_t b
   }
 
   WsEvent *event = self->event_pool_.allocate();
-  if (event == nullptr) return;  // queue full, drop this event
+  if (event == nullptr) return;  // queue full, drop this event (state_ is already correct regardless)
   event->event_id = ws_event_id;
+  event->was_connected = was_connected;
   if (ws_event_id == WEBSOCKET_EVENT_DATA) {
     event->data = std::move(self->rx_accum_);
     self->rx_accum_.clear();
@@ -133,20 +159,22 @@ void WsBridgeComponent::ws_event_handler_(void *handler_args, esp_event_base_t b
 void WsBridgeComponent::handle_event_(const WsEvent &event) {
   switch (event.event_id) {
     case WEBSOCKET_EVENT_CONNECTED:
+      // state_ is already WS_BRIDGE_WAIT_AUTH_REQUIRED — set by
+      // ws_event_handler_ itself, see the comment there.
       ESP_LOGI(TAG, "WebSocket transport connected");
-      this->set_state_(WS_BRIDGE_WAIT_AUTH_REQUIRED);
       break;
     case WEBSOCKET_EVENT_DISCONNECTED:
     case WEBSOCKET_EVENT_ERROR:
-    case WEBSOCKET_EVENT_CLOSED: {
-      bool was_connected = this->is_connected();
-      this->set_state_(WS_BRIDGE_DISCONNECTED);
-      if (was_connected) {
+    case WEBSOCKET_EVENT_CLOSED:
+      // state_ is already WS_BRIDGE_DISCONNECTED — set by ws_event_handler_
+      // itself. event.was_connected is a snapshot taken at that time; by now
+      // is_connected() would always read false, so it can't be used here to
+      // tell whether this is a real transition.
+      if (event.was_connected) {
         ESP_LOGW(TAG, "WebSocket disconnected");
         this->disconnected_cb_.call();
       }
       break;
-    }
     case WEBSOCKET_EVENT_DATA:
       this->handle_message_(event.data);
       break;

--- a/components/ws_bridge/ws_bridge.h
+++ b/components/ws_bridge/ws_bridge.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <atomic>
 #include <functional>
 #include <string>
 #include <vector>
@@ -27,7 +28,18 @@ enum WsBridgeState : uint8_t {
 struct WsEvent {
   esp_websocket_event_id_t event_id{WEBSOCKET_EVENT_ERROR};
   std::string data;
-  void release() { data.clear(); }
+  // Snapshot (taken by the producer at the moment of a disconnect-family
+  // event) of whether the connection was actually up before this event.
+  // The consumer uses this instead of re-reading state_, because state_ has
+  // already been updated by the producer by the time the consumer gets to
+  // it — and the queued event itself may never be dequeued at all if the
+  // queue was full, so it must not be the thing state_ correctness depends
+  // on.
+  bool was_connected{false};
+  void release() {
+    data.clear();
+    was_connected = false;
+  }
 };
 
 class WsBridgeComponent : public Component {
@@ -49,7 +61,11 @@ class WsBridgeComponent : public Component {
   float get_setup_priority() const override { return setup_priority::AFTER_WIFI; }
 
   void register_device(WsBridgeDevice *device) { this->devices_.push_back(device); }
-  bool is_connected() const { return this->state_ == WS_BRIDGE_CONNECTED; }
+  // state_ is written from two tasks (the esp_websocket_client task on
+  // disconnect/connect, the main loop task on auth progress), so it must be
+  // atomic. See ws_event_handler_ for why the disconnect-family transitions
+  // in particular can't wait for the main loop to process a queued event.
+  bool is_connected() const { return this->state_.load(std::memory_order_acquire) == WS_BRIDGE_CONNECTED; }
 
   // Called by platform entities (via WsBridgeDevice helpers) to push state
   // and declarations. No-ops while not connected; the next (re)connect will
@@ -83,7 +99,7 @@ class WsBridgeComponent : public Component {
   std::string gateway_name_;
   bool keep_last_state_on_disconnect_{false};
 
-  WsBridgeState state_{WS_BRIDGE_DISCONNECTED};
+  std::atomic<WsBridgeState> state_{WS_BRIDGE_DISCONNECTED};
   uint32_t msg_id_{0};
   std::vector<WsBridgeDevice *> devices_{};
 


### PR DESCRIPTION
is_connected() gated outgoing ws_bridge/* traffic on state_, but state_ was only updated when loop() drained a queued WEBSOCKET_EVENT_DISCONNECTED / _ERROR / _CLOSED event. That queue (size 8) silently drops events under pressure (e.g. a burst of buffered HA "result" replies arriving right as the socket drops), so a dropped disconnect event could leave state_ stuck at WS_BRIDGE_CONNECTED across a reconnect. is_connected() then still returned true on the fresh, not-yet-authenticated socket, so a state push could go out before HA even sent auth_required — which HA's auth phase correctly rejects ("extra keys not allowed @ data['id']/data['states']"). Because every reconnect attempt was equally vulnerable, this could turn into a self -sustaining loop that never settles into an authenticated connection.

Move the state_ transition into ws_event_handler_ (the producer task) itself, done unconditionally before the event is even queued, so it can never be lost to a full queue. state_ is now a std::atomic since it's written from both the esp_websocket_client task and the main loop task. Only the non-critical log line / disconnected_cb_ callback in handle_event_ can still be skipped on a drop, using a was_connected snapshot taken at transition time. Also hardens the ping/pong-timeout forced-reconnect path in check_liveness_ the same way.