### PR TITLE
feat(ws_bridge): add trackers: for GPS device_tracker entities

### DIFF
--- a/components/ws_bridge/README.md
+++ b/components/ws_bridge/README.md
@@ -116,6 +116,7 @@ button:
 | `pong_timeout` | | `15s` | How long to wait for a `pong` reply before assuming the connection is dead and forcing a reconnect |
 | `reconnect_timeout` | | `30s` | Cap for the reconnect backoff: while disconnected, we retry starting at 2s and doubling on each failure up to this value (matches the companion hass-ble-android client), rather than waiting on `esp_websocket_client`'s own auto-reconnect indefinitely |
 | `reannounce_interval` | | `60s` | How often to resend `ws_bridge/connect` + all entity/state declarations while nominally connected. Guards against the HA-side integration losing track of this gateway (e.g. its config entry reloaded) while the raw connection and ping/pong stay healthy — that scenario is otherwise invisible, since HA answers pings regardless of our integration's state. If a re-announce goes unanswered, forces a full reconnect rather than repeating the same no-op |
+| `trackers` | | - | List of GPS `device_tracker` entities — see [GPS device trackers](#gps-device-trackers) below |
 
 ### Platform options (all of `sensor`/`binary_sensor`/`text_sensor`/`switch`/`number`/`select`/`button`)
 
@@ -195,12 +196,45 @@ build/dashboard tooling produces):
   every periodic re-announce. Use this for hand-built declarations (see below),
   not `on_connected`.
 
-## Declaring entity types ESPHome has no domain for
+## GPS device trackers
 
-Home Assistant supports entity types ESPHome itself has no platform for — the
-main one being `device_tracker` (GPS location). Since there's no ESPHome
-`device_tracker:` domain to hang a `platform: ws_bridge` off, declare these by
-calling the protocol directly from a lambda:
+Home Assistant has a `device_tracker` entity type for GPS location, but
+ESPHome has no `device_tracker:` domain to hang a `platform: ws_bridge` off —
+so these are configured inline under the hub instead:
+
+```yaml
+ws_bridge:
+  host: !secret ha_address
+  token: !secret ha_token
+
+  trackers:
+    - unique_id: car_location
+      name: "Car Location"
+      icon: mdi:car
+      latitude: !lambda return id(my_gps).latitude;
+      longitude: !lambda return id(my_gps).longitude;
+      gps_accuracy: 8          # meters; optional
+      update_interval: 30s     # default 60s
+```
+
+| Option | Required | Description |
+|--------|:--------:|-------------|
+| `unique_id` / `name` | ✓ | Same as every other platform |
+| `latitude` / `longitude` | ✓ | Float or `!lambda`. Return `NAN` when there's no fix yet — Home Assistant then shows the tracker as unavailable rather than pinning it at 0,0 |
+| `gps_accuracy` | | Float or `!lambda`, meters. Home Assistant uses it when deciding zone membership |
+| `icon` | | Same as every other platform |
+| `update_interval` | | Default `60s` |
+| `ws_device_id` / `ws_device_name` | | Same as every other platform |
+
+There's no `battery_level` option — Home Assistant has deprecated it on
+`device_tracker` in favor of a separate entity; declare a normal `sensor` with
+`device_class: battery` instead.
+
+## Declaring other entity types ESPHome has no domain for
+
+`trackers:` above is really just a thin wrapper around two building blocks
+available to any lambda, for whatever other Home Assistant entity type
+ESPHome itself doesn't have a domain for:
 
 ```yaml
 ws_bridge:
@@ -211,26 +245,22 @@ ws_bridge:
   on_declare:
     - lambda: |-
         id(my_ws_bridge)->send_entity_declare(
-            "car_location", "device_tracker", "Car Location", "", "", nullptr);
+            "some_id", "some_platform", "Some Name", "", "", nullptr);
 
 interval:
   - interval: 30s
     then:
       - lambda: |-
-          id(my_ws_bridge)->send_state_object("car_location", [](JsonObject v) {
-            v["latitude"] = id(my_gps).latitude;
-            v["longitude"] = id(my_gps).longitude;
-            v["gps_accuracy"] = 8;
-          });
+          id(my_ws_bridge)->send_state_float("some_id", 42.0f);
 ```
 
 - **Declare from `on_declare:`, not `on_connected:`.** Declarations are re-sent
-  both on connect and on each periodic re-announce (see below); `on_connected`
-  only covers the former, so a re-announce that heals a lost Home Assistant-side
+  both on connect and on each periodic re-announce; `on_connected` only covers
+  the former, so a re-announce that heals a lost Home Assistant-side
   registration would silently leave your hand-built entity behind.
-- `send_state_object()` is for states that aren't a single scalar —
-  `device_tracker` needs latitude and longitude together. For ordinary values
-  use `send_state_float()` / `send_state_bool()` / `send_state_string()`.
+- `send_state_object()` is for states that aren't a single scalar (this is
+  what `trackers:` uses internally for latitude+longitude). For ordinary
+  values use `send_state_float()` / `send_state_bool()` / `send_state_string()`.
 - `send_entity_declare()`'s last argument adds platform-specific declare fields;
   pass `nullptr` when there are none, or a lambda taking a `JsonObject` (that's
   how `select` sends its `options`, `number` its `min`/`max`/`step`, and so on).

--- a/components/ws_bridge/__init__.py
+++ b/components/ws_bridge/__init__.py
@@ -2,7 +2,15 @@ import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome import automation
 from esphome.components import esp32
-from esphome.const import CONF_ID, CONF_PORT, CONF_NAME, CONF_TRIGGER_ID
+from esphome.const import (
+    CONF_ID,
+    CONF_PORT,
+    CONF_NAME,
+    CONF_TRIGGER_ID,
+    CONF_ICON,
+    CONF_LATITUDE,
+    CONF_LONGITUDE,
+)
 from esphome.core import CORE
 
 from .const import (
@@ -18,6 +26,8 @@ from .const import (
     CONF_ON_CONNECTED,
     CONF_ON_DISCONNECTED,
     CONF_ON_DECLARE,
+    CONF_TRACKERS,
+    CONF_GPS_ACCURACY,
     CONF_PING_INTERVAL,
     CONF_PONG_TIMEOUT,
     CONF_RECONNECT_TIMEOUT,
@@ -37,6 +47,25 @@ WsBridgeDevice = ws_bridge_ns.class_("WsBridgeDevice")
 ConnectedTrigger = ws_bridge_ns.class_("ConnectedTrigger", automation.Trigger.template())
 DisconnectedTrigger = ws_bridge_ns.class_("DisconnectedTrigger", automation.Trigger.template())
 DeclareTrigger = ws_bridge_ns.class_("DeclareTrigger", automation.Trigger.template())
+
+# device_tracker (GPS) entities. ESPHome has no device_tracker: domain to hang
+# a `platform: ws_bridge` off, so these are configured inline under the hub —
+# see README.md's "GPS device trackers" section.
+WsBridgeTracker = ws_bridge_ns.class_("WsBridgeTracker", cg.PollingComponent, WsBridgeDevice)
+
+TRACKER_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(): cv.declare_id(WsBridgeTracker),
+        cv.Required(CONF_UNIQUE_ID): cv.string_strict,
+        cv.Optional(CONF_WS_DEVICE_ID): cv.string_strict,
+        cv.Optional(CONF_WS_DEVICE_NAME): cv.string_strict,
+        cv.Required(CONF_NAME): cv.string_strict,
+        cv.Optional(CONF_ICON): cv.icon,
+        cv.Required(CONF_LATITUDE): cv.templatable(cv.float_),
+        cv.Required(CONF_LONGITUDE): cv.templatable(cv.float_),
+        cv.Optional(CONF_GPS_ACCURACY): cv.templatable(cv.float_),
+    }
+).extend(cv.polling_component_schema("60s"))
 
 
 def _validate_esp_idf(config):
@@ -93,6 +122,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_ON_DECLARE): automation.validate_automation(
                 {cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(DeclareTrigger)}
             ),
+            cv.Optional(CONF_TRACKERS, default=[]): cv.ensure_list(TRACKER_SCHEMA),
         }
     ).extend(cv.COMPONENT_SCHEMA),
     _validate_esp_idf,
@@ -148,3 +178,24 @@ async def to_code(config):
     for conf in config.get(CONF_ON_DECLARE, []):
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
         await automation.build_automation(trigger, [], conf)
+
+    for conf in config.get(CONF_TRACKERS, []):
+        tracker = cg.new_Pvariable(conf[CONF_ID])
+        await cg.register_component(tracker, conf)
+        cg.add(tracker.set_ws_bridge_parent(var))
+        cg.add(tracker.set_unique_id(conf[CONF_UNIQUE_ID]))
+        if CONF_WS_DEVICE_ID in conf:
+            cg.add(tracker.set_device_id(conf[CONF_WS_DEVICE_ID]))
+        if CONF_WS_DEVICE_NAME in conf:
+            cg.add(tracker.set_device_name(conf[CONF_WS_DEVICE_NAME]))
+        cg.add(var.register_device(tracker))
+        cg.add(tracker.set_name(conf[CONF_NAME]))
+        if CONF_ICON in conf:
+            cg.add(tracker.set_icon(conf[CONF_ICON]))
+        lat_template = await cg.templatable(conf[CONF_LATITUDE], [], cg.float_)
+        cg.add(tracker.set_latitude(lat_template))
+        lon_template = await cg.templatable(conf[CONF_LONGITUDE], [], cg.float_)
+        cg.add(tracker.set_longitude(lon_template))
+        if CONF_GPS_ACCURACY in conf:
+            acc_template = await cg.templatable(conf[CONF_GPS_ACCURACY], [], cg.float_)
+            cg.add(tracker.set_gps_accuracy(acc_template))

--- a/components/ws_bridge/const.py
+++ b/components/ws_bridge/const.py
@@ -16,6 +16,9 @@ CONF_ON_CONNECTED = "on_connected"
 CONF_ON_DISCONNECTED = "on_disconnected"
 CONF_ON_DECLARE = "on_declare"
 
+CONF_TRACKERS = "trackers"
+CONF_GPS_ACCURACY = "gps_accuracy"
+
 CONF_PING_INTERVAL = "ping_interval"
 CONF_PONG_TIMEOUT = "pong_timeout"
 CONF_RECONNECT_TIMEOUT = "reconnect_timeout"

--- a/components/ws_bridge/ws_bridge_tracker.cpp
+++ b/components/ws_bridge/ws_bridge_tracker.cpp
@@ -1,0 +1,48 @@
+#include "ws_bridge_tracker.h"
+#include <cmath>
+#include "esphome/core/log.h"
+#include "ws_bridge.h"
+
+namespace esphome {
+namespace ws_bridge {
+
+static const char *const TAG = "ws_bridge.tracker";
+
+void WsBridgeTracker::dump_config() {
+  ESP_LOGCONFIG(TAG, "WS Bridge Tracker '%s':", this->name_.c_str());
+  ESP_LOGCONFIG(TAG, "  Unique ID: %s", this->unique_id_.c_str());
+  LOG_UPDATE_INTERVAL(this);
+}
+
+void WsBridgeTracker::update() { this->publish_position_(); }
+
+void WsBridgeTracker::ws_bridge_declare() {
+  this->parent_->send_entity_declare(this->unique_id_, "device_tracker", this->name_, this->device_id_,
+                                     this->device_name_, [this](JsonObject root) {
+                                       if (!this->icon_.empty())
+                                         root["icon"] = this->icon_;
+                                     });
+  this->publish_position_();
+}
+
+void WsBridgeTracker::publish_position_() {
+  float lat = this->latitude_.value();
+  float lon = this->longitude_.value();
+  // No fix yet, or the source sensor has no state. Report the position as
+  // explicitly unknown rather than sending the coordinates anyway: a NaN that
+  // serializes badly, or a zeroed pair, would put the device at 0,0 — a spot
+  // in the Atlantic that Home Assistant can't tell apart from a real reading.
+  if (std::isnan(lat) || std::isnan(lon)) {
+    this->parent_->send_state_string(this->unique_id_, "unknown");
+    return;
+  }
+  this->parent_->send_state_object(this->unique_id_, [this, lat, lon](JsonObject value) {
+    value["latitude"] = lat;
+    value["longitude"] = lon;
+    if (this->has_gps_accuracy_)
+      value["gps_accuracy"] = this->gps_accuracy_.value();
+  });
+}
+
+}  // namespace ws_bridge
+}  // namespace esphome

--- a/components/ws_bridge/ws_bridge_tracker.h
+++ b/components/ws_bridge/ws_bridge_tracker.h
@@ -1,0 +1,45 @@
+#pragma once
+#include <string>
+#include "esphome/core/automation.h"
+#include "esphome/core/component.h"
+#include "ws_bridge_device.h"
+
+namespace esphome {
+namespace ws_bridge {
+
+// A Home Assistant device_tracker (GPS location) entity.
+//
+// Configured inside the `ws_bridge:` hub block rather than as a
+// `platform: ws_bridge` under some ESPHome domain, because ESPHome has no
+// device_tracker domain to hang one off. It still registers as a
+// WsBridgeDevice, so it is re-declared automatically on connect and on every
+// periodic re-announce, exactly like the real platform entities — which is the
+// main thing this buys over declaring one by hand from a lambda.
+class WsBridgeTracker : public PollingComponent, public WsBridgeDevice {
+ public:
+  void set_name(const std::string &name) { this->name_ = name; }
+  void set_icon(const std::string &icon) { this->icon_ = icon; }
+  template<typename V> void set_latitude(V v) { this->latitude_ = v; }
+  template<typename V> void set_longitude(V v) { this->longitude_ = v; }
+  template<typename V> void set_gps_accuracy(V v) {
+    this->gps_accuracy_ = v;
+    this->has_gps_accuracy_ = true;
+  }
+
+  void dump_config() override;
+  void update() override;
+  void ws_bridge_declare() override;
+
+ protected:
+  void publish_position_();
+
+  std::string name_;
+  std::string icon_;
+  TemplatableValue<float> latitude_{};
+  TemplatableValue<float> longitude_{};
+  TemplatableValue<float> gps_accuracy_{};
+  bool has_gps_accuracy_{false};
+};
+
+}  // namespace ws_bridge
+}  // namespace esphome

--- a/tests/components/ws_bridge/test.esp32-idf.yaml
+++ b/tests/components/ws_bridge/test.esp32-idf.yaml
@@ -29,15 +29,18 @@ ws_bridge:
     - logger.log: "ws_bridge connected"
   on_disconnected:
     - logger.log: "ws_bridge disconnected"
-  # Hand-built declaration for an entity type ESPHome has no domain for.
   on_declare:
-    - lambda: |-
-        id(my_ws_bridge)->send_entity_declare("car_location", "device_tracker", "Car Location", "", "", nullptr);
-        id(my_ws_bridge)->send_state_object("car_location", [](JsonObject v) {
-          v["latitude"] = 37.5665;
-          v["longitude"] = 126.9780;
-          v["gps_accuracy"] = 8;
-        });
+    - logger.log: "ws_bridge (re)declaring entities"
+  # GPS device_tracker — ESPHome has no device_tracker: domain, so these are
+  # configured inline under the hub instead of as `platform: ws_bridge`.
+  trackers:
+    - unique_id: car_location
+      name: "Car Location"
+      icon: mdi:car
+      latitude: !lambda return 37.5665;
+      longitude: !lambda return 126.9780;
+      gps_accuracy: 8
+      update_interval: 30s
 
 sensor:
   - platform: ws_bridge


### PR DESCRIPTION
ESPHome has no device_tracker: domain, so a `platform: ws_bridge` entry isn't possible for one. Adds a `trackers:` list under the ws_bridge: hub instead — each entry becomes a WsBridgeTracker (PollingComponent + WsBridgeDevice), so it's re-declared automatically on connect and on every periodic re-announce like every other platform entity, rather than requiring the caller to hook on_declare by hand.

latitude/longitude/gps_accuracy accept a plain float or !lambda (cv.templatable/cg.templatable, matching the pattern already used by sip_client/tcp_server in this repo). A NaN latitude/longitude (no GPS fix yet) is reported as an explicit "unknown" state rather than sending 0,0, which Home Assistant can't tell apart from a real reading.

Updates the CI test config and README with a worked example.