### PR TITLE
feat(ws_bridge): expose http_request OTA as an HA update entity

### DIFF
--- a/components/ws_bridge/README.md
+++ b/components/ws_bridge/README.md
@@ -99,6 +99,19 @@ button:
   - platform: ws_bridge
     unique_id: restart1
     name: "Restart"
+
+# Firmware update entity in HA — wraps ESPHome's http_request update.
+# See "Remote OTA updates" below.
+http_request:
+ota:
+  - platform: http_request
+update:
+  - platform: http_request
+    id: ota_update
+    source: https://your-firmware-host/manifest.json
+  - platform: ws_bridge
+    unique_id: firmware
+    update_id: ota_update
 ```
 
 ### `ws_bridge` (hub) options
@@ -118,17 +131,20 @@ button:
 | `reannounce_interval` | | `60s` | How often to resend `ws_bridge/connect` + all entity/state declarations while nominally connected. Guards against the HA-side integration losing track of this gateway (e.g. its config entry reloaded) while the raw connection and ping/pong stay healthy — that scenario is otherwise invisible, since HA answers pings regardless of our integration's state. If a re-announce goes unanswered, forces a full reconnect rather than repeating the same no-op |
 | `trackers` | | - | List of GPS `device_tracker` entities — see [GPS device trackers](#gps-device-trackers) below |
 
-### Platform options (all of `sensor`/`binary_sensor`/`text_sensor`/`switch`/`number`/`select`/`button`)
+### Platform options (all of `sensor`/`binary_sensor`/`text_sensor`/`switch`/`number`/`select`/`button`/`update`)
 
 | Option | Required | Description |
 |--------|:--------:|-------------|
 | `unique_id` | ✓ | Identifier for this entity, unique within the gateway |
 | `ws_device_id` | | Groups this entity under a sub-device in HA (e.g. multiple sensors on one physical board) |
 | `ws_device_name` | | Display name for that sub-device |
+| `update_id` | ✓ (`update` only) | ID of the ESPHome `update:` entity to wrap — typically `platform: http_request` |
 
 Plus each platform's normal ESPHome options (`name`, `device_class`, `icon`,
 `entity_category`, `unit_of_measurement`/`state_class` for `sensor`,
-`min_value`/`max_value`/`step` for `number`, `options` for `select`).
+`min_value`/`max_value`/`step` for `number`, `options` for `select`). The
+`update` platform takes its name/icon/`entity_category` from the wrapped
+`http_request` update entity.
 
 ## Remote OTA updates (no VPN, no MQTT)
 
@@ -137,7 +153,41 @@ protocol, not built for streaming a multi-hundred-KB file. Firmware updates
 work over the same outbound-only connection anyway, through ESPHome's
 `http_request` OTA/update platforms: the device *pulls* the firmware over a
 plain outbound HTTPS request, so no inbound port, VPN, or MQTT broker is
-needed.
+needed. `update: platform: ws_bridge` then exposes that on-device updater to
+Home Assistant as a real `update` entity (Install button, current vs.
+available version), which native `http_request` update cannot do on its own
+when the device is not using ESPHome's native API. This requires a
+`hass-ws-bridge` version that includes the `update` platform.
+
+The [ESPHome OTA Publisher](https://github.com/eigger/hassio-apps/tree/master/esphome_ota)
+add-on is the intended firmware host: it publishes `firmware.ota.bin` + a
+manifest under HA's `/local/` (reachable over LAN and a remote tunnel). Use
+its generated `ota_server/update.yaml` package, then wrap that update entity:
+
+```yaml
+substitutions:
+  ota_device: livingroom          # must match the published node name
+
+packages:
+  ota: !include ota_server/update.yaml
+
+esphome:
+  project:
+    name: "you.something"
+    version: "1.0.0"              # bump this to offer an update
+
+update:
+  - platform: ws_bridge
+    unique_id: firmware
+    update_id: ota_update         # id from ota_server/update.yaml
+
+# Auto-rolls back to the previous firmware if the new one fails to come up
+# cleanly. Strongly recommended for any device you can't walk up to.
+safe_mode:
+```
+
+Without the add-on, the same pieces work against any host that serves an
+ESP Web Tools `manifest.json`:
 
 ```yaml
 http_request:
@@ -148,30 +198,33 @@ ota:
 
 update:
   - platform: http_request
-    id: my_update
+    id: ota_update
     source: https://your-firmware-host/manifest.json
     update_interval: 6h   # periodically checks for a new version (default 6h)
+  - platform: ws_bridge
+    unique_id: firmware
+    update_id: ota_update
 
-# Auto-rolls back to the previous firmware if the new one fails to come up
-# cleanly. Strongly recommended for any device you can't walk up to.
 safe_mode:
 ```
 
 - `update: platform: http_request` polls `source` (a `manifest.json` in the
   [ESP Web Tools](https://esphome.io/) format below), compares the reported
   `version` against the running firmware, and only flashes when they differ
-  — it won't re-flash the same version on every check.
-- It shows up in Home Assistant as an `update` entity (current vs. available
-  version); install manually from the card, or automate it (e.g. from a
-  `ws_bridge` button's `on_press`, or on a schedule) with the
-  `update.perform` action.
+  — it won't re-flash the same version on every check. **Without an
+  `esphome.project` `version`** the device reports the ESPHome release
+  string, so an update only appears when you upgrade ESPHome itself.
+- `update: platform: ws_bridge` is what Home Assistant actually sees. Install
+  from the update card, or trigger a check with `homeassistant.update_entity`.
+  On-device automations still use the wrapped entity (`update.perform:
+  ota_update`, `on_update_available`).
 - **`safe_mode:` matters more than the happy path here** — without it, a
   bad flash on a device you can't physically reach is unrecoverable. It's
   wired to ESP-IDF's app rollback, so a firmware that fails to come up
   cleanly reverts automatically.
 
 `manifest.json` format (ESP Web Tools spec, the same one ESPHome's own
-build/dashboard tooling produces):
+build/dashboard tooling and the OTA Publisher add-on produce):
 ```json
 {
   "name": "My Device",
@@ -275,10 +328,11 @@ for the full set of declarable platforms and their fields.
 
 - **Read-only platforms** (`sensor`, `binary_sensor`, `text_sensor`) push
   their state to Home Assistant automatically whenever it changes.
-- **Controllable platforms** (`switch`, `number`, `select`, `button`) receive
-  commands from Home Assistant and update their own state optimistically
-  (`publish_state`/`this->state`) — hook `on_turn_on`/`lambda:`/etc. in your
-  own YAML if you need to drive real hardware from the state.
+- **Controllable platforms** (`switch`, `number`, `select`, `button`, `update`)
+  receive commands from Home Assistant and update their own state
+  optimistically (`publish_state`/`this->state`) — hook `on_turn_on`/`lambda:`/etc.
+  in your own YAML if you need to drive real hardware from the state. `update`
+  forwards `install`/`check` to the wrapped `http_request` update entity.
 - On every (re)connect, all declared entities and their current state are
   re-sent, per the protocol's reconnection guidance.
 - While connected, an application-level `ping`/`pong` (HA's standard

--- a/components/ws_bridge/README.md
+++ b/components/ws_bridge/README.md
@@ -10,10 +10,11 @@ Assistant securely from outside your LAN (e.g. Nabu Casa remote UI, or your
 own reverse proxy with a valid certificate), it can also remove the need for
 a VPN just to get a remote device's data into Home Assistant.
 
-> Requires the `ws_bridge` custom component installed on the Home Assistant
+> Requires the `ws_bridge` custom component **1.2.0+** on the Home Assistant
 > side: https://github.com/eigger/hass-ws-bridge (see its
 > [PROTOCOL.md](https://github.com/eigger/hass-ws-bridge/blob/main/docs/PROTOCOL.md)
-> for the full wire protocol).
+> for the full wire protocol). The `update` platform needs **ESPHome 2025.7+**
+> (`UpdateEntity::update_info` / `state` as public refs).
 
 ## Installation
 
@@ -111,6 +112,7 @@ update:
     source: https://your-firmware-host/manifest.json
   - platform: ws_bridge
     unique_id: firmware
+    name: "Firmware"
     update_id: ota_update
 ```
 
@@ -139,12 +141,14 @@ update:
 | `ws_device_id` | | Groups this entity under a sub-device in HA (e.g. multiple sensors on one physical board) |
 | `ws_device_name` | | Display name for that sub-device |
 | `update_id` | ✓ (`update` only) | ID of the ESPHome `update:` entity to wrap — typically `platform: http_request` |
+| `name` | (`update`) | HA-facing name. If omitted, uses the wrapped entity's name when that entity has its own `name:`; otherwise the `unique_id` |
 
 Plus each platform's normal ESPHome options (`name`, `device_class`, `icon`,
 `entity_category`, `unit_of_measurement`/`state_class` for `sensor`,
-`min_value`/`max_value`/`step` for `number`, `options` for `select`). The
-`update` platform takes its name/icon/`entity_category` from the wrapped
-`http_request` update entity.
+`min_value`/`max_value`/`step` for `number`, `options` for `select`). An
+id-only `http_request` update is `internal` and named after its id — set
+`name:` on the `ws_bridge` wrapper so Home Assistant does not show
+`"ota_update"`.
 
 ## Remote OTA updates (no VPN, no MQTT)
 
@@ -156,8 +160,8 @@ plain outbound HTTPS request, so no inbound port, VPN, or MQTT broker is
 needed. `update: platform: ws_bridge` then exposes that on-device updater to
 Home Assistant as a real `update` entity (Install button, current vs.
 available version), which native `http_request` update cannot do on its own
-when the device is not using ESPHome's native API. This requires a
-`hass-ws-bridge` version that includes the `update` platform.
+when the device is not using ESPHome's native API. This requires
+`hass-ws-bridge` **1.2.0+** (the `update` platform) and **ESPHome 2025.7+**.
 
 The [ESPHome OTA Publisher](https://github.com/eigger/hassio-apps/tree/master/esphome_ota)
 add-on is the intended firmware host: it publishes `firmware.ota.bin` + a
@@ -179,6 +183,7 @@ esphome:
 update:
   - platform: ws_bridge
     unique_id: firmware
+    name: "Firmware"
     update_id: ota_update         # id from ota_server/update.yaml
 
 # Auto-rolls back to the previous firmware if the new one fails to come up
@@ -203,6 +208,7 @@ update:
     update_interval: 6h   # periodically checks for a new version (default 6h)
   - platform: ws_bridge
     unique_id: firmware
+    name: "Firmware"
     update_id: ota_update
 
 safe_mode:

--- a/components/ws_bridge/__init__.py
+++ b/components/ws_bridge/__init__.py
@@ -129,7 +129,7 @@ CONFIG_SCHEMA = cv.All(
 )
 
 # Shared schema every ws_bridge platform (sensor/binary_sensor/switch/number/
-# select/button) must extend, mirroring uartex's UARTEX_DEVICE_SCHEMA pattern.
+# select/button/update) must extend, mirroring uartex's UARTEX_DEVICE_SCHEMA pattern.
 WS_BRIDGE_DEVICE_SCHEMA = cv.Schema(
     {
         cv.GenerateID(CONF_WS_BRIDGE_ID): cv.use_id(WsBridgeComponent),

--- a/components/ws_bridge/const.py
+++ b/components/ws_bridge/const.py
@@ -18,6 +18,7 @@ CONF_ON_DECLARE = "on_declare"
 
 CONF_TRACKERS = "trackers"
 CONF_GPS_ACCURACY = "gps_accuracy"
+CONF_UPDATE_ID = "update_id"
 
 CONF_PING_INTERVAL = "ping_interval"
 CONF_PONG_TIMEOUT = "pong_timeout"

--- a/components/ws_bridge/update/__init__.py
+++ b/components/ws_bridge/update/__init__.py
@@ -1,0 +1,33 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import update, ws_bridge
+from esphome.const import CONF_ID
+
+from .. import ws_bridge_ns
+from ..const import CONF_UPDATE_ID
+
+DEPENDENCIES = ["ws_bridge"]
+
+# Wraps an existing ESPHome UpdateEntity (typically `update: platform: http_request`
+# from the esphome_ota add-on) and exposes it to Home Assistant over ws_bridge.
+# The http_request platform must be declared separately so its C++ is compiled;
+# this platform only bridges state/commands.
+WsBridgeUpdate = ws_bridge_ns.class_("WsBridgeUpdate", cg.Component, ws_bridge.WsBridgeDevice)
+
+CONFIG_SCHEMA = (
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(WsBridgeUpdate),
+            cv.Required(CONF_UPDATE_ID): cv.use_id(update.UpdateEntity),
+        }
+    )
+    .extend(ws_bridge.WS_BRIDGE_DEVICE_SCHEMA)
+    .extend(cv.COMPONENT_SCHEMA)
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await ws_bridge.register_ws_bridge_device(var, config)
+    cg.add(var.set_update(await cg.get_variable(config[CONF_UPDATE_ID])))

--- a/components/ws_bridge/update/__init__.py
+++ b/components/ws_bridge/update/__init__.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import update, ws_bridge
-from esphome.const import CONF_ID
+from esphome.const import CONF_ID, CONF_NAME
 
 from .. import ws_bridge_ns
 from ..const import CONF_UPDATE_ID
@@ -19,6 +19,9 @@ CONFIG_SCHEMA = (
         {
             cv.GenerateID(): cv.declare_id(WsBridgeUpdate),
             cv.Required(CONF_UPDATE_ID): cv.use_id(update.UpdateEntity),
+            # HA-facing name. Do not rely on the wrapped http_request entity —
+            # an id-only update gets name=id and internal: true.
+            cv.Optional(CONF_NAME): cv.string_strict,
         }
     )
     .extend(ws_bridge.WS_BRIDGE_DEVICE_SCHEMA)
@@ -31,3 +34,5 @@ async def to_code(config):
     await cg.register_component(var, config)
     await ws_bridge.register_ws_bridge_device(var, config)
     cg.add(var.set_update(await cg.get_variable(config[CONF_UPDATE_ID])))
+    if CONF_NAME in config:
+        cg.add(var.set_name(config[CONF_NAME]))

--- a/components/ws_bridge/update/ws_bridge_update.cpp
+++ b/components/ws_bridge/update/ws_bridge_update.cpp
@@ -1,5 +1,4 @@
 #include "ws_bridge_update.h"
-#include <array>
 #include "esphome/core/log.h"
 #include "../ws_bridge.h"
 #include "../ws_bridge_entity_json.h"
@@ -13,9 +12,20 @@ void WsBridgeUpdate::setup() {
   this->update_->add_on_state_callback([this]() { this->send_state_(); });
 }
 
+std::string WsBridgeUpdate::ha_name_() const {
+  if (!this->name_.empty())
+    return this->name_;
+  // http_request update with only `id:` gets name=id and internal: true —
+  // that id (e.g. "ota_update") must not become the HA entity name.
+  if (this->update_->has_own_name())
+    return this->update_->get_name().str();
+  return this->unique_id_;
+}
+
 void WsBridgeUpdate::dump_config() {
-  ESP_LOGCONFIG(TAG, "WS Bridge Update");
+  ESP_LOGCONFIG(TAG, "WS Bridge Update '%s'", this->ha_name_().c_str());
   ESP_LOGCONFIG(TAG, "  Unique ID: %s", this->unique_id_.c_str());
+  ESP_LOGCONFIG(TAG, "  Wrapped: '%s'", this->update_->get_name().str().c_str());
 }
 
 void WsBridgeUpdate::ws_bridge_handle_command(const WsCommand &command) {
@@ -49,12 +59,10 @@ void WsBridgeUpdate::send_state_() {
 
 void WsBridgeUpdate::ws_bridge_declare() {
   this->parent_->send_entity_declare(
-      this->unique_id_, "update", this->update_->get_name().str(), this->device_id_, this->device_name_,
+      this->unique_id_, "update", this->ha_name_(), this->device_id_, this->device_name_,
       [this](JsonObject root) {
         add_common_entity_fields(root, *this->update_);
-        std::array<char, MAX_DEVICE_CLASS_LENGTH> dc_buf;
-        const char *dc = this->update_->get_device_class_to(dc_buf);
-        if (dc == nullptr || dc[0] == '\0')
+        if (root["device_class"].isNull())
           root["device_class"] = "firmware";
       });
   if (this->update_->has_state())

--- a/components/ws_bridge/update/ws_bridge_update.cpp
+++ b/components/ws_bridge/update/ws_bridge_update.cpp
@@ -1,0 +1,65 @@
+#include "ws_bridge_update.h"
+#include <array>
+#include "esphome/core/log.h"
+#include "../ws_bridge.h"
+#include "../ws_bridge_entity_json.h"
+
+namespace esphome {
+namespace ws_bridge {
+
+static const char *const TAG = "ws_bridge.update";
+
+void WsBridgeUpdate::setup() {
+  this->update_->add_on_state_callback([this]() { this->send_state_(); });
+}
+
+void WsBridgeUpdate::dump_config() {
+  ESP_LOGCONFIG(TAG, "WS Bridge Update");
+  ESP_LOGCONFIG(TAG, "  Unique ID: %s", this->unique_id_.c_str());
+}
+
+void WsBridgeUpdate::ws_bridge_handle_command(const WsCommand &command) {
+  if (command.action == "install") {
+    this->update_->perform();
+  } else if (command.action == "check") {
+    this->update_->check();
+  }
+}
+
+void WsBridgeUpdate::fill_state_(JsonObject value) {
+  const auto &info = this->update_->update_info;
+  if (!info.current_version.empty())
+    value["installed_version"] = info.current_version;
+  if (!info.latest_version.empty())
+    value["latest_version"] = info.latest_version;
+  value["in_progress"] = this->update_->state == update::UPDATE_STATE_INSTALLING;
+  if (info.has_progress)
+    value["progress"] = static_cast<int>(info.progress);
+  if (!info.title.empty())
+    value["title"] = info.title;
+  if (!info.summary.empty())
+    value["summary"] = info.summary;
+  if (!info.release_url.empty())
+    value["release_url"] = info.release_url;
+}
+
+void WsBridgeUpdate::send_state_() {
+  this->parent_->send_state_object(this->unique_id_, [this](JsonObject value) { this->fill_state_(value); });
+}
+
+void WsBridgeUpdate::ws_bridge_declare() {
+  this->parent_->send_entity_declare(
+      this->unique_id_, "update", this->update_->get_name().str(), this->device_id_, this->device_name_,
+      [this](JsonObject root) {
+        add_common_entity_fields(root, *this->update_);
+        std::array<char, MAX_DEVICE_CLASS_LENGTH> dc_buf;
+        const char *dc = this->update_->get_device_class_to(dc_buf);
+        if (dc == nullptr || dc[0] == '\0')
+          root["device_class"] = "firmware";
+      });
+  if (this->update_->has_state())
+    this->send_state_();
+}
+
+}  // namespace ws_bridge
+}  // namespace esphome

--- a/components/ws_bridge/update/ws_bridge_update.h
+++ b/components/ws_bridge/update/ws_bridge_update.h
@@ -1,0 +1,29 @@
+#pragma once
+#include "esphome/components/json/json_util.h"
+#include "esphome/components/update/update_entity.h"
+#include "esphome/core/component.h"
+#include "../ws_bridge_device.h"
+
+namespace esphome {
+namespace ws_bridge {
+
+// Bridges an existing ESPHome UpdateEntity (http_request OTA) to Home Assistant
+// as an `update` entity over the ws_bridge protocol. Does not perform the
+// download/flash itself — that stays with the wrapped http_request update.
+class WsBridgeUpdate : public Component, public WsBridgeDevice {
+ public:
+  void set_update(update::UpdateEntity *update) { this->update_ = update; }
+  void setup() override;
+  void dump_config() override;
+  void ws_bridge_declare() override;
+  void ws_bridge_handle_command(const WsCommand &command) override;
+
+ protected:
+  void send_state_();
+  void fill_state_(JsonObject value);
+
+  update::UpdateEntity *update_{nullptr};
+};
+
+}  // namespace ws_bridge
+}  // namespace esphome

--- a/components/ws_bridge/update/ws_bridge_update.h
+++ b/components/ws_bridge/update/ws_bridge_update.h
@@ -13,6 +13,7 @@ namespace ws_bridge {
 class WsBridgeUpdate : public Component, public WsBridgeDevice {
  public:
   void set_update(update::UpdateEntity *update) { this->update_ = update; }
+  void set_name(const std::string &name) { this->name_ = name; }
   void setup() override;
   void dump_config() override;
   void ws_bridge_declare() override;
@@ -21,8 +22,10 @@ class WsBridgeUpdate : public Component, public WsBridgeDevice {
  protected:
   void send_state_();
   void fill_state_(JsonObject value);
+  std::string ha_name_() const;
 
   update::UpdateEntity *update_{nullptr};
+  std::string name_;
 };
 
 }  // namespace ws_bridge

--- a/components/ws_bridge/ws_bridge_device.h
+++ b/components/ws_bridge/ws_bridge_device.h
@@ -8,7 +8,7 @@ namespace ws_bridge {
 class WsBridgeComponent;
 
 // Shared base for every ws_bridge platform entity (sensor/binary_sensor/switch/
-// number/select/button). Holds the protocol-facing identity fields and gives
+// number/select/button/update). Holds the protocol-facing identity fields and gives
 // the hub a uniform way to ask any registered entity to (re)send its
 // ws_bridge/entity declaration (used on first connect and on every reconnect).
 class WsBridgeDevice {

--- a/components/ws_bridge/ws_protocol.h
+++ b/components/ws_bridge/ws_protocol.h
@@ -8,10 +8,10 @@ namespace esphome {
 namespace ws_bridge {
 
 // A command pushed by Home Assistant to a controllable entity
-// (switch/number/select/button), per PROTOCOL.md §4.
+// (switch/number/select/button/update), per PROTOCOL.md §4.
 struct WsCommand {
   std::string unique_id;
-  std::string action;  // "turn_on" | "turn_off" | "set_value" | "select_option" | "press"
+  std::string action;  // "turn_on" | "turn_off" | "set_value" | "select_option" | "press" | "install" | "check"
   bool has_value{false};
   float value_float{0};
   std::string value_string;
@@ -54,7 +54,8 @@ std::string build_state_bool(uint32_t id, const std::string &unique_id, bool val
 std::string build_state_string(uint32_t id, const std::string &unique_id, const std::string &value);
 
 // State whose `value` is a JSON object rather than a scalar — for platforms
-// that need several fields at once (device_tracker's latitude+longitude).
+// that need several fields at once (device_tracker's latitude+longitude,
+// update's installed/latest version).
 // `value_fn` is called with the (empty) value object to fill in.
 std::string build_state_object(uint32_t id, const std::string &unique_id,
                                const std::function<void(JsonObject)> &value_fn);

--- a/tests/components/ws_bridge/test.esp32-idf.yaml
+++ b/tests/components/ws_bridge/test.esp32-idf.yaml
@@ -106,6 +106,7 @@ update:
     source: https://example.com/manifest.json
   - platform: ws_bridge
     unique_id: firmware
+    name: "Firmware"
     update_id: my_update
 
 safe_mode:

--- a/tests/components/ws_bridge/test.esp32-idf.yaml
+++ b/tests/components/ws_bridge/test.esp32-idf.yaml
@@ -91,8 +91,9 @@ button:
     name: "Restart"
 
 # Remote OTA over the outbound-only ws_bridge connection: http_request pulls
-# the firmware (no inbound port needed), update: checks the manifest
-# periodically, safe_mode: auto-rolls-back a bad flash.
+# the firmware (no inbound port needed), update.http_request checks the
+# manifest periodically, and update.ws_bridge exposes it to Home Assistant.
+# safe_mode: auto-rolls-back a bad flash.
 http_request:
 
 ota:
@@ -103,5 +104,8 @@ update:
   - platform: http_request
     id: my_update
     source: https://example.com/manifest.json
+  - platform: ws_bridge
+    unique_id: firmware
+    update_id: my_update
 
 safe_mode:


### PR DESCRIPTION
## Summary
- Add `update: platform: ws_bridge` that wraps ESPHome's `http_request` update and forwards `install`/`check` over the outbound WebSocket.
- Native `http_request` update never appears in Home Assistant without ESPHome's API; this is what remote/ws_bridge-only devices actually show as an Install card.
- Document the [ESPHome OTA Publisher](https://github.com/eigger/hassio-apps/tree/master/esphome_ota) package path (`update_id: ota_update`).

Companion HA integration: https://github.com/eigger/hass-ws-bridge/compare/main...feat/ws-bridge-update-entity

## Test plan
- [ ] Compile `tests/components/ws_bridge/test.esp32-idf.yaml`
- [ ] With hass-ws-bridge that includes the `update` platform, confirm the firmware update entity appears in HA
- [ ] `update.check` / Install from the HA card triggers `http_request` OTA
- [ ] `esphome.project` version bump makes the card show an available update

Made with [Cursor](https://cursor.com)