### PR TITLE
Fix multiline frame parsing for hexadecimal indices (A-F)

### DIFF
--- a/components/ble_elm327/ble_elm327.cpp
+++ b/components/ble_elm327/ble_elm327.cpp
@@ -288,7 +288,7 @@ void BleElm327Component::process_response(const std::string &response) {
     if (colon_pos != std::string::npos && colon_pos > 0) {
       bool all_digits = true;
       for (size_t i = 0; i < colon_pos; i++) {
-        if (!std::isdigit(static_cast<unsigned char>(line[i]))) {
+        if (!std::isxdigit(static_cast<unsigned char>(line[i]))) {
           all_digits = false;
           break;
         }


### PR DESCRIPTION
Problem:
When reading long UDS responses that span more than 10 frames, ELM327 adapters prefix the output lines with hexadecimal sequence indices (e.g., 0:, 1:, ... 9:, A:, B:, etc.).
The current parser stops processing the multiline payload as soon as it reaches line A:. Because it doesn't recognize letters as valid frame indices, it treats the frame as invalid or complete, leading to severely truncated payloads. For example, a 100+ byte response gets cut off at around 66 bytes.

Root Cause:
In the multiline frame check, the code uses std::isdigit() to validate the characters before the colon (:). std::isdigit() only returns true for decimal digits 0-9, causing the validation to fail when it encounters A, B, C, D, E, or F.

Solution:
Replaced std::isdigit with std::isxdigit. This allows the parser to correctly identify and process all 16 possible hexadecimal indices (0 through F), enabling the component to receive full, uninterrupted multi-frame responses.

Verification:
Tested with a Vgate iCar Pro BLE querying battery cell data (PID 2274CB) on a VW e-Up.

    Before the fix: The payload was constantly truncated exactly after line 9:, losing a third of the data.

    After the fix: The component successfully reads all lines up to F:, assembling and passing the complete 108-byte payload to the sensor formula.