### PR TITLE
fix(uartex): wire fan preset modes into FanTraits so Home Assistant sees them

### DIFF
--- a/components/uartex/fan/uartex_fan.cpp
+++ b/components/uartex/fan/uartex_fan.cpp
@@ -22,6 +22,7 @@ fan::FanTraits UARTExFan::get_traits()
         traits.set_speed(true);
         traits.set_supported_speed_count(this->speed_count_);
     }
+    this->wire_preset_modes_(traits);
     return traits;
 }
 


### PR DESCRIPTION
What follows is described here.

## Problem

A `uartex` fan configured with `preset_modes` never exposes preset-mode support to Home Assistant. The fan entity reports `supported_features` without the `PRESET_MODE` flag and `preset_modes: []`, so `fan.set_preset_mode` is unavailable — even after a clean build. Speed control works; only presets are missing.

## Root cause

Since ESPHome 2026.4 the fan preset-mode vectors moved onto the `Fan` entity base class, and `Fan::get_traits()` is virtual with no base-class hook to inject them. Each `get_traits()` override must call `this->wire_preset_modes_(traits)` explicitly (unlike `Climate`, whose base class wires custom modes automatically) — see the [migration note](https://developers.esphome.io/blog/2026/04/09/climate-and-fan-custom-mode-vectors-moved-to-entity/).

`UARTExFan::set_preset_modes()` already registers the modes on the entity via `set_supported_preset_modes()`, but `UARTExFan::get_traits()` returns a fresh `FanTraits` populated only with speed info and never wires the preset modes in. The modes are stored on the entity but never reach the traits sent to HA.

This is a regression from #226, which removed the trait-side mode registration from `uartex_fan.cpp` without adding the `wire_preset_modes_()` call the new API requires.

## Fix

Call `this->wire_preset_modes_(traits)` in `get_traits()`. It copies the registered preset modes into the returned `FanTraits`, and no-ops when none are configured (speed-only fans unchanged). No header change needed.

## Testing

Tested on a real Kocom ventilator (device `0x48`) with `preset_modes: ["자동", "수동"]`:

- **Before:** HA shows `supported_features: 49`, `preset_modes: []`; `fan.set_preset_mode` fails.
- **After:** `supported_features: 57` (PRESET_MODE bit set), `preset_modes` populated, and `fan.set_preset_mode` sends `command_preset` and reflects `state_preset`. Switching between the two presets works.