### PR TITLE
fix(sip_client): send silence RTP so the peer's audio can reach us (#…

### DIFF
--- a/components/sip_client/rtp_session.cpp
+++ b/components/sip_client/rtp_session.cpp
@@ -12,6 +12,11 @@ static const char *const TAG = "sip_client.rtp";
 
 static const uint32_t FRAME_MS = 20;
 static const int DTMF_END_PACKETS = 3;
+// How long the sender waits for real audio before it starts filling the stream
+// with silence. Long enough to ride out a microphone buffer boundary (so live
+// speech is never chopped up), short enough that a session with nothing to send
+// starts transmitting almost immediately.
+static const uint32_t SILENCE_GRACE_MS = 60;
 
 // Bind-any sockaddr for the given family. Unlike socket::set_sockaddr_any(),
 // this doesn't depend on ESPHome's global network::enable_ipv6 setting — the
@@ -92,6 +97,10 @@ bool RtpSession::start(uint16_t local_port) {
   this->dtmf_queue_.clear();
   this->dtmf_active_ = false;
   this->last_tx_ms_ = millis();
+  // Treat the session start as "just sent audio" so the grace period applies
+  // from here; a session with no microphone starts emitting silence right after.
+  this->last_audio_tx_ms_ = this->last_tx_ms_;
+  this->silence_pcm_.assign(this->pcm_samples_per_frame_(), 0);
   this->recv_buf_.resize(1500);
   ESP_LOGI(TAG, "RTP started on port %u (pt=%u %s, dtmf_pt=%d)", local_port,
            this->codec_->desc().pt, this->codec_->desc().rtpmap, this->dtmf_pt_);
@@ -188,6 +197,32 @@ void RtpSession::send_audio_packet_() {
       last_encode_mismatch_ms = now;
     }
   }
+  if (written > MAX_AUDIO_PAYLOAD_BYTES) written = MAX_AUDIO_PAYLOAD_BYTES;
+  this->socket_->sendto(packet, 12 + written, 0,
+                        reinterpret_cast<struct sockaddr *>(&this->remote_addr_),
+                        this->remote_addr_len_);
+  this->seq_++;
+  this->timestamp_ += ts_step;
+  this->first_packet_ = false;
+  this->last_audio_tx_ms_ = millis();
+}
+
+// Sends one frame of digital silence, keeping the RTP stream running when there
+// is nothing to transmit. The zero PCM is pushed through the codec rather than
+// writing a constant payload byte: G.722 is stateful ADPCM, so its encoder has
+// to see the samples to stay in step with the far end's decoder (for G.711 this
+// simply yields the usual 0xFF / 0xD5 silence).
+void RtpSession::send_silence_packet_() {
+  if (this->codec_ == nullptr) return;
+  const uint16_t pcm_n = this->pcm_samples_per_frame_();
+  const uint16_t pay_n = this->payload_bytes_();
+  const uint16_t ts_step = this->ts_per_frame_();
+  if (pay_n > MAX_AUDIO_PAYLOAD_BYTES || this->silence_pcm_.size() < pcm_n) return;
+
+  uint8_t packet[12 + MAX_AUDIO_PAYLOAD_BYTES];
+  this->build_rtp_header_(packet, this->first_packet_, this->codec_->desc().pt, this->timestamp_);
+  size_t written = this->codec_->encode(this->silence_pcm_.data(), pcm_n, packet + 12);
+  if (written == 0) return;
   if (written > MAX_AUDIO_PAYLOAD_BYTES) written = MAX_AUDIO_PAYLOAD_BYTES;
   this->socket_->sendto(packet, 12 + written, 0,
                         reinterpret_cast<struct sockaddr *>(&this->remote_addr_),
@@ -321,11 +356,24 @@ void RtpSession::loop() {
       }
       if (has_enough_samples) {
         this->send_audio_packet_();
-        this->last_tx_ms_ += FRAME_MS;
-        packets_sent++;
-      } else {
+      } else if (now - this->last_audio_tx_ms_ < SILENCE_GRACE_MS) {
+        // The buffer only just ran dry — most likely a microphone chunk
+        // boundary mid-speech. Wait for the real samples rather than splicing
+        // silence into live audio.
         break;
+      } else {
+        // Nothing to send for a while: no microphone configured, or half-duplex
+        // while listening. Keep the RTP stream running anyway, which is what a
+        // real SIP phone does and what opens the return path. The outbound
+        // packets hold the NAT/firewall mapping for our RTP port open, and
+        // PBXes that latch onto the source address (Asterisk's rtp_symmetric,
+        // on by default for NAT'd endpoints) only learn where to send audio
+        // once they have seen a packet from us. Without this the peer's audio
+        // never arrives at all.
+        this->send_silence_packet_();
       }
+      this->last_tx_ms_ += FRAME_MS;
+      packets_sent++;
     }
   }
 }

--- a/components/sip_client/rtp_session.h
+++ b/components/sip_client/rtp_session.h
@@ -38,6 +38,7 @@ class RtpSession {
 
  protected:
   void send_audio_packet_();
+  void send_silence_packet_();
   void send_dtmf_packet_();
   void receive_();
   void build_rtp_header_(uint8_t *buf, bool marker, uint8_t pt, uint32_t timestamp);
@@ -67,6 +68,8 @@ class RtpSession {
   std::vector<int16_t> tx_buffer_;
   std::mutex tx_mutex_;
   uint32_t last_tx_ms_{0};
+  uint32_t last_audio_tx_ms_{0};   // last real (non-silence) frame sent
+  std::vector<int16_t> silence_pcm_;  // one frame of zeroed PCM, sized on start()
 
   // DTMF state
   std::string dtmf_queue_;

--- a/tests/native/sip_sdp/run.sh
+++ b/tests/native/sip_sdp/run.sh
@@ -37,3 +37,10 @@ g++ "${CXXFLAGS[@]}" "${INC[@]}" \
   "$ROOT/tests/native/sip_sdp/test_g722_codec.cpp" \
   -o "$OUT/sip_g722_codec_test"
 "$OUT/sip_g722_codec_test"
+
+# Silence frames across every codec (what RtpSession sends to keep the stream up).
+g++ "${CXXFLAGS[@]}" "${INC[@]}" \
+  "$OUT/g722_encode.o" "$OUT/g722_decode.o" \
+  "$ROOT/tests/native/sip_sdp/test_codec_silence.cpp" \
+  -o "$OUT/sip_codec_silence_test"
+"$OUT/sip_codec_silence_test"

--- a/tests/native/sip_sdp/test_codec_silence.cpp
+++ b/tests/native/sip_sdp/test_codec_silence.cpp
@@ -1,0 +1,146 @@
+// Verifies the silence frame that RtpSession sends to keep the RTP stream
+// running when there is nothing to transmit (no microphone configured, or
+// half-duplex while listening). RtpSession builds it by pushing a frame of
+// zeroed PCM through the negotiated codec, so this checks that doing so
+// produces a well-formed, actually-silent payload for every codec.
+
+#include "g711_codec.h"
+#include "g722_codec.h"
+
+#include <cstdlib>
+#include <iostream>
+#include <vector>
+
+using esphome::sip_client::AudioCodecId;
+using esphome::sip_client::Codec;
+using esphome::sip_client::make_g711_codec;
+using esphome::sip_client::make_g722_codec;
+
+namespace {
+
+int g_failures = 0;
+
+void require(bool condition, const char *message) {
+  if (!condition) {
+    std::cerr << "FAIL: " << message << '\n';
+    g_failures++;
+  }
+}
+
+void require_eq(long actual, long expected, const char *message) {
+  if (actual != expected) {
+    std::cerr << "FAIL: " << message << " (got " << actual << ", expected " << expected << ")\n";
+    g_failures++;
+  }
+}
+
+// Mirrors RtpSession::send_silence_packet_(): one frame of zeroed PCM encoded
+// through the codec.
+std::vector<uint8_t> encode_silence_frame(Codec &codec) {
+  const auto &desc = codec.desc();
+  std::vector<int16_t> silence_pcm(desc.pcm_samples_per_frame, 0);
+  std::vector<uint8_t> out(desc.payload_bytes, 0);
+  size_t written = codec.encode(silence_pcm.data(), silence_pcm.size(), out.data());
+  out.resize(written);
+  return out;
+}
+
+// A silence frame must decode back to (near) zero PCM. G.722 is ADPCM, so its
+// decoder converges rather than returning exact zeros; allow a small band.
+void check_decodes_to_silence(Codec &codec, const std::vector<uint8_t> &payload, int tolerance,
+                              const char *label) {
+  const auto &desc = codec.desc();
+  std::vector<int16_t> pcm(desc.max_pcm_samples_for_payload(payload.size()) + 16, 0);
+  size_t samples = codec.decode(payload.data(), payload.size(), pcm.data());
+  require(samples > 0, "silence payload decodes to some PCM");
+
+  int peak = 0;
+  for (size_t i = 0; i < samples; i++) {
+    int magnitude = std::abs(static_cast<int>(pcm[i]));
+    if (magnitude > peak) peak = magnitude;
+  }
+  if (peak > tolerance) {
+    std::cerr << "FAIL: " << label << " decoded peak " << peak << " exceeds tolerance " << tolerance
+              << '\n';
+    g_failures++;
+  }
+}
+
+void test_g711_silence(AudioCodecId id, uint8_t expected_byte, const char *label) {
+  auto codec = make_g711_codec(/*pt=*/id == AudioCodecId::PCMA ? 8 : 0, id);
+  auto payload = encode_silence_frame(*codec);
+
+  require_eq(static_cast<long>(payload.size()), codec->desc().payload_bytes,
+             "G.711 silence frame is a full payload");
+
+  bool all_expected = !payload.empty();
+  for (uint8_t b : payload) {
+    if (b != expected_byte) all_expected = false;
+  }
+  require(all_expected, label);
+
+  check_decodes_to_silence(*codec, payload, /*tolerance=*/16, label);
+}
+
+void test_g722_silence() {
+  auto codec = make_g722_codec(/*pt=*/9);
+  codec->reset();
+
+  // Feed several consecutive silence frames: the encoder is stateful, so a
+  // steady silent input must stay silent rather than drifting.
+  for (int frame = 0; frame < 10; frame++) {
+    auto payload = encode_silence_frame(*codec);
+    require_eq(static_cast<long>(payload.size()), codec->desc().payload_bytes,
+               "G.722 silence frame is a full payload");
+  }
+
+  // Decode a fresh silence frame with a fresh decoder and confirm it is quiet.
+  auto encoder = make_g722_codec(9);
+  auto decoder = make_g722_codec(9);
+  encoder->reset();
+  decoder->reset();
+  int peak = 0;
+  for (int frame = 0; frame < 10; frame++) {
+    auto payload = encode_silence_frame(*encoder);
+    std::vector<int16_t> pcm(encoder->desc().pcm_samples_per_frame + 16, 0);
+    size_t samples = decoder->decode(payload.data(), payload.size(), pcm.data());
+    for (size_t i = 0; i < samples; i++) {
+      int magnitude = std::abs(static_cast<int>(pcm[i]));
+      if (magnitude > peak) peak = magnitude;
+    }
+  }
+  // Well under any audible level; a real signal would be orders of magnitude larger.
+  if (peak > 64) {
+    std::cerr << "FAIL: G.722 silence decoded peak " << peak << " exceeds tolerance 64\n";
+    g_failures++;
+  }
+}
+
+// The silence frame must never overflow the RTP stack buffer RtpSession sizes
+// to MAX_AUDIO_PAYLOAD_BYTES.
+void test_payload_fits_rtp_buffer() {
+  auto pcmu = make_g711_codec(0, AudioCodecId::PCMU);
+  auto pcma = make_g711_codec(8, AudioCodecId::PCMA);
+  auto g722 = make_g722_codec(9);
+  for (Codec *codec : {static_cast<Codec *>(pcmu.get()), static_cast<Codec *>(pcma.get()),
+                       static_cast<Codec *>(g722.get())}) {
+    require(codec->desc().payload_bytes <= esphome::sip_client::MAX_AUDIO_PAYLOAD_BYTES,
+            "codec payload fits MAX_AUDIO_PAYLOAD_BYTES");
+  }
+}
+
+}  // namespace
+
+int main() {
+  test_g711_silence(AudioCodecId::PCMU, 0xFF, "PCMU silence is 0xFF");
+  test_g711_silence(AudioCodecId::PCMA, 0xD5, "PCMA silence is 0xD5");
+  test_g722_silence();
+  test_payload_fits_rtp_buffer();
+
+  if (g_failures != 0) {
+    std::cerr << g_failures << " codec_silence test(s) failed\n";
+    return 1;
+  }
+  std::cout << "All codec_silence tests passed\n";
+  return 0;
+}


### PR DESCRIPTION
…291)

RtpSession::loop() only transmitted when the TX buffer held a full frame and otherwise broke out of the pacing loop, so an endpoint with nothing to send emitted no RTP at all — either with no microphone configured (now possible since #287) or in half-duplex while listening.

That silences the *inbound* direction too, which is what made the bug confusing: with zero outbound packets the NAT/firewall mapping for our RTP port is never created, and a PBX that latches onto the source address (Asterisk's rtp_symmetric, on by default for NAT'd endpoints) never learns where to send audio. The reporter's observation that audio starts flowing only after pressing PTT and sending some is exactly this — the first outbound packet opens the path. Their Asterisk `pjsip show channelstats` showed 0 packets in both directions, matching.

Keep the stream running instead, which is what a real SIP phone does. The silence frame is produced by encoding zeroed PCM through the negotiated codec rather than writing a constant payload byte, so it is correct for every codec: G.722 is stateful ADPCM and its encoder must see the samples to stay in step with the far end's decoder (for G.711 it simply yields the usual 0xFF / 0xD5).

A 60 ms grace period distinguishes the two cases, so a microphone chunk boundary mid-speech still waits for the real samples (previous behavior) instead of splicing silence into live audio.

Adds tests/native/sip_sdp/test_codec_silence.cpp covering the silence frame for all three codecs. Measured: PCMU 0xFF, PCMA 0xD5, and G.722 silence decoding to a peak of 3 (a 1 kHz tone peaks at 8246 for scale).

Verified: full native suite passes, plus an esp-idf build for esp32.