### PR TITLE
[sip_client] Use microphone source to process incoming audio

### DIFF
--- a/components/sip_client/README.md
+++ b/components/sip_client/README.md
@@ -45,9 +45,7 @@ speaker:
 
 sip_client:
   id: my_sip
-  microphone:               # omit for receive-only (speaker / announcements)
-    microphone: mic_id
-    gain_factor: 4
+  microphone: mic_id        # omit for receive-only (speaker / announcements)
   speaker: spk_id           # omit for send-only (mic / uplink)
   server: 192.168.0.10      # PBX address (IP recommended)
   port: 5060                # (default 5060)
@@ -97,7 +95,7 @@ sip_client:
 
 | Option | Required | Default | Description |
 |--------|:--------:|---------|-------------|
-| `microphone` | | - | The microphone settings to use for input. Omit for receive-only devices. |
+| `microphone` | | - | Microphone to capture from. Either an ID (`microphone: mic_id`) or a [microphone source](#microphone-source) block for per-channel/gain control. Omit for receive-only devices. |
 | `speaker` | | - | ID of the speaker component to use. Omit for send-only devices. |
 | `server` | ✓ | - | PBX address (IP recommended) |
 | `port` | | 5060 | SIP server port |
@@ -110,6 +108,26 @@ sip_client:
 | `channel` | | `stereo` | How call audio is pushed to the `speaker`. `stereo` (default) duplicates the mono call audio to L/R for stereo chains (e.g. a `mixer`/`resampler` feeding a stereo DAC like the Voice PE's AIC3204). Use `mono` for a single-channel codec such as the **es8311** (whose i2s speaker is set `channel: mono` and expects 1-channel input). Must match the channel count the assigned speaker expects. To route mono audio to one physical side, leave this `mono` and use the **speaker's** own `channel: left`/`right`. |
 | `half_duplex` | | `false` | Push-to-talk mode for boards that cannot capture and play at the same time (mic and speaker on a single shared I2S bus, e.g. M5Stack Atom Echo). When `true`, the mic and speaker are never active together: the call starts in **listen** (speaker) mode and you switch to **talk** (mic) with the `start_talking` / `stop_talking` actions. Requires both `microphone` and `speaker`. Leave `false` for full-duplex boards with separate input/output I2S buses (e.g. Voice PE). |
 | `codecs` | | `[pcmu, pcma]` | Ordered list of audio codecs to offer and prefer during negotiation. Allowed values: `pcmu`, `pcma`, `g722`. The first codec in the list that the remote party also supports is chosen. G.722 is **opt-in** — omit it from the list (or leave the default) to stay G.711-only. Example for wideband: `codecs: [g722, pcmu, pcma]`. |
+
+### Microphone source
+
+`microphone:` accepts either a plain ID or ESPHome's
+[microphone source](https://esphome.io/components/microphone/) block, which adds
+channel selection and gain on top of the microphone component:
+
+```yaml
+sip_client:
+  microphone:
+    microphone: mic_id
+    channels: 1       # which channel of the mic to capture (default 0)
+    gain_factor: 4    # digital gain, 1-64 (default 1)
+  # ...
+```
+
+Useful for stereo microphone hardware where only one channel carries the voice
+(the Voice PE's dual mics, for example), or for a quiet mic that needs a boost
+before it reaches the codec. Call audio is mono, so exactly one channel is
+captured; `bits_per_sample` is fixed at 16.
 
 ## Actions (Automation)
 

--- a/components/sip_client/README.md
+++ b/components/sip_client/README.md
@@ -45,8 +45,10 @@ speaker:
 
 sip_client:
   id: my_sip
-  microphone: mic_id   # omit for receive-only (speaker / announcements)
-  speaker: spk_id      # omit for send-only (mic / uplink)
+  microphone:               # omit for receive-only (speaker / announcements)
+    microphone: mic_id
+    gain_factor: 4
+  speaker: spk_id           # omit for send-only (mic / uplink)
   server: 192.168.0.10      # PBX address (IP recommended)
   port: 5060                # (default 5060)
   username: "1001"
@@ -95,7 +97,7 @@ sip_client:
 
 | Option | Required | Default | Description |
 |--------|:--------:|---------|-------------|
-| `microphone` | | - | ID of the microphone component to use. Omit for receive-only devices. |
+| `microphone` | | - | The microphone settings to use for input. Omit for receive-only devices. |
 | `speaker` | | - | ID of the speaker component to use. Omit for send-only devices. |
 | `server` | ✓ | - | PBX address (IP recommended) |
 | `port` | | 5060 | SIP server port |

--- a/components/sip_client/__init__.py
+++ b/components/sip_client/__init__.py
@@ -80,7 +80,14 @@ CONFIG_SCHEMA = cv.All(
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(SipClient),
-            cv.Optional(CONF_MICROPHONE): cv.use_id(microphone.Microphone),
+            cv.Optional(
+                CONF_MICROPHONE, default={}
+            ): microphone.microphone_source_schema(
+                min_bits_per_sample=16,
+                max_bits_per_sample=32,
+                min_channels=1,
+                max_channels=2,
+            ),
             cv.Optional(CONF_SPEAKER): cv.use_id(speaker.Speaker),
             cv.Required(CONF_SERVER): cv.string,
             cv.Optional(CONF_PORT, default=5060): cv.port,
@@ -123,8 +130,8 @@ async def to_code(config):
     await cg.register_component(var, config)
 
     if CONF_MICROPHONE in config:
-        mic = await cg.get_variable(config[CONF_MICROPHONE])
-        cg.add(var.set_microphone(mic))
+        mic_source = await microphone.microphone_source_to_code(config[CONF_MICROPHONE])
+        cg.add(var.set_microphone_source(mic_source))
     if CONF_SPEAKER in config:
         spk = await cg.get_variable(config[CONF_SPEAKER])
         cg.add(var.set_speaker(spk))

--- a/components/sip_client/__init__.py
+++ b/components/sip_client/__init__.py
@@ -80,13 +80,15 @@ CONFIG_SCHEMA = cv.All(
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(SipClient),
-            cv.Optional(
-                CONF_MICROPHONE, default={}
-            ): microphone.microphone_source_schema(
+            # No default: the microphone is genuinely optional here (receive-only
+            # devices omit it). A `default={}` would run the source schema even
+            # when the key is absent, and its GenerateID would then fail to find
+            # a microphone to bind to.
+            cv.Optional(CONF_MICROPHONE): microphone.microphone_source_schema(
                 min_bits_per_sample=16,
-                max_bits_per_sample=32,
+                max_bits_per_sample=16,
                 min_channels=1,
-                max_channels=2,
+                max_channels=1,
             ),
             cv.Optional(CONF_SPEAKER): cv.use_id(speaker.Speaker),
             cv.Required(CONF_SERVER): cv.string,

--- a/components/sip_client/sip_client.cpp
+++ b/components/sip_client/sip_client.cpp
@@ -57,8 +57,8 @@ void SipClient::setup() {
   this->recv_buf_.resize(2048);
 
 #ifdef USE_MICROPHONE
-  if (this->mic_ != nullptr) {
-    this->mic_->add_data_callback(
+  if (this->mic_source_ != nullptr) {
+    this->mic_source_->add_data_callback(
         [this](const std::vector<uint8_t> &data) { this->on_mic_data_(data); });
   }
 #endif
@@ -95,7 +95,7 @@ void SipClient::dump_config() {
     ESP_LOGCONFIG(TAG, "  Codecs: [%s]", codecs.c_str());
   }
 #ifdef USE_MICROPHONE
-  ESP_LOGCONFIG(TAG, "  Microphone: %s", this->mic_ ? "yes" : "no");
+  ESP_LOGCONFIG(TAG, "  Microphone: %s", this->mic_source_ ? "yes" : "no");
 #else
   ESP_LOGCONFIG(TAG, "  Microphone: no");
 #endif
@@ -747,7 +747,7 @@ void SipClient::start_media_() {
     this->start_mic_();
   }
 #ifdef USE_MICROPHONE
-  if (this->mic_ != nullptr) {
+  if (this->mic_source_ != nullptr) {
     ESP_LOGI(TAG, "Media started: remote %s:%u pt=%d (%s) dtmf_pt=%d dir=%s (mic %u Hz/%uch/%ubits)%s",
              this->remote_rtp_ip_.c_str(), this->remote_rtp_port_, this->chosen_pt_,
              this->chosen_rtpmap_ != nullptr ? this->chosen_rtpmap_ : "?", this->remote_dtmf_pt_,
@@ -794,18 +794,18 @@ void SipClient::stop_speaker_() {
 
 void SipClient::start_mic_() {
 #ifdef USE_MICROPHONE
-  if (this->mic_ == nullptr) return;
-  auto info = this->mic_->get_audio_stream_info();
+  if (this->mic_source_ == nullptr) return;
+  auto info = this->mic_source_->get_audio_stream_info();
   this->mic_rate_ = info.get_sample_rate();
   this->mic_channels_ = info.get_channels();
   this->mic_bits_ = info.get_bits_per_sample();
-  this->mic_->start();
+  this->mic_source_->start();
 #endif
 }
 
 void SipClient::stop_mic_() {
 #ifdef USE_MICROPHONE
-  if (this->mic_ != nullptr) this->mic_->stop();
+  if (this->mic_source_ != nullptr) this->mic_source_->stop();
 #endif
 }
 

--- a/components/sip_client/sip_client.h
+++ b/components/sip_client/sip_client.h
@@ -7,7 +7,7 @@
 #include "esphome/core/automation.h"
 #include "esphome/components/socket/socket.h"
 #ifdef USE_MICROPHONE
-#include "esphome/components/microphone/microphone.h"
+#include "esphome/components/microphone/microphone_source.h"
 #endif
 #ifdef USE_SPEAKER
 #include "esphome/components/speaker/speaker.h"
@@ -38,7 +38,7 @@ enum SipState {
 class SipClient : public Component {
  public:
 #ifdef USE_MICROPHONE
-  void set_microphone(microphone::Microphone *mic) { this->mic_ = mic; }
+  void set_microphone_source(microphone::MicrophoneSource *mic_source) { this->mic_source_ = mic_source; }
 #endif
 #ifdef USE_SPEAKER
   void set_speaker(speaker::Speaker *spk) { this->speaker_ = spk; }
@@ -126,7 +126,7 @@ class SipClient : public Component {
   // did not take a reference (send-only / receive-only).
   const char *media_direction_() const {
 #if defined(USE_MICROPHONE) && defined(USE_SPEAKER)
-    if (this->mic_ == nullptr)
+    if (this->mic_source_ == nullptr)
       return "recvonly";
     if (this->speaker_ == nullptr)
       return "sendonly";
@@ -145,7 +145,7 @@ class SipClient : public Component {
 
   // config
 #ifdef USE_MICROPHONE
-  microphone::Microphone *mic_{nullptr};
+  microphone::MicrophoneSource *mic_source_{nullptr};
 #endif
 #ifdef USE_SPEAKER
   speaker::Speaker *speaker_{nullptr};


### PR DESCRIPTION
This one makes sip_client use the microphone source component instead of the microphone component. ESPHome switched to that some time ago: https://github.com/esphome/esphome/commit/9f629dcaa245053d313f9db26c778ca33c27541c

Allows to specify the mic in the old format:

```
microphone: mic_id
```

And now additionally set parameters:

```
  microphone:
    microphone: mic_id
    gain_factor: 4
```