### PR TITLE
feat(sip_client): allow send-only and receive-only endpoints

### DIFF
--- a/components/sip_client/README.md
+++ b/components/sip_client/README.md
@@ -2,8 +2,9 @@
 
 An ESPHome external component for ESP32. It registers to a SIP PBX
 (Asterisk/FreePBX/3CX, etc.) and makes/receives voice calls. Audio I/O is
-delegated to ESPHome's standard `microphone` / `speaker` platforms, and the
-codec is G.711 (PCMU/PCMA, 8 kHz). DTMF is sent via RFC 2833 (telephone-event).
+delegated to ESPHome's standard `microphone` / `speaker` platforms (either may
+be omitted for send-only or receive-only endpoints), and the codec is G.711
+(PCMU/PCMA, 8 kHz). DTMF is sent via RFC 2833 (telephone-event).
 
 ## Installation
 
@@ -43,8 +44,8 @@ speaker:
 
 sip_client:
   id: my_sip
-  microphone: mic_id
-  speaker: spk_id
+  microphone: mic_id   # omit for receive-only (speaker / announcements)
+  speaker: spk_id      # omit for send-only (mic / uplink)
   server: 192.168.0.10      # PBX address (IP recommended)
   port: 5060                # (default 5060)
   username: "1001"
@@ -72,12 +73,29 @@ sip_client:
         args: [digit.c_str()]
 ```
 
+At least one of `microphone` / `speaker` is required. SDP advertises the matching
+direction: both → `sendrecv`, speaker only → `recvonly`, microphone only → `sendonly`.
+
+```yaml
+# Receive-only (announcement / paging speaker, no mic)
+sip_client:
+  id: my_sip
+  speaker: spk_id
+  # ...
+
+# Send-only (uplink mic, no speaker)
+sip_client:
+  id: my_sip
+  microphone: mic_id
+  # ...
+```
+
 ### Options
 
 | Option | Required | Default | Description |
 |--------|:--------:|---------|-------------|
-| `microphone` | ✓ | - | ID of the microphone component to use |
-| `speaker` | ✓ | - | ID of the speaker component to use |
+| `microphone` | | - | ID of the microphone component to use. Omit for receive-only devices. |
+| `speaker` | | - | ID of the speaker component to use. Omit for send-only devices. |
 | `server` | ✓ | - | PBX address (IP recommended) |
 | `port` | | 5060 | SIP server port |
 | `username` | ✓ | - | SIP account (extension) |
@@ -87,7 +105,7 @@ sip_client:
 | `register_expiration` | | 300s | Registration refresh interval |
 | `local_rtp_port` | | 7078 | Local UDP port the device binds for RTP audio and advertises in SDP. Usually left at the default; change it only to avoid a port clash or to pin a firewall/NAT forward. |
 | `channel` | | `stereo` | How call audio is pushed to the `speaker`. `stereo` (default) duplicates the mono call audio to L/R for stereo chains (e.g. a `mixer`/`resampler` feeding a stereo DAC like the Voice PE's AIC3204). Use `mono` for a single-channel codec such as the **es8311** (whose i2s speaker is set `channel: mono` and expects 1-channel input). Must match the channel count the assigned speaker expects. To route mono audio to one physical side, leave this `mono` and use the **speaker's** own `channel: left`/`right`. |
-| `half_duplex` | | `false` | Push-to-talk mode for boards that cannot capture and play at the same time (mic and speaker on a single shared I2S bus, e.g. M5Stack Atom Echo). When `true`, the mic and speaker are never active together: the call starts in **listen** (speaker) mode and you switch to **talk** (mic) with the `start_talking` / `stop_talking` actions. Leave `false` for full-duplex boards with separate input/output I2S buses (e.g. Voice PE). |
+| `half_duplex` | | `false` | Push-to-talk mode for boards that cannot capture and play at the same time (mic and speaker on a single shared I2S bus, e.g. M5Stack Atom Echo). When `true`, the mic and speaker are never active together: the call starts in **listen** (speaker) mode and you switch to **talk** (mic) with the `start_talking` / `stop_talking` actions. Requires both `microphone` and `speaker`. Leave `false` for full-duplex boards with separate input/output I2S buses (e.g. Voice PE). |
 
 ## Actions (Automation)
 
@@ -154,6 +172,10 @@ binary_sensor:
 
 - Codec: **G.711 µ-law (PCMU) / A-law (PCMA)**, 8 kHz mono. Both are offered in
   SDP and the codec chosen by the PBX is used.
+- Media direction follows the configured endpoints (`sendrecv` / `recvonly` /
+  `sendonly`). A device with only a speaker can join calls or paging as a
+  listen-only endpoint; a mic-only device can uplink audio without local
+  playback.
 - If the microphone runs at 16 kHz it is automatically downsampled to 8 kHz; the
   speaker is configured to play at 8 kHz.
 - **Mono codecs (e.g. es8311):** set `channel: mono` and configure the i2s

--- a/components/sip_client/README.md
+++ b/components/sip_client/README.md
@@ -176,6 +176,11 @@ binary_sensor:
   `sendonly`). A device with only a speaker can join calls or paging as a
   listen-only endpoint; a mic-only device can uplink audio without local
   playback.
+- **Receive-only note:** with no microphone the device does not send RTP audio
+  (empty TX). Most PBXs honour `a=recvonly` and keep the call up; setups that
+  require periodic RTP (e.g. aggressive `rtp_timeout`) or that learn the remote
+  address only from the first received packet (symmetric RTP / `comedia`) may
+  need a PBX-side tweak. Comfort-noise / silence TX is not implemented yet.
 - If the microphone runs at 16 kHz it is automatically downsampled to 8 kHz; the
   speaker is configured to play at 8 kHz.
 - **Mono codecs (e.g. es8311):** set `channel: mono` and configure the i2s

--- a/components/sip_client/__init__.py
+++ b/components/sip_client/__init__.py
@@ -56,6 +56,7 @@ SendDtmfAction = sip_client_ns.class_("SendDtmfAction", automation.Action)
 StartTalkingAction = sip_client_ns.class_("StartTalkingAction", automation.Action)
 StopTalkingAction = sip_client_ns.class_("StopTalkingAction", automation.Action)
 
+
 def validate_audio(config):
     has_mic = CONF_MICROPHONE in config
     has_spk = CONF_SPEAKER in config

--- a/components/sip_client/__init__.py
+++ b/components/sip_client/__init__.py
@@ -56,12 +56,23 @@ SendDtmfAction = sip_client_ns.class_("SendDtmfAction", automation.Action)
 StartTalkingAction = sip_client_ns.class_("StartTalkingAction", automation.Action)
 StopTalkingAction = sip_client_ns.class_("StopTalkingAction", automation.Action)
 
+def validate_audio(config):
+    has_mic = CONF_MICROPHONE in config
+    has_spk = CONF_SPEAKER in config
+    if not has_mic and not has_spk:
+        raise cv.Invalid("At least one of 'microphone' or 'speaker' is required")
+    # Push-to-talk switches a shared I2S bus between mic and speaker.
+    if config.get(CONF_HALF_DUPLEX, False) and not (has_mic and has_spk):
+        raise cv.Invalid("'half_duplex' requires both 'microphone' and 'speaker'")
+    return config
+
+
 CONFIG_SCHEMA = cv.All(
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(SipClient),
-            cv.Required(CONF_MICROPHONE): cv.use_id(microphone.Microphone),
-            cv.Required(CONF_SPEAKER): cv.use_id(speaker.Speaker),
+            cv.Optional(CONF_MICROPHONE): cv.use_id(microphone.Microphone),
+            cv.Optional(CONF_SPEAKER): cv.use_id(speaker.Speaker),
             cv.Required(CONF_SERVER): cv.string,
             cv.Optional(CONF_PORT, default=5060): cv.port,
             cv.Required(CONF_USERNAME): cv.string,
@@ -90,7 +101,8 @@ CONFIG_SCHEMA = cv.All(
                 {cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(DtmfTrigger)}
             ),
         }
-    ).extend(cv.COMPONENT_SCHEMA)
+    ).extend(cv.COMPONENT_SCHEMA),
+    validate_audio,
 )
 
 
@@ -98,10 +110,12 @@ async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
 
-    mic = await cg.get_variable(config[CONF_MICROPHONE])
-    cg.add(var.set_microphone(mic))
-    spk = await cg.get_variable(config[CONF_SPEAKER])
-    cg.add(var.set_speaker(spk))
+    if CONF_MICROPHONE in config:
+        mic = await cg.get_variable(config[CONF_MICROPHONE])
+        cg.add(var.set_microphone(mic))
+    if CONF_SPEAKER in config:
+        spk = await cg.get_variable(config[CONF_SPEAKER])
+        cg.add(var.set_speaker(spk))
 
     cg.add(var.set_server(config[CONF_SERVER]))
     cg.add(var.set_port(config[CONF_PORT]))

--- a/components/sip_client/rtp_session.cpp
+++ b/components/sip_client/rtp_session.cpp
@@ -228,6 +228,7 @@ void RtpSession::receive_() {
       continue;
     }
     if (pt != 0 && pt != 8) continue;  // unknown codec
+    if (!this->on_audio_) continue;    // send-only / no speaker: skip decode
 
     size_t n = len - header_len;
     this->decode_buf_.resize(n);
@@ -235,7 +236,7 @@ void RtpSession::receive_() {
       uint8_t b = this->recv_buf_[header_len + i];
       this->decode_buf_[i] = (pt == 8) ? g711::alaw_to_linear(b) : g711::ulaw_to_linear(b);
     }
-    if (this->on_audio_) this->on_audio_(this->decode_buf_.data(), n);
+    this->on_audio_(this->decode_buf_.data(), n);
   }
 }
 

--- a/components/sip_client/sip_client.cpp
+++ b/components/sip_client/sip_client.cpp
@@ -53,10 +53,12 @@ void SipClient::setup() {
   if (this->domain_.empty()) this->domain_ = this->server_;
   this->recv_buf_.resize(2048);
 
+#ifdef USE_MICROPHONE
   if (this->mic_ != nullptr) {
     this->mic_->add_data_callback(
         [this](const std::vector<uint8_t> &data) { this->on_mic_data_(data); });
   }
+#endif
   ESP_LOGCONFIG(TAG, "sip_client initialized (server=%s:%u user=%s)", this->server_.c_str(),
                 this->server_port_, this->username_.c_str());
 }
@@ -69,8 +71,16 @@ void SipClient::dump_config() {
   ESP_LOGCONFIG(TAG, "  Local RTP port: %u", this->local_rtp_port_);
   ESP_LOGCONFIG(TAG, "  Channel: %s", this->channel_ == SIP_CH_MONO ? "mono" : "stereo");
   ESP_LOGCONFIG(TAG, "  Half-duplex (PTT): %s", this->half_duplex_ ? "yes" : "no");
+#ifdef USE_MICROPHONE
   ESP_LOGCONFIG(TAG, "  Microphone: %s", this->mic_ ? "yes" : "no");
+#else
+  ESP_LOGCONFIG(TAG, "  Microphone: no");
+#endif
+#ifdef USE_SPEAKER
   ESP_LOGCONFIG(TAG, "  Speaker: %s", this->speaker_ ? "yes" : "no");
+#else
+  ESP_LOGCONFIG(TAG, "  Speaker: no");
+#endif
   ESP_LOGCONFIG(TAG, "  Media direction: %s", this->media_direction_());
 }
 
@@ -596,6 +606,7 @@ void SipClient::start_media_() {
   this->rtp_.set_payload_type(this->chosen_pt_);
   this->rtp_.set_dtmf_payload_type(this->remote_dtmf_pt_);
   this->rtp_.set_remote(this->remote_rtp_ip_, this->remote_rtp_port_);
+#ifdef USE_SPEAKER
   if (this->speaker_ != nullptr) {
     this->rtp_.set_on_audio([this](const int16_t *pcm, size_t n) {
       if (this->half_duplex_ && this->talking_) return;  // speaker is off while transmitting
@@ -626,6 +637,9 @@ void SipClient::start_media_() {
   } else {
     this->rtp_.set_on_audio({});  // send-only: skip G.711 decode in receive_()
   }
+#else
+  this->rtp_.set_on_audio({});  // no speaker in build: skip G.711 decode in receive_()
+#endif
   this->rtp_.set_on_dtmf([this](char c) {
     std::string s(1, c);
     this->dtmf_cb_.call(s);
@@ -642,6 +656,7 @@ void SipClient::start_media_() {
     this->start_speaker_();
     this->start_mic_();
   }
+#ifdef USE_MICROPHONE
   if (this->mic_ != nullptr) {
     ESP_LOGI(TAG, "Media started: remote %s:%u pt=%u dtmf_pt=%d dir=%s (mic %u Hz/%uch/%ubits)%s",
              this->remote_rtp_ip_.c_str(), this->remote_rtp_port_, this->chosen_pt_,
@@ -653,6 +668,11 @@ void SipClient::start_media_() {
              this->remote_rtp_ip_.c_str(), this->remote_rtp_port_, this->chosen_pt_,
              this->remote_dtmf_pt_, this->media_direction_());
   }
+#else
+  ESP_LOGI(TAG, "Media started: remote %s:%u pt=%u dtmf_pt=%d dir=%s",
+           this->remote_rtp_ip_.c_str(), this->remote_rtp_port_, this->chosen_pt_,
+           this->remote_dtmf_pt_, this->media_direction_());
+#endif
 }
 
 void SipClient::stop_media_() {
@@ -665,30 +685,39 @@ void SipClient::stop_media_() {
 }
 
 void SipClient::start_speaker_() {
+#ifdef USE_SPEAKER
   if (this->speaker_ == nullptr) return;
   this->speaker_rate_ = 8000;
   this->speaker_->set_audio_stream_info(audio::AudioStreamInfo(16, this->output_channels_(), 8000));
   this->speaker_->start();
+#endif
 }
 
 void SipClient::stop_speaker_() {
+#ifdef USE_SPEAKER
   if (this->speaker_ != nullptr) this->speaker_->stop();
+#endif
 }
 
 void SipClient::start_mic_() {
+#ifdef USE_MICROPHONE
   if (this->mic_ == nullptr) return;
   auto info = this->mic_->get_audio_stream_info();
   this->mic_rate_ = info.get_sample_rate();
   this->mic_channels_ = info.get_channels();
   this->mic_bits_ = info.get_bits_per_sample();
   this->mic_->start();
+#endif
 }
 
 void SipClient::stop_mic_() {
+#ifdef USE_MICROPHONE
   if (this->mic_ != nullptr) this->mic_->stop();
+#endif
 }
 
 void SipClient::start_talking() {
+#if defined(USE_MICROPHONE) && defined(USE_SPEAKER)
   if (!this->half_duplex_ || !this->media_active_ || this->talking_) return;
   // Hand the shared bus from speaker to mic.
   this->stop_speaker_();
@@ -696,9 +725,11 @@ void SipClient::start_talking() {
   this->start_mic_();
   this->talking_ = true;
   ESP_LOGD(TAG, "PTT: talking");
+#endif
 }
 
 void SipClient::stop_talking() {
+#if defined(USE_MICROPHONE) && defined(USE_SPEAKER)
   if (!this->half_duplex_ || !this->media_active_ || !this->talking_) return;
   // Hand the shared bus back from mic to speaker.
   this->stop_mic_();
@@ -706,8 +737,10 @@ void SipClient::stop_talking() {
   this->start_speaker_();
   this->talking_ = false;
   ESP_LOGD(TAG, "PTT: listening");
+#endif
 }
 
+#ifdef USE_MICROPHONE
 void SipClient::on_mic_data_(const std::vector<uint8_t> &data) {
   if (!this->media_active_ || this->state_ != SIP_IN_CALL) return;
   if (this->half_duplex_ && !this->talking_) return;  // only transmit while PTT is held
@@ -746,6 +779,7 @@ void SipClient::on_mic_data_(const std::vector<uint8_t> &data) {
     this->rtp_.push_tx_audio(samples, n);
   }
 }
+#endif
 
 // ---------------- main loop ----------------
 

--- a/components/sip_client/sip_client.cpp
+++ b/components/sip_client/sip_client.cpp
@@ -71,6 +71,12 @@ void SipClient::dump_config() {
   ESP_LOGCONFIG(TAG, "  Half-duplex (PTT): %s", this->half_duplex_ ? "yes" : "no");
   ESP_LOGCONFIG(TAG, "  Microphone: %s", this->mic_ ? "yes" : "no");
   ESP_LOGCONFIG(TAG, "  Speaker: %s", this->speaker_ ? "yes" : "no");
+  const char *dir = "sendrecv";
+  if (this->mic_ == nullptr)
+    dir = "recvonly";
+  else if (this->speaker_ == nullptr)
+    dir = "sendonly";
+  ESP_LOGCONFIG(TAG, "  Media direction: %s", dir);
 }
 
 bool SipClient::open_socket_() {
@@ -267,7 +273,14 @@ std::string SipClient::local_sdp_() {
   sdp += "a=rtpmap:101 telephone-event/8000\r\n";
   sdp += "a=fmtp:101 0-15\r\n";
   sdp += "a=ptime:20\r\n";
-  sdp += "a=sendrecv\r\n";
+  // Advertise media direction from which endpoints are actually wired.
+  if (this->mic_ != nullptr && this->speaker_ != nullptr) {
+    sdp += "a=sendrecv\r\n";
+  } else if (this->mic_ != nullptr) {
+    sdp += "a=sendonly\r\n";
+  } else {
+    sdp += "a=recvonly\r\n";
+  }
   return sdp;
 }
 
@@ -638,9 +651,14 @@ void SipClient::start_media_() {
     this->start_speaker_();
     this->start_mic_();
   }
-  ESP_LOGI(TAG, "Media started: remote %s:%u pt=%u dtmf_pt=%d (mic %u Hz/%uch/%ubits)%s",
+  const char *dir = "sendrecv";
+  if (this->mic_ == nullptr)
+    dir = "recvonly";
+  else if (this->speaker_ == nullptr)
+    dir = "sendonly";
+  ESP_LOGI(TAG, "Media started: remote %s:%u pt=%u dtmf_pt=%d dir=%s (mic %u Hz/%uch/%ubits)%s",
            this->remote_rtp_ip_.c_str(), this->remote_rtp_port_, this->chosen_pt_,
-           this->remote_dtmf_pt_, static_cast<unsigned>(this->mic_rate_), this->mic_channels_,
+           this->remote_dtmf_pt_, dir, static_cast<unsigned>(this->mic_rate_), this->mic_channels_,
            this->mic_bits_, this->half_duplex_ ? " [half-duplex: listening]" : "");
 }
 

--- a/components/sip_client/sip_client.cpp
+++ b/components/sip_client/sip_client.cpp
@@ -71,12 +71,7 @@ void SipClient::dump_config() {
   ESP_LOGCONFIG(TAG, "  Half-duplex (PTT): %s", this->half_duplex_ ? "yes" : "no");
   ESP_LOGCONFIG(TAG, "  Microphone: %s", this->mic_ ? "yes" : "no");
   ESP_LOGCONFIG(TAG, "  Speaker: %s", this->speaker_ ? "yes" : "no");
-  const char *dir = "sendrecv";
-  if (this->mic_ == nullptr)
-    dir = "recvonly";
-  else if (this->speaker_ == nullptr)
-    dir = "sendonly";
-  ESP_LOGCONFIG(TAG, "  Media direction: %s", dir);
+  ESP_LOGCONFIG(TAG, "  Media direction: %s", this->media_direction_());
 }
 
 bool SipClient::open_socket_() {
@@ -273,14 +268,7 @@ std::string SipClient::local_sdp_() {
   sdp += "a=rtpmap:101 telephone-event/8000\r\n";
   sdp += "a=fmtp:101 0-15\r\n";
   sdp += "a=ptime:20\r\n";
-  // Advertise media direction from which endpoints are actually wired.
-  if (this->mic_ != nullptr && this->speaker_ != nullptr) {
-    sdp += "a=sendrecv\r\n";
-  } else if (this->mic_ != nullptr) {
-    sdp += "a=sendonly\r\n";
-  } else {
-    sdp += "a=recvonly\r\n";
-  }
+  sdp += std::string("a=") + this->media_direction_() + "\r\n";
   return sdp;
 }
 
@@ -608,33 +596,36 @@ void SipClient::start_media_() {
   this->rtp_.set_payload_type(this->chosen_pt_);
   this->rtp_.set_dtmf_payload_type(this->remote_dtmf_pt_);
   this->rtp_.set_remote(this->remote_rtp_ip_, this->remote_rtp_port_);
-  this->rtp_.set_on_audio([this](const int16_t *pcm, size_t n) {
-    if (this->speaker_ == nullptr) return;
-    if (this->half_duplex_ && this->talking_) return;  // speaker is off while transmitting
+  if (this->speaker_ != nullptr) {
+    this->rtp_.set_on_audio([this](const int16_t *pcm, size_t n) {
+      if (this->half_duplex_ && this->talking_) return;  // speaker is off while transmitting
 
-    const int16_t *play_pcm = pcm;
-    size_t play_n = n;
-    std::vector<int16_t> upsampled;
+      const int16_t *play_pcm = pcm;
+      size_t play_n = n;
+      std::vector<int16_t> upsampled;
 
-    if (this->speaker_rate_ >= 16000) {
-      resampler::upsample_1to2(pcm, n, upsampled);
-      play_pcm = upsampled.data();
-      play_n = upsampled.size();
-    }
-
-    if (this->channel_ == SIP_CH_STEREO) {
-      // Duplicate mono samples to stereo (L/R) for stereo mixers/speakers (e.g. Voice PE).
-      std::vector<int16_t> stereo(play_n * 2);
-      for (size_t i = 0; i < play_n; i++) {
-        stereo[i * 2] = play_pcm[i];
-        stereo[i * 2 + 1] = play_pcm[i];
+      if (this->speaker_rate_ >= 16000) {
+        resampler::upsample_1to2(pcm, n, upsampled);
+        play_pcm = upsampled.data();
+        play_n = upsampled.size();
       }
-      this->speaker_->play(reinterpret_cast<const uint8_t *>(stereo.data()), stereo.size() * sizeof(int16_t));
-    } else {
-      // Mono output (e.g. es8311): push samples as-is.
-      this->speaker_->play(reinterpret_cast<const uint8_t *>(play_pcm), play_n * sizeof(int16_t));
-    }
-  });
+
+      if (this->channel_ == SIP_CH_STEREO) {
+        // Duplicate mono samples to stereo (L/R) for stereo mixers/speakers (e.g. Voice PE).
+        std::vector<int16_t> stereo(play_n * 2);
+        for (size_t i = 0; i < play_n; i++) {
+          stereo[i * 2] = play_pcm[i];
+          stereo[i * 2 + 1] = play_pcm[i];
+        }
+        this->speaker_->play(reinterpret_cast<const uint8_t *>(stereo.data()), stereo.size() * sizeof(int16_t));
+      } else {
+        // Mono output (e.g. es8311): push samples as-is.
+        this->speaker_->play(reinterpret_cast<const uint8_t *>(play_pcm), play_n * sizeof(int16_t));
+      }
+    });
+  } else {
+    this->rtp_.set_on_audio({});  // send-only: skip G.711 decode in receive_()
+  }
   this->rtp_.set_on_dtmf([this](char c) {
     std::string s(1, c);
     this->dtmf_cb_.call(s);
@@ -651,15 +642,17 @@ void SipClient::start_media_() {
     this->start_speaker_();
     this->start_mic_();
   }
-  const char *dir = "sendrecv";
-  if (this->mic_ == nullptr)
-    dir = "recvonly";
-  else if (this->speaker_ == nullptr)
-    dir = "sendonly";
-  ESP_LOGI(TAG, "Media started: remote %s:%u pt=%u dtmf_pt=%d dir=%s (mic %u Hz/%uch/%ubits)%s",
-           this->remote_rtp_ip_.c_str(), this->remote_rtp_port_, this->chosen_pt_,
-           this->remote_dtmf_pt_, dir, static_cast<unsigned>(this->mic_rate_), this->mic_channels_,
-           this->mic_bits_, this->half_duplex_ ? " [half-duplex: listening]" : "");
+  if (this->mic_ != nullptr) {
+    ESP_LOGI(TAG, "Media started: remote %s:%u pt=%u dtmf_pt=%d dir=%s (mic %u Hz/%uch/%ubits)%s",
+             this->remote_rtp_ip_.c_str(), this->remote_rtp_port_, this->chosen_pt_,
+             this->remote_dtmf_pt_, this->media_direction_(),
+             static_cast<unsigned>(this->mic_rate_), this->mic_channels_, this->mic_bits_,
+             this->half_duplex_ ? " [half-duplex: listening]" : "");
+  } else {
+    ESP_LOGI(TAG, "Media started: remote %s:%u pt=%u dtmf_pt=%d dir=%s",
+             this->remote_rtp_ip_.c_str(), this->remote_rtp_port_, this->chosen_pt_,
+             this->remote_dtmf_pt_, this->media_direction_());
+  }
 }
 
 void SipClient::stop_media_() {

--- a/components/sip_client/sip_client.h
+++ b/components/sip_client/sip_client.h
@@ -104,6 +104,14 @@ class SipClient : public Component {
   void start_mic_();
   void stop_mic_();
   void on_mic_data_(const std::vector<uint8_t> &data);
+  // SDP / logs: based on which audio endpoints are wired.
+  const char *media_direction_() const {
+    if (this->mic_ == nullptr)
+      return "recvonly";
+    if (this->speaker_ == nullptr)
+      return "sendonly";
+    return "sendrecv";
+  }
 
   void set_state_(SipState s);
   std::string extract_caller_(const SipMessage &m);

--- a/components/sip_client/sip_client.h
+++ b/components/sip_client/sip_client.h
@@ -2,11 +2,16 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include "esphome/core/defines.h"
 #include "esphome/core/component.h"
 #include "esphome/core/automation.h"
 #include "esphome/components/socket/socket.h"
+#ifdef USE_MICROPHONE
 #include "esphome/components/microphone/microphone.h"
+#endif
+#ifdef USE_SPEAKER
 #include "esphome/components/speaker/speaker.h"
+#endif
 #include "rtp_session.h"
 #include "sip_message.h"
 
@@ -31,8 +36,12 @@ enum SipState {
 
 class SipClient : public Component {
  public:
+#ifdef USE_MICROPHONE
   void set_microphone(microphone::Microphone *mic) { this->mic_ = mic; }
+#endif
+#ifdef USE_SPEAKER
   void set_speaker(speaker::Speaker *spk) { this->speaker_ = spk; }
+#endif
   void set_server(const std::string &server) { this->server_ = server; }
   void set_port(uint16_t port) { this->server_port_ = port; }
   void set_username(const std::string &v) { this->username_ = v; }
@@ -103,22 +112,39 @@ class SipClient : public Component {
   void stop_speaker_();
   void start_mic_();
   void stop_mic_();
+#ifdef USE_MICROPHONE
   void on_mic_data_(const std::vector<uint8_t> &data);
+#endif
   // SDP / logs: based on which audio endpoints are wired.
+  // USE_MICROPHONE / USE_SPEAKER are set by ESPHome when any mic/speaker
+  // platform is in the build; pointers may still be null if this component
+  // did not take a reference (send-only / receive-only).
   const char *media_direction_() const {
+#if defined(USE_MICROPHONE) && defined(USE_SPEAKER)
     if (this->mic_ == nullptr)
       return "recvonly";
     if (this->speaker_ == nullptr)
       return "sendonly";
     return "sendrecv";
+#elif defined(USE_SPEAKER)
+    return "recvonly";
+#elif defined(USE_MICROPHONE)
+    return "sendonly";
+#else
+    return "inactive";
+#endif
   }
 
   void set_state_(SipState s);
   std::string extract_caller_(const SipMessage &m);
 
   // config
+#ifdef USE_MICROPHONE
   microphone::Microphone *mic_{nullptr};
+#endif
+#ifdef USE_SPEAKER
   speaker::Speaker *speaker_{nullptr};
+#endif
   std::string server_;
   uint16_t server_port_{5060};
   std::string username_;

--- a/tests/components/sip_client/test.esp32-idf.mic-only.yaml
+++ b/tests/components/sip_client/test.esp32-idf.mic-only.yaml
@@ -1,0 +1,44 @@
+esphome:
+  name: test-sip-client-mic-only
+
+esp32:
+  board: esp32dev
+  framework:
+    type: esp-idf
+
+external_components:
+  - source:
+      type: local
+      path: ../../../components
+    components: [ sip_client ]
+
+wifi:
+  ssid: "test_ssid"
+  password: "test_password"
+
+logger:
+
+i2s_audio:
+  - id: i2s_in
+    i2s_lrclk_pin: GPIO25
+    i2s_bclk_pin: GPIO26
+
+microphone:
+  - platform: i2s_audio
+    id: mic_id
+    i2s_audio_id: i2s_in
+    adc_type: external
+    i2s_din_pin: GPIO33
+    pdm: false
+
+# Send-only: no speaker → SDP a=sendonly
+sip_client:
+  id: my_sip
+  microphone: mic_id
+  server: 192.168.0.10
+  username: "1001"
+  password: "secret"
+  domain: "192.168.0.10"
+
+  on_incoming_call:
+    - sip_client.answer: my_sip

--- a/tests/components/sip_client/test.esp32-idf.speaker-only.yaml
+++ b/tests/components/sip_client/test.esp32-idf.speaker-only.yaml
@@ -1,0 +1,43 @@
+esphome:
+  name: test-sip-client-speaker-only
+
+esp32:
+  board: esp32dev
+  framework:
+    type: esp-idf
+
+external_components:
+  - source:
+      type: local
+      path: ../../../components
+    components: [ sip_client ]
+
+wifi:
+  ssid: "test_ssid"
+  password: "test_password"
+
+logger:
+
+i2s_audio:
+  - id: i2s_out
+    i2s_lrclk_pin: GPIO27
+    i2s_bclk_pin: GPIO14
+
+speaker:
+  - platform: i2s_audio
+    id: spk_id
+    i2s_audio_id: i2s_out
+    dac_type: external
+    i2s_dout_pin: GPIO22
+
+# Receive-only: no microphone → SDP a=recvonly
+sip_client:
+  id: my_sip
+  speaker: spk_id
+  server: 192.168.0.10
+  username: "1001"
+  password: "secret"
+  domain: "192.168.0.10"
+
+  on_incoming_call:
+    - sip_client.answer: my_sip


### PR DESCRIPTION
Make microphone and speaker optional (at least one required) and advertise matching SDP direction so announcement speakers and mic-only uplink devices work without unused audio I/O. half_duplex still requires both.

Closes #285