### PR TITLE
test(ble_elm327): add native tests for multiline hex-index parsing

### DIFF
--- a/.github/workflows/ble-elm327-parser-tests.yml
+++ b/.github/workflows/ble-elm327-parser-tests.yml
@@ -1,0 +1,26 @@
+name: BLE ELM327 Parser Native Tests
+
+on:
+  push:
+    branches: [ main, master ]
+    paths:
+      - 'components/ble_elm327/**'
+      - 'tests/native/ble_elm327_parser/**'
+  pull_request:
+    branches: [ main, master ]
+    paths:
+      - 'components/ble_elm327/**'
+      - 'tests/native/ble_elm327_parser/**'
+  workflow_dispatch:
+
+jobs:
+  parser-native-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Build and run parser native tests
+        run: |
+          chmod +x tests/native/ble_elm327_parser/run.sh
+          tests/native/ble_elm327_parser/run.sh

--- a/components/ble_elm327/ble_elm327.cpp
+++ b/components/ble_elm327/ble_elm327.cpp
@@ -1,6 +1,6 @@
 #include "ble_elm327.h"
+#include "response_parser.h"
 #include "esphome/core/log.h"
-#include <cctype>
 
 #ifdef USE_ESP32
 
@@ -10,16 +10,6 @@ namespace ble_elm327 {
 static const char *const TAG = "ble_elm327";
 // Always sent first on connect, in this order, before any YAML init_commands.
 static const char *const BASE_INIT_COMMANDS[] = {"ATZ", "ATE0", "ATL0", "ATS0", "ATH0", "ATSP0"};
-
-static std::string normalize_command(const std::string &cmd) {
-  std::string compact;
-  compact.reserve(cmd.size());
-  for (char c : cmd) {
-    if (std::isspace(static_cast<unsigned char>(c))) continue;  // remove internal spaces too
-    compact.push_back(static_cast<char>(std::tolower(static_cast<unsigned char>(c))));
-  }
-  return compact;
-}
 
 // ── BleElm327Device ─────────────────────────────────────────────────────────
 
@@ -247,87 +237,7 @@ void BleElm327Component::process_response(const std::string &response) {
 
   if (elm_state_ != ElmState::READY) return;
 
-  // Split response by carriage return / newline
-  std::vector<std::string> lines;
-  size_t start = 0;
-  while (start < response.size()) {
-    size_t end = response.find_first_of("\r\n", start);
-    if (end == std::string::npos) {
-      lines.push_back(response.substr(start));
-      break;
-    }
-    if (end > start) {
-      lines.push_back(response.substr(start, end - start));
-    }
-    start = end + 1;
-  }
-
-  std::string multiline_hex;
-  std::string singleline_hex;
-
-  for (const auto &raw_line : lines) {
-    // Trim leading/trailing whitespace
-    std::string line = raw_line;
-    line.erase(line.begin(), std::find_if(line.begin(), line.end(), [](unsigned char ch) {
-      return !std::isspace(ch);
-    }));
-    line.erase(std::find_if(line.rbegin(), line.rend(), [](unsigned char ch) {
-      return !std::isspace(ch);
-    }).base(), line.end());
-
-    if (line.empty()) continue;
-
-    // Check if it's the command echo
-    if (normalize_command(line) == last_sent_command_) {
-      continue;
-    }
-
-    // Check if it's a multiline frame line (e.g. "0: 62 E0 02...")
-    bool is_multiline_frame = false;
-    size_t colon_pos = line.find(':');
-    if (colon_pos != std::string::npos && colon_pos > 0) {
-      bool all_digits = true;
-      for (size_t i = 0; i < colon_pos; i++) {
-        if (!std::isxdigit(static_cast<unsigned char>(line[i]))) {
-          all_digits = false;
-          break;
-        }
-      }
-      if (all_digits) {
-        is_multiline_frame = true;
-      }
-    }
-
-    if (is_multiline_frame) {
-      std::string hex_part = line.substr(colon_pos + 1);
-      for (char c : hex_part) {
-        if (std::isxdigit(static_cast<unsigned char>(c))) {
-          multiline_hex += c;
-        }
-      }
-    } else {
-      std::string hex_part;
-      for (char c : line) {
-        if (std::isxdigit(static_cast<unsigned char>(c))) {
-          hex_part += c;
-        }
-      }
-      if (hex_part.size() > 3) {
-        singleline_hex += hex_part;
-      }
-    }
-  }
-
-  std::string hex = multiline_hex.empty() ? singleline_hex : multiline_hex;
-
-  // Must have at least 4 hex chars (1-byte response code + 1-byte PID/data)
-  if (hex.size() < 4) return;
-
-  // Parse consecutive 2-char groups into bytes
-  std::vector<uint8_t> bytes;
-  for (size_t i = 0; i + 1 < hex.size(); i += 2)
-    bytes.push_back(static_cast<uint8_t>(std::stoul(hex.substr(i, 2), nullptr, 16)));
-
+  std::vector<uint8_t> bytes = parse_response_bytes(response, last_sent_command_);
   if (bytes.empty()) return;
 
   // Broadcast to all devices — each checks its own mode+PID and updates if matched

--- a/components/ble_elm327/response_parser.cpp
+++ b/components/ble_elm327/response_parser.cpp
@@ -1,0 +1,107 @@
+#include "response_parser.h"
+
+#include <algorithm>
+#include <cctype>
+
+namespace esphome {
+namespace ble_elm327 {
+
+std::string normalize_command(const std::string &cmd) {
+  std::string compact;
+  compact.reserve(cmd.size());
+  for (char c : cmd) {
+    if (std::isspace(static_cast<unsigned char>(c))) continue;  // remove internal spaces too
+    compact.push_back(static_cast<char>(std::tolower(static_cast<unsigned char>(c))));
+  }
+  return compact;
+}
+
+std::vector<uint8_t> parse_response_bytes(const std::string &response,
+                                           const std::string &last_sent_command_normalized) {
+  // Split response by carriage return / newline
+  std::vector<std::string> lines;
+  size_t start = 0;
+  while (start < response.size()) {
+    size_t end = response.find_first_of("\r\n", start);
+    if (end == std::string::npos) {
+      lines.push_back(response.substr(start));
+      break;
+    }
+    if (end > start) {
+      lines.push_back(response.substr(start, end - start));
+    }
+    start = end + 1;
+  }
+
+  std::string multiline_hex;
+  std::string singleline_hex;
+
+  for (const auto &raw_line : lines) {
+    // Trim leading/trailing whitespace
+    std::string line = raw_line;
+    line.erase(line.begin(), std::find_if(line.begin(), line.end(), [](unsigned char ch) {
+      return !std::isspace(ch);
+    }));
+    line.erase(std::find_if(line.rbegin(), line.rend(), [](unsigned char ch) {
+      return !std::isspace(ch);
+    }).base(), line.end());
+
+    if (line.empty()) continue;
+
+    // Check if it's the command echo
+    if (normalize_command(line) == last_sent_command_normalized) {
+      continue;
+    }
+
+    // Check if it's a multiline frame line (e.g. "0: 62 E0 02..." or, once a
+    // response spans more than 10 lines, "A: ..." through "F: ...").
+    bool is_multiline_frame = false;
+    size_t colon_pos = line.find(':');
+    if (colon_pos != std::string::npos && colon_pos > 0) {
+      bool all_hex = true;
+      for (size_t i = 0; i < colon_pos; i++) {
+        if (!std::isxdigit(static_cast<unsigned char>(line[i]))) {
+          all_hex = false;
+          break;
+        }
+      }
+      if (all_hex) {
+        is_multiline_frame = true;
+      }
+    }
+
+    if (is_multiline_frame) {
+      std::string hex_part = line.substr(colon_pos + 1);
+      for (char c : hex_part) {
+        if (std::isxdigit(static_cast<unsigned char>(c))) {
+          multiline_hex += c;
+        }
+      }
+    } else {
+      std::string hex_part;
+      for (char c : line) {
+        if (std::isxdigit(static_cast<unsigned char>(c))) {
+          hex_part += c;
+        }
+      }
+      if (hex_part.size() > 3) {
+        singleline_hex += hex_part;
+      }
+    }
+  }
+
+  std::string hex = multiline_hex.empty() ? singleline_hex : multiline_hex;
+
+  // Must have at least 4 hex chars (1-byte response code + 1-byte PID/data)
+  if (hex.size() < 4) return {};
+
+  // Parse consecutive 2-char groups into bytes
+  std::vector<uint8_t> bytes;
+  for (size_t i = 0; i + 1 < hex.size(); i += 2)
+    bytes.push_back(static_cast<uint8_t>(std::stoul(hex.substr(i, 2), nullptr, 16)));
+
+  return bytes;
+}
+
+}  // namespace ble_elm327
+}  // namespace esphome

--- a/components/ble_elm327/response_parser.h
+++ b/components/ble_elm327/response_parser.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+// Framework-independent ELM327 response parsing. Kept free of ESPHome/ESP-IDF
+// headers so it can be compiled and unit-tested natively (see
+// tests/native/ble_elm327_parser).
+
+namespace esphome {
+namespace ble_elm327 {
+
+// Lowercases and strips whitespace (including internal whitespace) from a
+// command, matching the normalization applied before commands are queued
+// for transmission (see BleElm327Component::send_command).
+std::string normalize_command(const std::string &cmd);
+
+// Parses a raw ELM327 notification chunk (everything received between two
+// '>' prompt bytes) into the assembled response bytes.
+//
+// Handles:
+//  - CR/LF-delimited lines, with leading/trailing whitespace trimmed.
+//  - Command-echo suppression: a line matching `last_sent_command_normalized`
+//    (after normalize_command) is skipped.
+//  - Multi-line hex-indexed frames, e.g. "0: 62 E0 02 ..." through
+//    "F: ...". The index before ':' may be any single hex digit (0-9, A-F,
+//    a-f) — ELM327 adapters use hexadecimal sequence indices once a
+//    response spans more than 10 lines.
+//  - Plain single-line hex responses (no index prefix).
+//
+// Returns the assembled bytes, or an empty vector if fewer than 4 hex
+// characters (2 bytes) were found.
+std::vector<uint8_t> parse_response_bytes(const std::string &response,
+                                           const std::string &last_sent_command_normalized);
+
+}  // namespace ble_elm327
+}  // namespace esphome

--- a/tests/native/ble_elm327_parser/README.md
+++ b/tests/native/ble_elm327_parser/README.md
@@ -1,0 +1,44 @@
+# BLE ELM327 native parser tests
+
+`response_parser.cpp`(`parse_response_bytes` / `normalize_command`)를 호스트에서 검증합니다.
+ESPHome/ESP-IDF 프레임워크에 의존하지 않는 순수 파싱 로직만 분리되어 있어, 실제
+BLE 스택 없이도 응답 파싱 회귀를 잡을 수 있습니다.
+
+## 실행
+
+```bash
+tests/native/ble_elm327_parser/run.sh
+```
+
+Windows (g++ 필요):
+
+```powershell
+$root = (Resolve-Path "$PSScriptRoot\..\..\..").Path
+g++ -std=c++17 -Wall -Wextra -Werror `
+  -I"$root/components/ble_elm327" `
+  "$root/components/ble_elm327/response_parser.cpp" `
+  "$root/tests/native/ble_elm327_parser/test_parser.cpp" `
+  -o ble_elm327_parser_test.exe
+.\ble_elm327_parser_test.exe
+```
+
+## 커버 시나리오
+
+| 테스트 | 조건 |
+|--------|------|
+| `multiline_hex_index_regression_uppercase` | #294 회귀: `9:` 다음 `A:` 라인이 잘리지 않고 이어붙는지 |
+| `multiline_hex_index_regression_full_range` | 0~9, A~F 16개 라인 전체가 잘림 없이 조립되는지 (실제 108바이트 응답 재현 시나리오) |
+| `multiline_hex_index_lowercase` | 소문자 인덱스(`a:`, `b:`)도 허용되는지 |
+| `multiline_numeric_indices_only` | 순수 숫자 인덱스만 있는 짧은 응답 |
+| `singleline_response_no_index` | 콜론 인덱스가 없는 단일 라인 응답 |
+| `command_echo_is_skipped` | 에코된 명령 라인이 페이로드에서 제외되는지 |
+| `non_hex_prefixed_colon_line_is_not_multiline` | `OK:` 처럼 hex가 아닌 접두사는 멀티라인으로 오인되지 않는지 |
+| `short_response_is_ignored` | 4자리(2바이트) 미만 hex는 무시되는지 |
+| `odd_length_hex_drops_trailing_nibble` | 홀수 길이 hex의 마지막 니블이 버려지는지 |
+| `blank_lines_and_whitespace_are_ignored` | 빈 줄/공백 줄이 조립을 깨지 않는지 |
+| `empty_response_yields_no_bytes` | 빈 응답 처리 |
+| `normalize_command_*` | 명령어 정규화(공백 제거, 소문자화) |
+
+CI: `.github/workflows/ble-elm327-parser-tests.yml`
+(`components/ble_elm327`, `tests/native/ble_elm327_parser` 변경 시에만 트리거되는 별도
+워크플로 — 관련 없는 PR에는 체크 자체가 나타나지 않음).

--- a/tests/native/ble_elm327_parser/run.sh
+++ b/tests/native/ble_elm327_parser/run.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+INC=(-I"$ROOT/components/ble_elm327")
+SRC=("$ROOT/components/ble_elm327/response_parser.cpp")
+CXXFLAGS=(-std=c++17 -Wall -Wextra -Werror)
+
+g++ "${CXXFLAGS[@]}" "${INC[@]}" "${SRC[@]}" \
+  "$ROOT/tests/native/ble_elm327_parser/test_parser.cpp" \
+  -o "${TMPDIR:-/tmp}/ble_elm327_parser_test"
+"${TMPDIR:-/tmp}/ble_elm327_parser_test"

--- a/tests/native/ble_elm327_parser/test_parser.cpp
+++ b/tests/native/ble_elm327_parser/test_parser.cpp
@@ -1,0 +1,154 @@
+#include "response_parser.h"
+
+#include <cstdio>
+#include <cstdlib>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+using esphome::ble_elm327::normalize_command;
+using esphome::ble_elm327::parse_response_bytes;
+
+namespace {
+
+int g_failures = 0;
+
+void require(bool condition, const char *message) {
+  if (!condition) {
+    std::cerr << "FAIL: " << message << '\n';
+    g_failures++;
+  }
+}
+
+void require_eq(const std::vector<uint8_t> &actual, const std::vector<uint8_t> &expected, const char *message) {
+  if (actual != expected) {
+    std::cerr << "FAIL: " << message << " (size " << actual.size() << " vs " << expected.size() << ")\n";
+    std::cerr << "  actual:  ";
+    for (auto b : actual) std::cerr << std::hex << (int) b << ' ';
+    std::cerr << "\n  expected:";
+    for (auto b : expected) std::cerr << std::hex << (int) b << ' ';
+    std::cerr << std::dec << '\n';
+    g_failures++;
+  }
+}
+
+// The bug fixed by PR #294: ELM327 adapters prefix multiline responses with
+// hexadecimal sequence indices once a response exceeds 10 lines (0-9, then
+// A-F). Validating the index with std::isdigit (decimal only) instead of
+// std::isxdigit truncated any response spanning 11+ lines right after "9:".
+void test_multiline_hex_index_regression_uppercase() {
+  // Two data lines: "9: AA BB" then "A: CC DD" — a naive isdigit check would
+  // reject the "A:" line, so the assembled payload would stop at AABB.
+  std::string response = "9: AA BB\r\nA: CC DD\r\n";
+  auto bytes = parse_response_bytes(response, "");
+  require_eq(bytes, {0xAA, 0xBB, 0xCC, 0xDD},
+             "hex index regression: line 'A:' must not truncate the payload");
+}
+
+void test_multiline_hex_index_regression_full_range() {
+  // Simulates the PR's real-world report: a response spanning all 16
+  // possible sequence indices (0-9, A-F), each carrying 2 bytes.
+  std::ostringstream response;
+  std::vector<uint8_t> expected;
+  for (int i = 0; i < 16; i++) {
+    char index = i < 10 ? static_cast<char>('0' + i) : static_cast<char>('A' + (i - 10));
+    uint8_t b0 = static_cast<uint8_t>(i * 2);
+    uint8_t b1 = static_cast<uint8_t>(i * 2 + 1);
+    char buf[8];
+    std::snprintf(buf, sizeof(buf), "%02X %02X", b0, b1);
+    response << index << ": " << buf << "\r\n";
+    expected.push_back(b0);
+    expected.push_back(b1);
+  }
+  auto bytes = parse_response_bytes(response.str(), "");
+  require_eq(bytes, expected, "hex index regression: full 0-F sequence assembles without truncation");
+}
+
+void test_multiline_hex_index_lowercase() {
+  std::string response = "9: 01 02\r\nb: 03 04\r\n";
+  auto bytes = parse_response_bytes(response, "");
+  require_eq(bytes, {0x01, 0x02, 0x03, 0x04}, "hex index: lowercase index letters (b) are also accepted");
+}
+
+void test_multiline_numeric_indices_only() {
+  std::string response = "0: 62 22 74\r\n1: CB 01 02\r\n";
+  auto bytes = parse_response_bytes(response, "");
+  require_eq(bytes, {0x62, 0x22, 0x74, 0xCB, 0x01, 0x02}, "multiline: plain numeric indices assemble in order");
+}
+
+void test_singleline_response_no_index() {
+  std::string response = "41 0C 1A F8\r\n";
+  auto bytes = parse_response_bytes(response, "");
+  require_eq(bytes, {0x41, 0x0C, 0x1A, 0xF8}, "singleline: no colon-index prefix parses as one frame");
+}
+
+void test_command_echo_is_skipped() {
+  // The adapter echoes the command back before the actual response line.
+  std::string response = "010c\r\n41 0C 1A F8\r\n";
+  auto bytes = parse_response_bytes(response, normalize_command("010C"));
+  require_eq(bytes, {0x41, 0x0C, 0x1A, 0xF8}, "echo: echoed command line is excluded from the payload");
+}
+
+void test_non_hex_prefixed_colon_line_is_not_multiline() {
+  // "OK" contains no hex digits, so this must fall back to the singleline
+  // path (and, since it yields too little hex, produce no frame) rather
+  // than being misidentified as a multiline index line.
+  std::string response = "OK: 41\r\n";
+  auto bytes = parse_response_bytes(response, "");
+  require(bytes.empty(), "non-hex prefix: 'OK:' must not be treated as a multiline index");
+}
+
+void test_short_response_is_ignored() {
+  // Fewer than 4 hex characters (2 bytes) is not a usable frame.
+  std::string response = "41\r\n";
+  auto bytes = parse_response_bytes(response, "");
+  require(bytes.empty(), "short response: single byte of hex is ignored");
+}
+
+void test_odd_length_hex_drops_trailing_nibble() {
+  std::string response = "41 0C 1\r\n";
+  auto bytes = parse_response_bytes(response, "");
+  require_eq(bytes, {0x41, 0x0C}, "odd length: trailing incomplete nibble is dropped, not rounded");
+}
+
+void test_blank_lines_and_whitespace_are_ignored() {
+  std::string response = "\r\n   \r\n0: 41 0C\r\n\r\n1: 1A F8\r\n";
+  auto bytes = parse_response_bytes(response, "");
+  require_eq(bytes, {0x41, 0x0C, 0x1A, 0xF8}, "whitespace: blank/whitespace-only lines don't break assembly");
+}
+
+void test_empty_response_yields_no_bytes() {
+  auto bytes = parse_response_bytes("", "");
+  require(bytes.empty(), "empty response: yields no bytes");
+}
+
+void test_normalize_command_strips_whitespace_and_case() {
+  require(normalize_command(" AT Z \r") == "atz", "normalize_command: trims and lowercases");
+  require(normalize_command("010C") == "010c", "normalize_command: lowercases hex command");
+}
+
+}  // namespace
+
+int main() {
+  test_multiline_hex_index_regression_uppercase();
+  test_multiline_hex_index_regression_full_range();
+  test_multiline_hex_index_lowercase();
+  test_multiline_numeric_indices_only();
+  test_singleline_response_no_index();
+  test_command_echo_is_skipped();
+  test_non_hex_prefixed_colon_line_is_not_multiline();
+  test_short_response_is_ignored();
+  test_odd_length_hex_drops_trailing_nibble();
+  test_blank_lines_and_whitespace_are_ignored();
+  test_empty_response_yields_no_bytes();
+  test_normalize_command_strips_whitespace_and_case();
+
+  if (g_failures > 0) {
+    std::cerr << g_failures << " ble_elm327 parser test(s) failed\n";
+    return EXIT_FAILURE;
+  }
+
+  std::cout << "All ble_elm327 parser tests passed.\n";
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
## Summary
- `14d47fd` already fixed the `isdigit`→`isxdigit` bug from #294 directly on master, but nothing in CI validated it — a response spanning more than 10 lines (hex indices `A:`–`F:`) could regress silently again.
- Extracted the framework-independent parsing logic (`process_response`'s line-splitting/hex-assembly, plus `normalize_command`) out of `ble_elm327.cpp` into `response_parser.h`/`.cpp`, since the original code is entangled with ESP32 BLE headers and can't be compiled natively as-is. No behavior change — same logic, just relocated.
- Added `tests/native/ble_elm327_parser/` following the existing `tests/native/uartex_parser` / `tests/native/sip_sdp` pattern, with 12 cases including a direct regression test for the `9:`→`A:` boundary and a full 0–F 16-line assembly test.
- Added `.github/workflows/ble-elm327-parser-tests.yml`, path-scoped to `components/ble_elm327/**` and `tests/native/ble_elm327_parser/**` (same shape as `uartex-parser-tests.yml`), so this check only appears on PRs that touch this component.

## Test plan
- [ ] CI: `BLE ELM327 Parser Native Tests` workflow passes on this PR
- [x] Manually traced each test case against `response_parser.cpp` logic (no local C++ toolchain available to compile/run directly)