### PR TITLE
refactor(sip_client): introduce Codec abstraction for G.711

### DIFF
--- a/components/sip_client/codec.h
+++ b/components/sip_client/codec.h
@@ -13,6 +13,10 @@ enum class AudioCodecId : uint8_t {
   PCMA = 1,
 };
 
+// Upper bound on a single RTP audio payload (bytes). Stack buffers and
+// sendto sizes are capped to this; codecs that need more must raise it.
+static constexpr size_t MAX_AUDIO_PAYLOAD_BYTES = 320;
+
 struct CodecDesc {
   uint8_t pt{0};                      // negotiated wire payload type
   const char *rtpmap{"PCMU/8000"};    // SDP a=rtpmap encoding name/rate
@@ -20,6 +24,12 @@ struct CodecDesc {
   uint16_t pcm_samples_per_frame{160};
   uint16_t payload_bytes{160};
   uint16_t ts_per_frame{160};         // RTP timestamp clock increment
+
+  // Decode output capacity for a payload of `n` bytes (G.711 1:1, G.722 2:1).
+  size_t max_pcm_samples_for_payload(size_t n) const {
+    if (this->payload_bytes == 0) return n;
+    return (n * this->pcm_samples_per_frame + this->payload_bytes - 1) / this->payload_bytes;
+  }
 };
 
 // Pluggable audio codec used by RtpSession. PCM is always signed 16-bit mono

--- a/components/sip_client/codec.h
+++ b/components/sip_client/codec.h
@@ -1,0 +1,42 @@
+#pragma once
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+
+namespace esphome {
+namespace sip_client {
+
+// Identifies the audio encoding independently of the negotiated RTP payload
+// type (which may be a dynamic PT such as 97 for PCMA).
+enum class AudioCodecId : uint8_t {
+  PCMU = 0,
+  PCMA = 1,
+};
+
+struct CodecDesc {
+  uint8_t pt{0};                      // negotiated wire payload type
+  const char *rtpmap{"PCMU/8000"};    // SDP a=rtpmap encoding name/rate
+  uint32_t pcm_rate{8000};            // linear PCM sample rate for I/O
+  uint16_t pcm_samples_per_frame{160};
+  uint16_t payload_bytes{160};
+  uint16_t ts_per_frame{160};         // RTP timestamp clock increment
+};
+
+// Pluggable audio codec used by RtpSession. PCM is always signed 16-bit mono
+// at desc().pcm_rate.
+class Codec {
+ public:
+  virtual ~Codec() = default;
+  virtual const CodecDesc &desc() const = 0;
+  // Encode `samples` PCM frames into `out` (capacity >= desc().payload_bytes).
+  // Returns bytes written.
+  virtual size_t encode(const int16_t *pcm, size_t samples, uint8_t *out) = 0;
+  // Decode `bytes` of payload into `pcm` (capacity >= samples produced).
+  // Returns number of PCM samples written.
+  virtual size_t decode(const uint8_t *in, size_t bytes, int16_t *pcm) = 0;
+  virtual void reset() {}
+  virtual AudioCodecId id() const = 0;
+};
+
+}  // namespace sip_client
+}  // namespace esphome

--- a/components/sip_client/codec.h
+++ b/components/sip_client/codec.h
@@ -39,7 +39,9 @@ class Codec {
   virtual ~Codec() = default;
   virtual const CodecDesc &desc() const = 0;
   // Encode `samples` PCM frames into `out` (capacity >= desc().payload_bytes).
-  // Returns bytes written.
+  // Must not write more than desc().payload_bytes (callers size the RTP buffer
+  // to MAX_AUDIO_PAYLOAD_BYTES and send only the returned length).
+  // Returns bytes written (0 = drop the packet).
   virtual size_t encode(const int16_t *pcm, size_t samples, uint8_t *out) = 0;
   // Decode `bytes` of payload into `pcm` (capacity >= samples produced).
   // Returns number of PCM samples written.

--- a/components/sip_client/g711_codec.h
+++ b/components/sip_client/g711_codec.h
@@ -1,0 +1,50 @@
+#pragma once
+#include "codec.h"
+#include "g711.h"
+
+namespace esphome {
+namespace sip_client {
+
+// Stateless G.711 µ-law / A-law codec. `pt` is the negotiated wire PT (static
+// 0/8 or a dynamic PT); encoding is selected by AudioCodecId, not by PT.
+class G711Codec : public Codec {
+ public:
+  G711Codec(uint8_t pt, AudioCodecId id) : id_(id) {
+    desc_.pt = pt;
+    desc_.rtpmap = (id == AudioCodecId::PCMA) ? "PCMA/8000" : "PCMU/8000";
+    desc_.pcm_rate = 8000;
+    desc_.pcm_samples_per_frame = 160;
+    desc_.payload_bytes = 160;
+    desc_.ts_per_frame = 160;
+  }
+
+  const CodecDesc &desc() const override { return desc_; }
+  AudioCodecId id() const override { return id_; }
+
+  size_t encode(const int16_t *pcm, size_t samples, uint8_t *out) override {
+    const bool alaw = this->id_ == AudioCodecId::PCMA;
+    for (size_t i = 0; i < samples; i++) {
+      out[i] = alaw ? g711::linear_to_alaw(pcm[i]) : g711::linear_to_ulaw(pcm[i]);
+    }
+    return samples;
+  }
+
+  size_t decode(const uint8_t *in, size_t bytes, int16_t *pcm) override {
+    const bool alaw = this->id_ == AudioCodecId::PCMA;
+    for (size_t i = 0; i < bytes; i++) {
+      pcm[i] = alaw ? g711::alaw_to_linear(in[i]) : g711::ulaw_to_linear(in[i]);
+    }
+    return bytes;
+  }
+
+ private:
+  AudioCodecId id_;
+  CodecDesc desc_{};
+};
+
+inline std::unique_ptr<Codec> make_g711_codec(uint8_t pt, AudioCodecId id) {
+  return std::unique_ptr<Codec>(new G711Codec(pt, id));
+}
+
+}  // namespace sip_client
+}  // namespace esphome

--- a/components/sip_client/rtp_session.cpp
+++ b/components/sip_client/rtp_session.cpp
@@ -12,8 +12,6 @@ static const char *const TAG = "sip_client.rtp";
 
 static const uint32_t FRAME_MS = 20;
 static const int DTMF_END_PACKETS = 3;
-// Bound TX latency (~1 s at 8 kHz; scales with higher pcm rates in PR3).
-static const size_t TX_BUFFER_MAX = 16000;
 
 // Bind-any sockaddr for the given family. Unlike socket::set_sockaddr_any(),
 // this doesn't depend on ESPHome's global network::enable_ipv6 setting — the
@@ -115,10 +113,13 @@ void RtpSession::stop() {
 
 void RtpSession::push_tx_audio(const int16_t *pcm, size_t samples) {
   if (!this->socket_) return;
+  // ~1 s of PCM at the codec sample rate (8000 for G.711).
+  const size_t tx_max =
+      this->codec_ != nullptr ? static_cast<size_t>(this->codec_->desc().pcm_rate) : 8000;
   std::lock_guard<std::mutex> lock(this->tx_mutex_);
-  if (this->tx_buffer_.size() + samples > TX_BUFFER_MAX) {
+  if (this->tx_buffer_.size() + samples > tx_max) {
     // Drop oldest to bound latency.
-    size_t overflow = this->tx_buffer_.size() + samples - TX_BUFFER_MAX;
+    size_t overflow = this->tx_buffer_.size() + samples - tx_max;
     if (overflow >= this->tx_buffer_.size())
       this->tx_buffer_.clear();
     else
@@ -155,19 +156,30 @@ void RtpSession::send_audio_packet_() {
   const uint16_t pcm_n = this->pcm_samples_per_frame_();
   const uint16_t pay_n = this->payload_bytes_();
   const uint16_t ts_step = this->ts_per_frame_();
-  uint8_t packet[12 + 320];  // room for G.722-sized payloads later
-  if (pay_n > 320) return;
+  uint8_t packet[12 + MAX_AUDIO_PAYLOAD_BYTES];
+  if (pay_n > MAX_AUDIO_PAYLOAD_BYTES) {
+    ESP_LOGW(TAG, "codec payload %u exceeds MAX_AUDIO_PAYLOAD_BYTES (%u); drop", pay_n,
+             static_cast<unsigned>(MAX_AUDIO_PAYLOAD_BYTES));
+    return;
+  }
+  size_t written = 0;
   {
     std::lock_guard<std::mutex> lock(this->tx_mutex_);
     if (this->tx_buffer_.size() < pcm_n) return;
     this->build_rtp_header_(packet, this->first_packet_, this->codec_->desc().pt, this->timestamp_);
-    size_t written = this->codec_->encode(this->tx_buffer_.data(), pcm_n, packet + 12);
-    if (written != pay_n) {
-      ESP_LOGW(TAG, "encode size mismatch: %u vs %u", static_cast<unsigned>(written), pay_n);
-    }
+    written = this->codec_->encode(this->tx_buffer_.data(), pcm_n, packet + 12);
     this->tx_buffer_.erase(this->tx_buffer_.begin(), this->tx_buffer_.begin() + pcm_n);
   }
-  this->socket_->sendto(packet, 12 + pay_n, 0,
+  if (written == 0) {
+    ESP_LOGW(TAG, "encode produced 0 bytes; packet dropped");
+    return;
+  }
+  if (written != pay_n) {
+    ESP_LOGW(TAG, "encode size mismatch: %u vs expected %u; sending written size",
+             static_cast<unsigned>(written), pay_n);
+  }
+  if (written > MAX_AUDIO_PAYLOAD_BYTES) written = MAX_AUDIO_PAYLOAD_BYTES;
+  this->socket_->sendto(packet, 12 + written, 0,
                         reinterpret_cast<struct sockaddr *>(&this->remote_addr_),
                         this->remote_addr_len_);
   this->seq_++;
@@ -239,11 +251,22 @@ void RtpSession::receive_() {
       }
       continue;
     }
-    if (pt != expect_pt) continue;  // not the negotiated audio PT
+    if (pt != expect_pt) {
+      // Throttle: unexpected PT (e.g. comfort noise 13) otherwise leaves silence
+      // with no log trail.
+      static uint32_t last_unexpected_ms = 0;
+      uint32_t now = millis();
+      if (now - last_unexpected_ms > 2000) {
+        ESP_LOGW(TAG, "Ignoring RTP pt=%u (negotiated pt=%u)", pt, expect_pt);
+        last_unexpected_ms = now;
+      }
+      continue;
+    }
     if (!this->on_audio_) continue;  // send-only / no speaker: skip decode
 
     size_t n = len - header_len;
-    this->decode_buf_.resize(n);  // G.711: 1 byte → 1 sample; G.722 differs later
+    const size_t pcm_cap = this->codec_->desc().max_pcm_samples_for_payload(n);
+    this->decode_buf_.resize(pcm_cap);
     size_t samples = this->codec_->decode(this->recv_buf_.data() + header_len, n,
                                           this->decode_buf_.data());
     this->decode_buf_.resize(samples);

--- a/components/sip_client/rtp_session.cpp
+++ b/components/sip_client/rtp_session.cpp
@@ -4,18 +4,16 @@
 #include "esphome/core/defines.h"
 #include "esphome/core/hal.h"
 #include "esphome/core/log.h"
-#include "g711.h"
 
 namespace esphome {
 namespace sip_client {
 
 static const char *const TAG = "sip_client.rtp";
 
-static const size_t SAMPLES_PER_FRAME = 160;   // 20 ms @ 8 kHz
 static const uint32_t FRAME_MS = 20;
-static const uint32_t DTMF_TONE_SAMPLES = 8 * SAMPLES_PER_FRAME;  // ~160 ms tone
 static const int DTMF_END_PACKETS = 3;
-static const size_t TX_BUFFER_MAX = 8000;  // 1 s of audio, drop excess
+// Bound TX latency (~1 s at 8 kHz; scales with higher pcm rates in PR3).
+static const size_t TX_BUFFER_MAX = 16000;
 
 // Bind-any sockaddr for the given family. Unlike socket::set_sockaddr_any(),
 // this doesn't depend on ESPHome's global network::enable_ipv6 setting — the
@@ -60,6 +58,11 @@ void RtpSession::set_remote(const std::string &ip, uint16_t port) {
 
 bool RtpSession::start(uint16_t local_port) {
   this->stop();
+  if (this->codec_ == nullptr) {
+    ESP_LOGW(TAG, "RTP start failed: no codec");
+    return false;
+  }
+  this->codec_->reset();
   // Match the remote peer's address family (set via set_remote() before this
   // call) instead of socket::socket_ip(), which is fixed to AF_INET6 whenever
   // ESPHome's global network::enable_ipv6 is on — see open_socket_() in
@@ -92,8 +95,8 @@ bool RtpSession::start(uint16_t local_port) {
   this->dtmf_active_ = false;
   this->last_tx_ms_ = millis();
   this->recv_buf_.resize(1500);
-  ESP_LOGI(TAG, "RTP started on port %u (pt=%u, dtmf_pt=%d)", local_port, this->payload_type_,
-           this->dtmf_pt_);
+  ESP_LOGI(TAG, "RTP started on port %u (pt=%u %s, dtmf_pt=%d)", local_port,
+           this->codec_->desc().pt, this->codec_->desc().rtpmap, this->dtmf_pt_);
   return true;
 }
 
@@ -148,26 +151,34 @@ void RtpSession::build_rtp_header_(uint8_t *buf, bool marker, uint8_t pt, uint32
 }
 
 void RtpSession::send_audio_packet_() {
-  uint8_t packet[12 + SAMPLES_PER_FRAME];
+  if (this->codec_ == nullptr) return;
+  const uint16_t pcm_n = this->pcm_samples_per_frame_();
+  const uint16_t pay_n = this->payload_bytes_();
+  const uint16_t ts_step = this->ts_per_frame_();
+  uint8_t packet[12 + 320];  // room for G.722-sized payloads later
+  if (pay_n > 320) return;
   {
     std::lock_guard<std::mutex> lock(this->tx_mutex_);
-    if (this->tx_buffer_.size() < SAMPLES_PER_FRAME) return;
-    this->build_rtp_header_(packet, this->first_packet_, this->payload_type_, this->timestamp_);
-    for (size_t i = 0; i < SAMPLES_PER_FRAME; i++) {
-      int16_t s = this->tx_buffer_[i];
-      packet[12 + i] = (this->payload_type_ == 8) ? g711::linear_to_alaw(s) : g711::linear_to_ulaw(s);
+    if (this->tx_buffer_.size() < pcm_n) return;
+    this->build_rtp_header_(packet, this->first_packet_, this->codec_->desc().pt, this->timestamp_);
+    size_t written = this->codec_->encode(this->tx_buffer_.data(), pcm_n, packet + 12);
+    if (written != pay_n) {
+      ESP_LOGW(TAG, "encode size mismatch: %u vs %u", static_cast<unsigned>(written), pay_n);
     }
-    this->tx_buffer_.erase(this->tx_buffer_.begin(), this->tx_buffer_.begin() + SAMPLES_PER_FRAME);
+    this->tx_buffer_.erase(this->tx_buffer_.begin(), this->tx_buffer_.begin() + pcm_n);
   }
-  this->socket_->sendto(packet, sizeof(packet), 0,
+  this->socket_->sendto(packet, 12 + pay_n, 0,
                         reinterpret_cast<struct sockaddr *>(&this->remote_addr_),
                         this->remote_addr_len_);
   this->seq_++;
-  this->timestamp_ += SAMPLES_PER_FRAME;
+  this->timestamp_ += ts_step;
   this->first_packet_ = false;
 }
 
 void RtpSession::send_dtmf_packet_() {
+  const uint16_t ts_step = this->ts_per_frame_();
+  const uint32_t dtmf_tone_samples = 8 * ts_step;  // ~160 ms
+
   if (!this->dtmf_active_) {
     if (this->dtmf_queue_.empty()) return;
     int event = dtmf_char_to_event(this->dtmf_queue_.front());
@@ -180,7 +191,7 @@ void RtpSession::send_dtmf_packet_() {
     this->dtmf_timestamp_ = this->timestamp_;
   }
 
-  bool end = this->dtmf_duration_ >= DTMF_TONE_SAMPLES;
+  bool end = this->dtmf_duration_ >= dtmf_tone_samples;
   uint8_t packet[16];
   this->build_rtp_header_(packet, this->dtmf_duration_ == 0, (uint8_t) this->dtmf_pt_,
                           this->dtmf_timestamp_);
@@ -197,16 +208,17 @@ void RtpSession::send_dtmf_packet_() {
     this->dtmf_end_packets_++;
     if (this->dtmf_end_packets_ >= DTMF_END_PACKETS) {
       this->dtmf_active_ = false;
-      this->timestamp_ = this->dtmf_timestamp_ + this->dtmf_duration_ + SAMPLES_PER_FRAME;
+      this->timestamp_ = this->dtmf_timestamp_ + this->dtmf_duration_ + ts_step;
       this->first_packet_ = true;  // re-mark audio after DTMF
     }
   } else {
-    this->dtmf_duration_ += SAMPLES_PER_FRAME;
+    this->dtmf_duration_ += ts_step;
   }
 }
 
 void RtpSession::receive_() {
-  if (!this->socket_) return;
+  if (!this->socket_ || this->codec_ == nullptr) return;
+  const uint8_t expect_pt = this->codec_->desc().pt;
   for (int guard = 0; guard < 8; guard++) {
     ssize_t len = this->socket_->read(this->recv_buf_.data(), this->recv_buf_.size());
     if (len < 12) return;  // EAGAIN or runt packet
@@ -227,16 +239,15 @@ void RtpSession::receive_() {
       }
       continue;
     }
-    if (pt != 0 && pt != 8) continue;  // unknown codec
-    if (!this->on_audio_) continue;    // send-only / no speaker: skip decode
+    if (pt != expect_pt) continue;  // not the negotiated audio PT
+    if (!this->on_audio_) continue;  // send-only / no speaker: skip decode
 
     size_t n = len - header_len;
-    this->decode_buf_.resize(n);
-    for (size_t i = 0; i < n; i++) {
-      uint8_t b = this->recv_buf_[header_len + i];
-      this->decode_buf_[i] = (pt == 8) ? g711::alaw_to_linear(b) : g711::ulaw_to_linear(b);
-    }
-    this->on_audio_(this->decode_buf_.data(), n);
+    this->decode_buf_.resize(n);  // G.711: 1 byte → 1 sample; G.722 differs later
+    size_t samples = this->codec_->decode(this->recv_buf_.data() + header_len, n,
+                                          this->decode_buf_.data());
+    this->decode_buf_.resize(samples);
+    this->on_audio_(this->decode_buf_.data(), samples);
   }
 }
 
@@ -260,6 +271,7 @@ void RtpSession::loop() {
     this->last_tx_ms_ = now;
   }
 
+  const uint16_t pcm_n = this->pcm_samples_per_frame_();
   int packets_sent = 0;
   while (now - this->last_tx_ms_ >= FRAME_MS && packets_sent < 5) {
     if (this->dtmf_active_ || !this->dtmf_queue_.empty()) {
@@ -270,7 +282,7 @@ void RtpSession::loop() {
       bool has_enough_samples = false;
       {
         std::lock_guard<std::mutex> lock(this->tx_mutex_);
-        if (this->tx_buffer_.size() >= SAMPLES_PER_FRAME) {
+        if (this->tx_buffer_.size() >= pcm_n) {
           has_enough_samples = true;
         }
       }

--- a/components/sip_client/rtp_session.h
+++ b/components/sip_client/rtp_session.h
@@ -2,22 +2,23 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <vector>
-#include <mutex>
+#include "codec.h"
 #include "esphome/components/socket/socket.h"
 
 namespace esphome {
 namespace sip_client {
 
-// RTP audio session for a single G.711 call. Owns one UDP socket, paces packet
-// transmission at 20 ms (160 samples @ 8 kHz), decodes received audio, and can
-// emit RFC 2833 telephone-event (DTMF) packets. All PCM exchanged with the
-// caller is signed 16-bit linear at 8 kHz, mono.
+// RTP audio session for a single negotiated codec. Owns one UDP socket, paces
+// packet transmission at 20 ms, and can emit RFC 2833 telephone-event (DTMF).
+// PCM exchanged with the caller is signed 16-bit linear mono at the codec's
+// pcm_rate.
 class RtpSession {
  public:
-  // payload_type: 0 = PCMU (mu-law), 8 = PCMA (A-law).
-  void set_payload_type(uint8_t pt) { this->payload_type_ = pt; }
+  // Non-owning. Must outlive the session while running; call reset() on start.
+  void set_codec(Codec *codec) { this->codec_ = codec; }
   void set_dtmf_payload_type(int pt) { this->dtmf_pt_ = pt; }
   void set_remote(const std::string &ip, uint16_t port);
 
@@ -28,7 +29,7 @@ class RtpSession {
   void stop();
   bool is_running() const { return this->socket_ != nullptr; }
 
-  // Append captured PCM (8 kHz) for transmission.
+  // Append captured PCM at the codec's sample rate for transmission.
   void push_tx_audio(const int16_t *pcm, size_t samples);
   // Queue DTMF digits ('0'-'9','*','#','A'-'D') for RFC 2833 transmission.
   void queue_dtmf(const std::string &digits);
@@ -40,13 +41,22 @@ class RtpSession {
   void send_dtmf_packet_();
   void receive_();
   void build_rtp_header_(uint8_t *buf, bool marker, uint8_t pt, uint32_t timestamp);
+  uint16_t ts_per_frame_() const {
+    return this->codec_ != nullptr ? this->codec_->desc().ts_per_frame : 160;
+  }
+  uint16_t pcm_samples_per_frame_() const {
+    return this->codec_ != nullptr ? this->codec_->desc().pcm_samples_per_frame : 160;
+  }
+  uint16_t payload_bytes_() const {
+    return this->codec_ != nullptr ? this->codec_->desc().payload_bytes : 160;
+  }
 
   std::unique_ptr<socket::Socket> socket_{nullptr};
   struct sockaddr_storage remote_addr_;
   socklen_t remote_addr_len_{0};
   bool remote_set_{false};
 
-  uint8_t payload_type_{0};
+  Codec *codec_{nullptr};
   int dtmf_pt_{101};
 
   uint16_t seq_{0};

--- a/components/sip_client/sdp_builder.cpp
+++ b/components/sip_client/sdp_builder.cpp
@@ -1,0 +1,44 @@
+#include "sdp_builder.h"
+
+namespace esphome {
+namespace sip_client {
+
+std::string build_sdp_body(const SdpMediaParams &p) {
+  std::string sdp;
+  sdp += "v=0\r\n";
+  sdp += "o=- " + p.session_id + " " + p.session_id + " IN IP4 " + p.local_ip + "\r\n";
+  sdp += "s=esphome\r\n";
+  sdp += "c=IN IP4 " + p.local_ip + "\r\n";
+  sdp += "t=0 0\r\n";
+
+  if (p.answer) {
+    // RFC 3264: answer lists only the selected format(s).
+    std::string mline = "m=audio " + std::to_string(p.rtp_port) + " RTP/AVP " +
+                        std::to_string(p.answer_pt);
+    if (p.dtmf_pt >= 0)
+      mline += " " + std::to_string(p.dtmf_pt);
+    sdp += mline + "\r\n";
+    const char *rtpmap = p.answer_rtpmap != nullptr ? p.answer_rtpmap : "PCMU/8000";
+    sdp += "a=rtpmap:" + std::to_string(p.answer_pt) + " " + rtpmap + "\r\n";
+    if (p.dtmf_pt >= 0) {
+      sdp += "a=rtpmap:" + std::to_string(p.dtmf_pt) + " telephone-event/8000\r\n";
+      sdp += "a=fmtp:" + std::to_string(p.dtmf_pt) + " 0-15\r\n";
+    }
+  } else {
+    // Offer: PCMU, PCMA, telephone-event (static preferences for now).
+    const int dtmf = p.dtmf_pt >= 0 ? p.dtmf_pt : 101;
+    sdp += "m=audio " + std::to_string(p.rtp_port) + " RTP/AVP 0 8 " + std::to_string(dtmf) +
+           "\r\n";
+    sdp += "a=rtpmap:0 PCMU/8000\r\n";
+    sdp += "a=rtpmap:8 PCMA/8000\r\n";
+    sdp += "a=rtpmap:" + std::to_string(dtmf) + " telephone-event/8000\r\n";
+    sdp += "a=fmtp:" + std::to_string(dtmf) + " 0-15\r\n";
+  }
+
+  sdp += "a=ptime:20\r\n";
+  sdp += std::string("a=") + (p.direction != nullptr ? p.direction : "sendrecv") + "\r\n";
+  return sdp;
+}
+
+}  // namespace sip_client
+}  // namespace esphome

--- a/components/sip_client/sdp_builder.h
+++ b/components/sip_client/sdp_builder.h
@@ -1,0 +1,26 @@
+#pragma once
+#include <cstdint>
+#include <string>
+
+namespace esphome {
+namespace sip_client {
+
+// Host-testable SDP body builder (no ESPHome runtime dependency).
+struct SdpMediaParams {
+  std::string session_id;
+  std::string local_ip;
+  uint16_t rtp_port{7078};
+  const char *direction{"sendrecv"};  // sendrecv / recvonly / sendonly
+  bool answer{false};
+  // Answer only: selected audio PT + rtpmap label (e.g. "PCMA/8000").
+  int answer_pt{0};
+  const char *answer_rtpmap{"PCMU/8000"};
+  // telephone-event PT. Offer always includes 101 when dtmf_pt < 0 and !answer.
+  // Answer includes DTMF only when dtmf_pt >= 0.
+  int dtmf_pt{-1};
+};
+
+std::string build_sdp_body(const SdpMediaParams &p);
+
+}  // namespace sip_client
+}  // namespace esphome

--- a/components/sip_client/sip_client.cpp
+++ b/components/sip_client/sip_client.cpp
@@ -276,6 +276,11 @@ void SipClient::call(const std::string &number) {
 }
 
 void SipClient::apply_chosen_codec_(int pt, AudioCodecId id) {
+  // Defense in depth: never free the codec object while rtp_ holds a raw ptr.
+  if (this->media_active_) {
+    ESP_LOGW(TAG, "Ignoring codec change while media is active");
+    return;
+  }
   this->chosen_pt_ = pt;
   this->active_codec_ = make_g711_codec((uint8_t) pt, id);
   this->chosen_rtpmap_ = this->active_codec_->desc().rtpmap;
@@ -393,6 +398,13 @@ void SipClient::handle_invite_response_(const SipMessage &m, const std::string &
   }
 
   if (m.status_code >= 200 && m.status_code < 300) {
+    // Retransmitted INVITE 2xx (ACK lost): re-ACK only. Re-running this block
+    // would replace active_codec_ while rtp_ still holds the old raw pointer.
+    if (this->state_ != SIP_INVITING && this->state_ != SIP_RINGING_OUT) {
+      this->send_raw_(this->build_ack_(m));
+      return;
+    }
+
     // Capture remote tag and target, parse SDP, ACK, start media.
     std::string to = m.header("To");
     if (!to.empty()) this->d_remote_ = to;

--- a/components/sip_client/sip_client.cpp
+++ b/components/sip_client/sip_client.cpp
@@ -6,8 +6,10 @@
 #include "esphome/core/hal.h"
 #include "esphome/components/network/util.h"
 #include "esphome/components/audio/audio.h"
-#include "sip_auth.h"
 #include "audio_resampler.h"
+#include "g711_codec.h"
+#include "sdp_builder.h"
+#include "sip_auth.h"
 
 namespace esphome {
 namespace sip_client {
@@ -133,18 +135,20 @@ void SipClient::send_raw_(const std::string &msg) {
   ESP_LOGV(TAG, "TX >>>\n%s", msg.c_str());
 }
 
-// Prefer PCMU, then PCMA. Returns -1 when the offer has no common audio codec.
-static int choose_payload_(const SdpInfo &sdp) {
-  if (sdp.pcmu_pt >= 0) return sdp.pcmu_pt;
-  if (sdp.pcma_pt >= 0) return sdp.pcma_pt;
-  return -1;
-}
+struct ChosenAudio {
+  int pt{-1};
+  AudioCodecId id{AudioCodecId::PCMU};
+  const char *rtpmap{nullptr};
+};
 
-// Answer rtpmap label from static PT only. Dynamic PT ↔ codec name (e.g. 97=PCMA)
-// needs a chosen-codec field — deferred to the Codec abstraction (PR2 / #286).
-static const char *rtpmap_for_static_pt_(int pt) {
-  if (pt == 8) return "PCMA/8000";
-  return "PCMU/8000";  // PT 0 and unknown static fallback
+// Prefer PCMU, then PCMA. Encoding follows the rtpmap name, not the wire PT
+// number — so a dynamic PT (e.g. 97=PCMA) selects A-law correctly.
+static ChosenAudio choose_payload_(const SdpInfo &sdp) {
+  if (sdp.pcmu_pt >= 0)
+    return {sdp.pcmu_pt, AudioCodecId::PCMU, "PCMU/8000"};
+  if (sdp.pcma_pt >= 0)
+    return {sdp.pcma_pt, AudioCodecId::PCMA, "PCMA/8000"};
+  return {};
 }
 
 void SipClient::set_state_(SipState s) {
@@ -271,39 +275,27 @@ void SipClient::call(const std::string &number) {
   ESP_LOGI(TAG, "Calling %s", number.c_str());
 }
 
+void SipClient::apply_chosen_codec_(int pt, AudioCodecId id) {
+  this->chosen_pt_ = pt;
+  this->active_codec_ = make_g711_codec((uint8_t) pt, id);
+  this->chosen_rtpmap_ = this->active_codec_->desc().rtpmap;
+}
+
 std::string SipClient::local_sdp_(bool answer) {
-  std::string id = std::to_string(millis());
-  std::string sdp;
-  sdp += "v=0\r\n";
-  sdp += "o=- " + id + " " + id + " IN IP4 " + this->local_ip_ + "\r\n";
-  sdp += "s=esphome\r\n";
-  sdp += "c=IN IP4 " + this->local_ip_ + "\r\n";
-  sdp += "t=0 0\r\n";
-
+  SdpMediaParams p;
+  p.session_id = std::to_string(millis());
+  p.local_ip = this->local_ip_;
+  p.rtp_port = this->local_rtp_port_;
+  p.direction = this->media_direction_();
+  p.answer = answer;
   if (answer) {
-    // RFC 3264: answer lists only the selected format(s), not the full offer.
-    int audio_pt = this->chosen_pt_ >= 0 ? this->chosen_pt_ : 0;
-    std::string mline = "m=audio " + std::to_string(this->local_rtp_port_) + " RTP/AVP " +
-                        std::to_string(audio_pt);
-    if (this->remote_dtmf_pt_ >= 0)
-      mline += " " + std::to_string(this->remote_dtmf_pt_);
-    sdp += mline + "\r\n";
-    sdp += "a=rtpmap:" + std::to_string(audio_pt) + " " + rtpmap_for_static_pt_(audio_pt) + "\r\n";
-    if (this->remote_dtmf_pt_ >= 0) {
-      sdp += "a=rtpmap:" + std::to_string(this->remote_dtmf_pt_) + " telephone-event/8000\r\n";
-      sdp += "a=fmtp:" + std::to_string(this->remote_dtmf_pt_) + " 0-15\r\n";
-    }
+    p.answer_pt = this->chosen_pt_ >= 0 ? this->chosen_pt_ : 0;
+    p.answer_rtpmap = this->chosen_rtpmap_ != nullptr ? this->chosen_rtpmap_ : "PCMU/8000";
+    p.dtmf_pt = this->remote_dtmf_pt_;
   } else {
-    sdp += "m=audio " + std::to_string(this->local_rtp_port_) + " RTP/AVP 0 8 101\r\n";
-    sdp += "a=rtpmap:0 PCMU/8000\r\n";
-    sdp += "a=rtpmap:8 PCMA/8000\r\n";
-    sdp += "a=rtpmap:101 telephone-event/8000\r\n";
-    sdp += "a=fmtp:101 0-15\r\n";
+    p.dtmf_pt = 101;
   }
-
-  sdp += "a=ptime:20\r\n";
-  sdp += std::string("a=") + this->media_direction_() + "\r\n";
-  return sdp;
+  return build_sdp_body(p);
 }
 
 std::string SipClient::build_invite_() {
@@ -412,9 +404,9 @@ void SipClient::handle_invite_response_(const SipMessage &m, const std::string &
     SdpInfo sdp = parse_sdp(m.body);
     this->remote_rtp_ip_ = sdp.connection_ip.empty() ? this->remote_rtp_ip_ : sdp.connection_ip;
     this->remote_rtp_port_ = sdp.audio_port;
-    this->chosen_pt_ = choose_payload_(sdp);
+    ChosenAudio chosen = choose_payload_(sdp);
     this->remote_dtmf_pt_ = sdp.telephone_event_pt;
-    if (this->chosen_pt_ < 0) {
+    if (chosen.pt < 0) {
       // Intentional: empty / non-G.711 answer SDP used to fall back to PT 0 and
       // leave a silent "connected" call. Reject instead. Dialog is confirmed by
       // ACK, so send BYE so the PBX does not wait for rtp_timeout.
@@ -427,6 +419,7 @@ void SipClient::handle_invite_response_(const SipMessage &m, const std::string &
       this->ended_cb_.call();
       return;
     }
+    this->apply_chosen_codec_(chosen.pt, chosen.id);
 
     this->send_raw_(this->build_ack_(m));
     this->start_media_();
@@ -494,8 +487,8 @@ void SipClient::handle_request_(const SipMessage &m, const std::string &raw) {
     // Negotiate codec before touching dialog state so a 488 does not leave
     // stale Call-ID / RTP endpoint fields for the next call.
     SdpInfo sdp = parse_sdp(m.body);
-    int chosen = choose_payload_(sdp);
-    if (chosen < 0) {
+    ChosenAudio chosen = choose_payload_(sdp);
+    if (chosen.pt < 0) {
       // To-tag for the 488 only. Leave it set — clearing would make a later
       // OPTIONS 200 OK emit a malformed empty ";tag=" via build_response_.
       this->d_local_tag_ = gen_tag();
@@ -519,7 +512,7 @@ void SipClient::handle_request_(const SipMessage &m, const std::string &raw) {
     this->d_cseq_ = std::atoi(m.header("CSeq").c_str());
     this->remote_rtp_ip_ = sdp.connection_ip;
     this->remote_rtp_port_ = sdp.audio_port;
-    this->chosen_pt_ = chosen;
+    this->apply_chosen_codec_(chosen.pt, chosen.id);
     this->remote_dtmf_pt_ = sdp.telephone_event_pt;
 
     this->send_raw_(this->build_response_(m, 100, "Trying", false));
@@ -652,7 +645,11 @@ void SipClient::start_media_() {
     ESP_LOGW(TAG, "No remote RTP endpoint; media not started");
     return;
   }
-  this->rtp_.set_payload_type((uint8_t) this->chosen_pt_);
+  if (this->active_codec_ == nullptr) {
+    ESP_LOGW(TAG, "No negotiated codec; media not started");
+    return;
+  }
+  this->rtp_.set_codec(this->active_codec_.get());
   this->rtp_.set_dtmf_payload_type(this->remote_dtmf_pt_);
   this->rtp_.set_remote(this->remote_rtp_ip_, this->remote_rtp_port_);
 #ifdef USE_SPEAKER
@@ -707,20 +704,22 @@ void SipClient::start_media_() {
   }
 #ifdef USE_MICROPHONE
   if (this->mic_ != nullptr) {
-    ESP_LOGI(TAG, "Media started: remote %s:%u pt=%d dtmf_pt=%d dir=%s (mic %u Hz/%uch/%ubits)%s",
+    ESP_LOGI(TAG, "Media started: remote %s:%u pt=%d (%s) dtmf_pt=%d dir=%s (mic %u Hz/%uch/%ubits)%s",
              this->remote_rtp_ip_.c_str(), this->remote_rtp_port_, this->chosen_pt_,
-             this->remote_dtmf_pt_, this->media_direction_(),
-             static_cast<unsigned>(this->mic_rate_), this->mic_channels_, this->mic_bits_,
-             this->half_duplex_ ? " [half-duplex: listening]" : "");
+             this->chosen_rtpmap_ != nullptr ? this->chosen_rtpmap_ : "?", this->remote_dtmf_pt_,
+             this->media_direction_(), static_cast<unsigned>(this->mic_rate_), this->mic_channels_,
+             this->mic_bits_, this->half_duplex_ ? " [half-duplex: listening]" : "");
   } else {
-    ESP_LOGI(TAG, "Media started: remote %s:%u pt=%d dtmf_pt=%d dir=%s",
+    ESP_LOGI(TAG, "Media started: remote %s:%u pt=%d (%s) dtmf_pt=%d dir=%s",
              this->remote_rtp_ip_.c_str(), this->remote_rtp_port_, this->chosen_pt_,
-             this->remote_dtmf_pt_, this->media_direction_());
+             this->chosen_rtpmap_ != nullptr ? this->chosen_rtpmap_ : "?", this->remote_dtmf_pt_,
+             this->media_direction_());
   }
 #else
-  ESP_LOGI(TAG, "Media started: remote %s:%u pt=%d dtmf_pt=%d dir=%s",
+  ESP_LOGI(TAG, "Media started: remote %s:%u pt=%d (%s) dtmf_pt=%d dir=%s",
            this->remote_rtp_ip_.c_str(), this->remote_rtp_port_, this->chosen_pt_,
-           this->remote_dtmf_pt_, this->media_direction_());
+           this->chosen_rtpmap_ != nullptr ? this->chosen_rtpmap_ : "?", this->remote_dtmf_pt_,
+           this->media_direction_());
 #endif
 }
 

--- a/components/sip_client/sip_client.h
+++ b/components/sip_client/sip_client.h
@@ -12,6 +12,7 @@
 #ifdef USE_SPEAKER
 #include "esphome/components/speaker/speaker.h"
 #endif
+#include "codec.h"
 #include "rtp_session.h"
 #include "sip_message.h"
 
@@ -99,9 +100,10 @@ class SipClient : public Component {
   std::string build_request_in_dialog_(const std::string &method);
   std::string build_response_(const SipMessage &req, int code, const std::string &reason,
                               bool with_sdp);
-  // Offer (answer=false): all supported codecs. Answer (true): chosen_pt_ only
-  // + telephone-event when the remote offered it (RFC 3264 §6.1).
+  // Offer (answer=false): all supported codecs. Answer (true): chosen codec
+  // only + telephone-event when the remote offered it (RFC 3264 §6.1).
   std::string local_sdp_(bool answer = false);
+  void apply_chosen_codec_(int pt, AudioCodecId id);
   std::string contact_uri_();
 
   // registration
@@ -194,7 +196,9 @@ class SipClient : public Component {
   // negotiated media
   std::string remote_rtp_ip_;
   uint16_t remote_rtp_port_{0};
-  int chosen_pt_{-1};       // negotiated audio PT, -1 if none
+  int chosen_pt_{-1};                     // negotiated wire PT, -1 if none
+  const char *chosen_rtpmap_{nullptr};    // SDP label, e.g. "PCMA/8000"
+  std::unique_ptr<Codec> active_codec_;   // encode/decode for the call
   int remote_dtmf_pt_{-1};
 
   RtpSession rtp_;

--- a/tests/native/sip_sdp/README.md
+++ b/tests/native/sip_sdp/README.md
@@ -1,7 +1,6 @@
-# sip_client SDP native tests
+# sip_client SDP / codec native tests
 
-Host-side tests for `parse_sdp()` in `components/sip_client/sip_message.cpp`
-(no ESPHome runtime dependency).
+Host-side tests with no ESPHome runtime dependency.
 
 ## Run
 
@@ -10,6 +9,8 @@ tests/native/sip_sdp/run.sh
 ```
 
 ## Coverage
+
+### `parse_sdp` (`test_parse_sdp.cpp`)
 
 | Test | Intent |
 |------|--------|
@@ -22,5 +23,21 @@ tests/native/sip_sdp/run.sh
 | `non_numeric_fmt_token_skipped` | `*` etc. must not become PT 0 via `atoi` |
 | `rejected_audio_stream_port_zero` | `m=audio 0` still parses |
 | `port_with_number_of_ports_suffix` | `m=audio 12345/2` → port 12345 |
+
+### `build_sdp_body` (`test_sdp_builder.cpp`)
+
+| Test | Intent |
+|------|--------|
+| `offer_lists_both_g711_and_dtmf` | offer m-line `0 8 101` |
+| `answer_single_codec_dynamic_pcma` | answer PT 97 + `PCMA/8000` (not PCMU) |
+| `answer_without_dtmf` | no telephone-event when dtmf_pt < 0 |
+
+### `G711Codec` (`test_g711_codec.cpp`)
+
+| Test | Intent |
+|------|--------|
+| framing constants | pcm/payload/ts split for µ-law and dynamic A-law |
+| roundtrip SNR | encode→decode tone ≥ 25 dB |
+| dynamic PT A-law | PT 97 uses A-law bytes, not µ-law |
 
 CI: `.github/workflows/sip-sdp-tests.yml`

--- a/tests/native/sip_sdp/run.sh
+++ b/tests/native/sip_sdp/run.sh
@@ -3,10 +3,22 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 INC=(-I"$ROOT/components/sip_client")
-SRC=("$ROOT/components/sip_client/sip_message.cpp")
 CXXFLAGS=(-std=c++17 -Wall -Wextra -Werror)
+OUT="${TMPDIR:-/tmp}"
 
-g++ "${CXXFLAGS[@]}" "${INC[@]}" "${SRC[@]}" \
+g++ "${CXXFLAGS[@]}" "${INC[@]}" \
+  "$ROOT/components/sip_client/sip_message.cpp" \
   "$ROOT/tests/native/sip_sdp/test_parse_sdp.cpp" \
-  -o "${TMPDIR:-/tmp}/sip_sdp_test"
-"${TMPDIR:-/tmp}/sip_sdp_test"
+  -o "$OUT/sip_sdp_parse_test"
+"$OUT/sip_sdp_parse_test"
+
+g++ "${CXXFLAGS[@]}" "${INC[@]}" \
+  "$ROOT/components/sip_client/sdp_builder.cpp" \
+  "$ROOT/tests/native/sip_sdp/test_sdp_builder.cpp" \
+  -o "$OUT/sip_sdp_builder_test"
+"$OUT/sip_sdp_builder_test"
+
+g++ "${CXXFLAGS[@]}" "${INC[@]}" \
+  "$ROOT/tests/native/sip_sdp/test_g711_codec.cpp" \
+  -o "$OUT/sip_g711_codec_test"
+"$OUT/sip_g711_codec_test"

--- a/tests/native/sip_sdp/test_g711_codec.cpp
+++ b/tests/native/sip_sdp/test_g711_codec.cpp
@@ -1,0 +1,99 @@
+#include "g711_codec.h"
+
+#include <cmath>
+#include <cstdlib>
+#include <iostream>
+#include <string>
+#include <vector>
+
+using esphome::sip_client::AudioCodecId;
+using esphome::sip_client::G711Codec;
+using esphome::sip_client::make_g711_codec;
+
+namespace {
+
+int g_failures = 0;
+
+void require(bool condition, const char *message) {
+  if (!condition) {
+    std::cerr << "FAIL: " << message << '\n';
+    g_failures++;
+  }
+}
+
+void require_eq(int actual, int expected, const char *message) {
+  if (actual != expected) {
+    std::cerr << "FAIL: " << message << " (got " << actual << ", expected " << expected << ")\n";
+    g_failures++;
+  }
+}
+
+void test_desc_framing_constants() {
+  G711Codec ulaw(0, AudioCodecId::PCMU);
+  require_eq(ulaw.desc().pcm_samples_per_frame, 160, "ulaw pcm samples");
+  require_eq(ulaw.desc().payload_bytes, 160, "ulaw payload");
+  require_eq(ulaw.desc().ts_per_frame, 160, "ulaw ts");
+  require_eq((int) ulaw.desc().pcm_rate, 8000, "ulaw rate");
+
+  // Dynamic PT must not change framing or encoding family.
+  auto alaw = make_g711_codec(97, AudioCodecId::PCMA);
+  require_eq(alaw->desc().pt, 97, "dynamic pt stored");
+  require(std::string(alaw->desc().rtpmap) == "PCMA/8000", "dynamic pcma rtpmap");
+  require_eq(alaw->desc().pcm_samples_per_frame, 160, "alaw pcm samples");
+  require_eq(alaw->desc().payload_bytes, 160, "alaw payload");
+  require_eq(alaw->desc().ts_per_frame, 160, "alaw ts");
+}
+
+void test_roundtrip_snr(AudioCodecId id, const char *label) {
+  G711Codec codec(id == AudioCodecId::PCMA ? 8 : 0, id);
+  const size_t n = 160;
+  std::vector<int16_t> pcm(n);
+  for (size_t i = 0; i < n; i++) {
+    // ~1 kHz tone at moderate amplitude (well inside G.711 range).
+    pcm[i] = (int16_t) (8000.0 * std::sin(2.0 * 3.141592653589793 * 1000.0 * i / 8000.0));
+  }
+  std::vector<uint8_t> encoded(n);
+  std::vector<int16_t> decoded(n);
+  require_eq((int) codec.encode(pcm.data(), n, encoded.data()), (int) n, "encode size");
+  require_eq((int) codec.decode(encoded.data(), n, decoded.data()), (int) n, "decode size");
+
+  double err = 0, signal = 0;
+  for (size_t i = 0; i < n; i++) {
+    double e = (double) pcm[i] - (double) decoded[i];
+    err += e * e;
+    signal += (double) pcm[i] * (double) pcm[i];
+  }
+  double snr = 10.0 * std::log10(signal / (err + 1e-12));
+  // G.711 SNR for a mid-level tone should be comfortably above 20 dB.
+  if (snr < 25.0) {
+    std::cerr << "FAIL: " << label << " SNR too low: " << snr << " dB\n";
+    g_failures++;
+  }
+}
+
+void test_dynamic_pt_uses_alaw_not_ulaw() {
+  // Encode silence-ish sample with both; A-law and µ-law differ for most values.
+  int16_t sample = 1234;
+  G711Codec ulaw(0, AudioCodecId::PCMU);
+  G711Codec alaw_dyn(97, AudioCodecId::PCMA);
+  uint8_t u = 0, a = 0;
+  ulaw.encode(&sample, 1, &u);
+  alaw_dyn.encode(&sample, 1, &a);
+  require(u != a, "dynamic PCMA must not encode as µ-law");
+}
+
+}  // namespace
+
+int main() {
+  test_desc_framing_constants();
+  test_roundtrip_snr(esphome::sip_client::AudioCodecId::PCMU, "PCMU");
+  test_roundtrip_snr(esphome::sip_client::AudioCodecId::PCMA, "PCMA");
+  test_dynamic_pt_uses_alaw_not_ulaw();
+
+  if (g_failures != 0) {
+    std::cerr << g_failures << " failure(s)\n";
+    return 1;
+  }
+  std::cout << "All g711_codec tests passed\n";
+  return 0;
+}

--- a/tests/native/sip_sdp/test_g711_codec.cpp
+++ b/tests/native/sip_sdp/test_g711_codec.cpp
@@ -34,6 +34,8 @@ void test_desc_framing_constants() {
   require_eq(ulaw.desc().payload_bytes, 160, "ulaw payload");
   require_eq(ulaw.desc().ts_per_frame, 160, "ulaw ts");
   require_eq((int) ulaw.desc().pcm_rate, 8000, "ulaw rate");
+  require_eq((int) ulaw.desc().max_pcm_samples_for_payload(160), 160, "ulaw decode cap 1:1");
+  require_eq((int) ulaw.desc().max_pcm_samples_for_payload(80), 80, "ulaw decode cap half");
 
   // Dynamic PT must not change framing or encoding family.
   auto alaw = make_g711_codec(97, AudioCodecId::PCMA);
@@ -42,6 +44,12 @@ void test_desc_framing_constants() {
   require_eq(alaw->desc().pcm_samples_per_frame, 160, "alaw pcm samples");
   require_eq(alaw->desc().payload_bytes, 160, "alaw payload");
   require_eq(alaw->desc().ts_per_frame, 160, "alaw ts");
+
+  // G.722-shaped desc (2:1) — capacity helper must reserve 2n samples.
+  esphome::sip_client::CodecDesc g722_like{};
+  g722_like.pcm_samples_per_frame = 320;
+  g722_like.payload_bytes = 160;
+  require_eq((int) g722_like.max_pcm_samples_for_payload(160), 320, "g722-like decode cap");
 }
 
 void test_roundtrip_snr(AudioCodecId id, const char *label) {

--- a/tests/native/sip_sdp/test_sdp_builder.cpp
+++ b/tests/native/sip_sdp/test_sdp_builder.cpp
@@ -11,13 +11,6 @@ namespace {
 
 int g_failures = 0;
 
-void require(bool condition, const char *message) {
-  if (!condition) {
-    std::cerr << "FAIL: " << message << '\n';
-    g_failures++;
-  }
-}
-
 void require_contains(const std::string &hay, const std::string &needle, const char *message) {
   if (hay.find(needle) == std::string::npos) {
     std::cerr << "FAIL: " << message << " (missing \"" << needle << "\")\n";

--- a/tests/native/sip_sdp/test_sdp_builder.cpp
+++ b/tests/native/sip_sdp/test_sdp_builder.cpp
@@ -1,0 +1,98 @@
+#include "sdp_builder.h"
+
+#include <cstdlib>
+#include <iostream>
+#include <string>
+
+using esphome::sip_client::SdpMediaParams;
+using esphome::sip_client::build_sdp_body;
+
+namespace {
+
+int g_failures = 0;
+
+void require(bool condition, const char *message) {
+  if (!condition) {
+    std::cerr << "FAIL: " << message << '\n';
+    g_failures++;
+  }
+}
+
+void require_contains(const std::string &hay, const std::string &needle, const char *message) {
+  if (hay.find(needle) == std::string::npos) {
+    std::cerr << "FAIL: " << message << " (missing \"" << needle << "\")\n";
+    g_failures++;
+  }
+}
+
+void require_not_contains(const std::string &hay, const std::string &needle, const char *message) {
+  if (hay.find(needle) != std::string::npos) {
+    std::cerr << "FAIL: " << message << " (unexpected \"" << needle << "\")\n";
+    g_failures++;
+  }
+}
+
+void test_offer_lists_both_g711_and_dtmf() {
+  SdpMediaParams p;
+  p.session_id = "1";
+  p.local_ip = "192.168.0.2";
+  p.rtp_port = 7078;
+  p.direction = "sendrecv";
+  p.answer = false;
+  std::string sdp = build_sdp_body(p);
+  require_contains(sdp, "m=audio 7078 RTP/AVP 0 8 101\r\n", "offer m-line");
+  require_contains(sdp, "a=rtpmap:0 PCMU/8000\r\n", "offer pcmu");
+  require_contains(sdp, "a=rtpmap:8 PCMA/8000\r\n", "offer pcma");
+  require_contains(sdp, "a=rtpmap:101 telephone-event/8000\r\n", "offer dtmf");
+  require_contains(sdp, "a=sendrecv\r\n", "offer direction");
+}
+
+void test_answer_single_codec_dynamic_pcma() {
+  // Dynamic PT 97 mapped to PCMA — rtpmap label must say PCMA, not PCMU.
+  SdpMediaParams p;
+  p.session_id = "2";
+  p.local_ip = "10.0.0.1";
+  p.rtp_port = 4000;
+  p.direction = "recvonly";
+  p.answer = true;
+  p.answer_pt = 97;
+  p.answer_rtpmap = "PCMA/8000";
+  p.dtmf_pt = 101;
+  std::string sdp = build_sdp_body(p);
+  require_contains(sdp, "m=audio 4000 RTP/AVP 97 101\r\n", "answer m-line");
+  require_contains(sdp, "a=rtpmap:97 PCMA/8000\r\n", "answer dynamic pcma label");
+  require_not_contains(sdp, "PCMU/8000", "answer must not list PCMU");
+  require_not_contains(sdp, "RTP/AVP 0 8", "answer must not re-offer full list");
+  require_contains(sdp, "a=rtpmap:101 telephone-event/8000\r\n", "answer dtmf");
+  require_contains(sdp, "a=recvonly\r\n", "answer direction");
+}
+
+void test_answer_without_dtmf() {
+  SdpMediaParams p;
+  p.session_id = "3";
+  p.local_ip = "10.0.0.2";
+  p.rtp_port = 5000;
+  p.direction = "sendonly";
+  p.answer = true;
+  p.answer_pt = 0;
+  p.answer_rtpmap = "PCMU/8000";
+  p.dtmf_pt = -1;
+  std::string sdp = build_sdp_body(p);
+  require_contains(sdp, "m=audio 5000 RTP/AVP 0\r\n", "answer no-dtmf m-line");
+  require_not_contains(sdp, "telephone-event", "answer no-dtmf: no event");
+}
+
+}  // namespace
+
+int main() {
+  test_offer_lists_both_g711_and_dtmf();
+  test_answer_single_codec_dynamic_pcma();
+  test_answer_without_dtmf();
+
+  if (g_failures != 0) {
+    std::cerr << g_failures << " failure(s)\n";
+    return 1;
+  }
+  std::cout << "All sdp_builder tests passed\n";
+  return 0;
+}


### PR DESCRIPTION
Split RTP framing into pcm_samples / payload_bytes / ts_per_frame, drive encode/decode through Codec, and track AudioCodecId beside the wire PT so dynamic PCMA (e.g. PT 97) answers and encodes correctly. Extract build_sdp_body for host tests; behavior remains G.711-only (no G.722 yet).

Refs #286