### PR TITLE
feat(ws_bridge): wrap existing buttons via button_id

### DIFF
--- a/components/ws_bridge/README.md
+++ b/components/ws_bridge/README.md
@@ -141,6 +141,7 @@ update:
 | `ws_device_id` | | Groups this entity under a sub-device in HA (e.g. multiple sensors on one physical board) |
 | `ws_device_name` | | Display name for that sub-device |
 | `update_id` | ✓ (`update` only) | ID of the ESPHome `update:` entity to wrap — typically `platform: http_request` |
+| `button_id` | (`button`) | ID of an existing ESPHome `button:` to wrap (e.g. `ota_flash_button` from `ota_server/flash_button.yaml`). HA press forwards to that button |
 | `name` | (`update`) | HA-facing name. If omitted, uses the wrapped entity's name when that entity has its own `name:`; otherwise the `unique_id` |
 
 Plus each platform's normal ESPHome options (`name`, `device_class`, `icon`,
@@ -165,12 +166,39 @@ when the device is not using ESPHome's native API. This requires
 
 The [ESPHome OTA Publisher](https://github.com/eigger/hassio-apps/tree/master/esphome_ota)
 add-on is the intended firmware host: it publishes `firmware.ota.bin` + a
-manifest under HA's `/local/` (reachable over LAN and a remote tunnel). Use
-its generated `ota_server/update.yaml` package, then wrap that update entity:
+manifest under HA's `/local/` (reachable over LAN and a remote tunnel). It
+generates two packages — pick one.
+
+**Force-install button** (`flash_button.yaml`, the add-on's default): no
+version tracking, just a button that pulls the `.ota.bin` and checks MD5.
+Wrap `ota_flash_button` so it appears in Home Assistant:
 
 ```yaml
 substitutions:
   ota_device: livingroom          # must match the published node name
+
+packages:
+  ota: !include ota_server/flash_button.yaml
+
+button:
+  - platform: ws_bridge
+    unique_id: ota_update_button
+    name: "Update"
+    icon: mdi:update
+    button_id: ota_flash_button   # id from flash_button.yaml
+
+# Auto-rolls back to the previous firmware if the new one fails to come up
+# cleanly. Strongly recommended for any device you can't walk up to.
+safe_mode:
+```
+
+**Update entity** (`update.yaml`): HA gets a real Install card with current
+vs. available version. Needs `esphome.project.version` bumped to offer an
+update:
+
+```yaml
+substitutions:
+  ota_device: livingroom
 
 packages:
   ota: !include ota_server/update.yaml
@@ -178,7 +206,7 @@ packages:
 esphome:
   project:
     name: "you.something"
-    version: "1.0.0"              # bump this to offer an update
+    version: "1.0.0"
 
 update:
   - platform: ws_bridge
@@ -186,8 +214,6 @@ update:
     name: "Firmware"
     update_id: ota_update         # id from ota_server/update.yaml
 
-# Auto-rolls back to the previous firmware if the new one fails to come up
-# cleanly. Strongly recommended for any device you can't walk up to.
 safe_mode:
 ```
 

--- a/components/ws_bridge/button/__init__.py
+++ b/components/ws_bridge/button/__init__.py
@@ -3,6 +3,7 @@ import esphome.config_validation as cv
 from esphome.components import button, ws_bridge
 
 from .. import ws_bridge_ns
+from ..const import CONF_BUTTON_ID
 
 DEPENDENCIES = ["ws_bridge"]
 WsBridgeButton = ws_bridge_ns.class_("WsBridgeButton", button.Button, cg.Component, ws_bridge.WsBridgeDevice)
@@ -11,6 +12,15 @@ CONFIG_SCHEMA = (
     button.button_schema(WsBridgeButton)
     .extend(ws_bridge.WS_BRIDGE_DEVICE_SCHEMA)
     .extend(cv.COMPONENT_SCHEMA)
+    .extend(
+        cv.Schema(
+            {
+                # Wrap an existing ESPHome button (e.g. ota_flash_button from
+                # ota_server/flash_button.yaml) and expose it to Home Assistant.
+                cv.Optional(CONF_BUTTON_ID): cv.use_id(button.Button),
+            }
+        )
+    )
 )
 
 
@@ -18,3 +28,5 @@ async def to_code(config):
     var = await button.new_button(config)
     await cg.register_component(var, config)
     await ws_bridge.register_ws_bridge_device(var, config)
+    if CONF_BUTTON_ID in config:
+        cg.add(var.set_button(await cg.get_variable(config[CONF_BUTTON_ID])))

--- a/components/ws_bridge/button/ws_bridge_button.cpp
+++ b/components/ws_bridge/button/ws_bridge_button.cpp
@@ -1,4 +1,5 @@
 #include "ws_bridge_button.h"
+#include "esphome/core/log.h"
 #include "../ws_bridge.h"
 #include "../ws_bridge_entity_json.h"
 
@@ -7,7 +8,16 @@ namespace ws_bridge {
 
 static const char *const TAG = "ws_bridge.button";
 
-void WsBridgeButton::dump_config() { LOG_BUTTON("", "WS Bridge Button", this); }
+void WsBridgeButton::dump_config() {
+  LOG_BUTTON("", "WS Bridge Button", this);
+  if (this->button_ != nullptr)
+    ESP_LOGCONFIG(TAG, "  Wrapped: '%s'", this->button_->get_name().str().c_str());
+}
+
+void WsBridgeButton::press_action() {
+  if (this->button_ != nullptr)
+    this->button_->press();
+}
 
 void WsBridgeButton::ws_bridge_handle_command(const WsCommand &command) {
   if (command.action == "press") this->press();

--- a/components/ws_bridge/button/ws_bridge_button.h
+++ b/components/ws_bridge/button/ws_bridge_button.h
@@ -8,13 +8,15 @@ namespace ws_bridge {
 
 class WsBridgeButton : public button::Button, public Component, public WsBridgeDevice {
  public:
+  void set_button(button::Button *button) { this->button_ = button; }
   void setup() override {}
   void dump_config() override;
   void ws_bridge_declare() override;
   void ws_bridge_handle_command(const WsCommand &command) override;
 
  protected:
-  void press_action() override {}
+  void press_action() override;
+  button::Button *button_{nullptr};
 };
 
 }  // namespace ws_bridge

--- a/components/ws_bridge/const.py
+++ b/components/ws_bridge/const.py
@@ -19,6 +19,7 @@ CONF_ON_DECLARE = "on_declare"
 CONF_TRACKERS = "trackers"
 CONF_GPS_ACCURACY = "gps_accuracy"
 CONF_UPDATE_ID = "update_id"
+CONF_BUTTON_ID = "button_id"
 
 CONF_PING_INTERVAL = "ping_interval"
 CONF_PONG_TIMEOUT = "pong_timeout"

--- a/tests/components/ws_bridge/test.esp32-idf.yaml
+++ b/tests/components/ws_bridge/test.esp32-idf.yaml
@@ -86,9 +86,19 @@ select:
       - "Manual"
 
 button:
+  - platform: template
+    id: ota_flash_button
+    name: "Local Flash"
+    on_press:
+      - logger.log: "flash"
   - platform: ws_bridge
     unique_id: restart1
     name: "Restart"
+  - platform: ws_bridge
+    unique_id: ota_update_button
+    name: "Update"
+    icon: mdi:update
+    button_id: ota_flash_button
 
 # Remote OTA over the outbound-only ws_bridge connection: http_request pulls
 # the firmware (no inbound port needed), update.http_request checks the


### PR DESCRIPTION
## Summary
- Add optional `button_id` so `button: platform: ws_bridge` can wrap an on-device button (e.g. `ota_flash_button` from `ota_server/flash_button.yaml`). HA press forwards to that button — no `on_press` automation needed.
- Document both esphome_ota packages: `flash_button.yaml` (force-install) and `update.yaml` (versioned update entity).

## Test plan
- [ ] Compile `tests/components/ws_bridge/test.esp32-idf.yaml`
- [ ] With `packages: ota: !include ota_server/flash_button.yaml` and `button_id: ota_flash_button`, confirm the HA button triggers OTA flash

Made with [Cursor](https://cursor.com)