### PR TITLE
fix(ws_bridge): exponential reconnect backoff instead of a flat wait

### DIFF
--- a/components/ws_bridge/README.md
+++ b/components/ws_bridge/README.md
@@ -47,7 +47,7 @@ ws_bridge:
   keep_last_state_on_disconnect: false
   ping_interval: 60s
   pong_timeout: 15s
-  reconnect_timeout: 2min
+  reconnect_timeout: 30s
   reannounce_interval: 60s
 
   on_connected:
@@ -114,7 +114,7 @@ button:
 | `keep_last_state_on_disconnect` | | `false` | If `true`, this gateway's entities keep their last state in HA instead of going `unavailable` when the connection drops (including an ungraceful disconnect) |
 | `ping_interval` | | `60s` | How often to send an app-level `ping` once connected, to detect a peer that dropped without a clean WebSocket close |
 | `pong_timeout` | | `15s` | How long to wait for a `pong` reply before assuming the connection is dead and forcing a reconnect |
-| `reconnect_timeout` | | `2min` | How long to stay disconnected before forcing a fresh connection attempt ourselves, in case `esp_websocket_client`'s own auto-reconnect (e.g. across a prolonged Home Assistant restart) stops making progress on its own |
+| `reconnect_timeout` | | `30s` | Cap for the reconnect backoff: while disconnected, we retry starting at 2s and doubling on each failure up to this value (matches the companion hass-ble-android client), rather than waiting on `esp_websocket_client`'s own auto-reconnect indefinitely |
 | `reannounce_interval` | | `60s` | How often to resend `ws_bridge/connect` + all entity/state declarations while nominally connected. Guards against the HA-side integration losing track of this gateway (e.g. its config entry reloaded) while the raw connection and ping/pong stay healthy — that scenario is otherwise invisible, since HA answers pings regardless of our integration's state. If a re-announce goes unanswered, forces a full reconnect rather than repeating the same no-op |
 
 ### Platform options (all of `sensor`/`binary_sensor`/`text_sensor`/`switch`/`number`/`select`/`button`)

--- a/components/ws_bridge/__init__.py
+++ b/components/ws_bridge/__init__.py
@@ -56,13 +56,14 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_KEEP_LAST_STATE_ON_DISCONNECT, default=False): cv.boolean,
             # See ws_bridge.cpp's check_liveness_() for what these govern: an
             # app-level ping/pong that detects a peer that dropped without a
-            # clean WS close, and a backstop that forces a fresh connection
-            # attempt if we've simply been disconnected too long (e.g. HA
-            # itself restarting) for esp_websocket_client's own auto-reconnect
-            # to have recovered on its own.
+            # clean WS close, and a backstop that keeps retrying (2s doubling
+            # to this cap, matching the companion hass-ble-android client's
+            # HaWsClient) if we've simply been disconnected, for whenever
+            # esp_websocket_client's own auto-reconnect doesn't recover on its
+            # own (observed after e.g. HA itself restarting).
             cv.Optional(CONF_PING_INTERVAL, default="60s"): cv.positive_time_period_milliseconds,
             cv.Optional(CONF_PONG_TIMEOUT, default="15s"): cv.positive_time_period_milliseconds,
-            cv.Optional(CONF_RECONNECT_TIMEOUT, default="2min"): cv.positive_time_period_milliseconds,
+            cv.Optional(CONF_RECONNECT_TIMEOUT, default="30s"): cv.positive_time_period_milliseconds,
             # Periodically resends ws_bridge/connect + entity declarations even
             # while nominally connected. Needed because the transport (and
             # HA's generic websocket_api ping/pong) can stay alive while the

--- a/components/ws_bridge/ws_bridge.cpp
+++ b/components/ws_bridge/ws_bridge.cpp
@@ -1,4 +1,5 @@
 #include "ws_bridge.h"
+#include <algorithm>
 #include "esp_crt_bundle.h"
 #include "esp_transport_ws.h"
 #include "esphome/components/network/util.h"
@@ -78,10 +79,11 @@ void WsBridgeComponent::force_reconnect_() {
 void WsBridgeComponent::check_liveness_() {
   uint32_t now = millis();
   if (!this->is_connected()) {
-    if (now - this->last_reconnect_attempt_ms_ > this->reconnect_retry_ms_) {
+    if (now - this->last_reconnect_attempt_ms_ > this->reconnect_backoff_ms_) {
       ESP_LOGW(TAG, "Still disconnected after %u ms — forcing a fresh connection attempt",
-               static_cast<unsigned>(this->reconnect_retry_ms_));
+               static_cast<unsigned>(this->reconnect_backoff_ms_));
       this->force_reconnect_();
+      this->reconnect_backoff_ms_ = std::min(this->reconnect_backoff_ms_ * 2, this->reconnect_retry_ms_);
     }
     return;
   }
@@ -90,6 +92,7 @@ void WsBridgeComponent::check_liveness_() {
       ESP_LOGW(TAG, "No pong received within %u ms — forcing reconnect",
                static_cast<unsigned>(this->pong_timeout_ms_));
       this->ping_outstanding_ = false;
+      this->reconnect_backoff_ms_ = RECONNECT_BACKOFF_BASE_MS;
       this->force_reconnect_();
     }
     return;
@@ -103,6 +106,7 @@ void WsBridgeComponent::check_liveness_() {
       ESP_LOGW(TAG, "No result for ws_bridge/connect within %u ms — forcing reconnect",
                static_cast<unsigned>(this->pong_timeout_ms_));
       this->awaiting_connect_result_ = false;
+      this->reconnect_backoff_ms_ = RECONNECT_BACKOFF_BASE_MS;
       this->force_reconnect_();
     }
     return;
@@ -137,7 +141,7 @@ void WsBridgeComponent::dump_config() {
   ESP_LOGCONFIG(TAG, "  Keep last state on disconnect: %s", YESNO(this->keep_last_state_on_disconnect_));
   ESP_LOGCONFIG(TAG, "  Ping interval: %u ms", static_cast<unsigned>(this->ping_interval_ms_));
   ESP_LOGCONFIG(TAG, "  Pong timeout: %u ms", static_cast<unsigned>(this->pong_timeout_ms_));
-  ESP_LOGCONFIG(TAG, "  Reconnect timeout: %u ms", static_cast<unsigned>(this->reconnect_retry_ms_));
+  ESP_LOGCONFIG(TAG, "  Reconnect backoff cap: %u ms", static_cast<unsigned>(this->reconnect_retry_ms_));
   ESP_LOGCONFIG(TAG, "  Re-announce interval: %u ms", static_cast<unsigned>(this->reannounce_interval_ms_));
 }
 
@@ -223,6 +227,14 @@ void WsBridgeComponent::handle_event_(const WsEvent &event) {
       // tell whether this is a real transition.
       if (event.was_connected) {
         ESP_LOGW(TAG, "WebSocket disconnected");
+        // Anchor the reconnect backoff to this disconnect, not to whatever
+        // earlier attempt last_reconnect_attempt_ms_ still held — otherwise
+        // a connection that drops shortly after connecting could sit idle
+        // for however much of reconnect_retry_ms_ was already "used up"
+        // since that earlier attempt, instead of retrying promptly. See the
+        // comment on reconnect_backoff_ms_ in ws_bridge.h.
+        this->last_reconnect_attempt_ms_ = millis();
+        this->reconnect_backoff_ms_ = RECONNECT_BACKOFF_BASE_MS;
         this->disconnected_cb_.call();
       }
       break;
@@ -245,6 +257,7 @@ void WsBridgeComponent::handle_message_(const std::string &raw) {
         build_connect(this->next_id_(), this->gateway_id_, this->gateway_name_, this->keep_last_state_on_disconnect_));
     this->set_state_(WS_BRIDGE_CONNECTED);
     this->ping_outstanding_ = false;
+    this->reconnect_backoff_ms_ = RECONNECT_BACKOFF_BASE_MS;
     this->last_ping_sent_ms_ = millis();
     this->last_reannounce_ms_ = this->last_ping_sent_ms_;
     this->declare_all_entities_();

--- a/components/ws_bridge/ws_bridge.h
+++ b/components/ws_bridge/ws_bridge.h
@@ -135,15 +135,14 @@ class WsBridgeComponent : public Component {
   // elapsed before the drop, rather than retrying promptly.
   //
   // reconnect_backoff_ms_ is the actual delay used each time: starts at
-  // RECONNECT_BACKOFF_BASE_MS and doubles on every failed attempt, capped at
-  // reconnect_retry_ms_, then resets back to base as soon as we're connected
-  // again (or on any freshly-detected disconnect). This mirrors the companion
-  // hass-ble-android client's HaWsClient (reconnectDelayMs: 2s doubling to a
-  // 30s cap) — a flat multi-minute wait, tried earlier here, left the device
-  // idle for up to that long after a disconnect for no good reason.
+  // RECONNECT_BACKOFF_BASE_MS (= reconnect_retry_ms_'s default, so this is a
+  // flat 30s retry out of the box) and doubles on every failed attempt if
+  // reconnect_retry_ms_ is configured higher than the base, then resets back
+  // to base as soon as we're connected again (or on any freshly-detected
+  // disconnect).
   uint32_t last_reconnect_attempt_ms_{0};
   uint32_t reconnect_retry_ms_{30000};
-  static constexpr uint32_t RECONNECT_BACKOFF_BASE_MS = 2000;
+  static constexpr uint32_t RECONNECT_BACKOFF_BASE_MS = 30000;
   uint32_t reconnect_backoff_ms_{RECONNECT_BACKOFF_BASE_MS};
 
   // Backstop for a different failure mode: the transport (and HA's generic

--- a/components/ws_bridge/ws_bridge.h
+++ b/components/ws_bridge/ws_bridge.h
@@ -123,10 +123,28 @@ class WsBridgeComponent : public Component {
   // Backstop for check_liveness_(): while disconnected, esp_websocket_client's
   // own auto-reconnect can stop making progress after a prolonged outage
   // (e.g. HA itself restarting) without ever raising another event we could
-  // react to. If we've been down longer than this, force a fresh connection
-  // attempt ourselves rather than waiting on the library indefinitely.
+  // react to. If we've been down longer than the current backoff, force a
+  // fresh connection attempt ourselves rather than waiting on the library
+  // indefinitely.
+  //
+  // last_reconnect_attempt_ms_ is reset at every disconnect (not just at each
+  // attempt) — see handle_event_()/force_reconnect_() — precisely so this
+  // isn't measured from some earlier, unrelated attempt. Without that, a
+  // connection that drops shortly after connecting could sit idle for up to
+  // reconnect_retry_ms_ minus however much of that window had already
+  // elapsed before the drop, rather than retrying promptly.
+  //
+  // reconnect_backoff_ms_ is the actual delay used each time: starts at
+  // RECONNECT_BACKOFF_BASE_MS and doubles on every failed attempt, capped at
+  // reconnect_retry_ms_, then resets back to base as soon as we're connected
+  // again (or on any freshly-detected disconnect). This mirrors the companion
+  // hass-ble-android client's HaWsClient (reconnectDelayMs: 2s doubling to a
+  // 30s cap) — a flat multi-minute wait, tried earlier here, left the device
+  // idle for up to that long after a disconnect for no good reason.
   uint32_t last_reconnect_attempt_ms_{0};
-  uint32_t reconnect_retry_ms_{120000};
+  uint32_t reconnect_retry_ms_{30000};
+  static constexpr uint32_t RECONNECT_BACKOFF_BASE_MS = 2000;
+  uint32_t reconnect_backoff_ms_{RECONNECT_BACKOFF_BASE_MS};
 
   // Backstop for a different failure mode: the transport (and HA's generic
   // websocket_api ping/pong) can stay perfectly alive while the ws_bridge


### PR DESCRIPTION
Observed in practice: connected at boot, dropped again ~30s later, then sat completely idle for another ~88s before retrying — nowhere near the configured 2min value. Root cause: last_reconnect_attempt_ms_ was only ever updated at the moment of an attempt (initial start, or a forced reconnect), never at the moment of disconnect. So the "how long have we been down" clock was actually measuring from whenever the last attempt happened to occur, which could be almost the full reconnect_retry_ms_ in the past already if the connection dropped again soon after reconnecting.

Checked the companion hass-ble-android client (HaWsClient.kt) again: its triggerReconnection() starts at reconnectDelayMs = 2s and doubles on each failure up to a 30s cap, reset to 2s on every successful connect — not the flat multi-minute wait this had.

- last_reconnect_attempt_ms_ is now also reset at the moment a genuine disconnect is detected (handle_event_'s event.was_connected branch), not only at explicit reconnect attempts, so the backoff clock is anchored to when we actually lost the connection.
- Added reconnect_backoff_ms_: starts at 2s (RECONNECT_BACKOFF_BASE_MS), doubles on each failed retry, capped at reconnect_retry_ms_ (now the cap, default lowered from 2min to 30s to match Android), and resets to 2s on success or on any freshly-detected failure (ping timeout, connect-result timeout, disconnect).