### PR TITLE
feat(ws_bridge): add sync_entities to remove stale HA entities

### DIFF
--- a/components/ws_bridge/README.md
+++ b/components/ws_bridge/README.md
@@ -46,6 +46,7 @@ ws_bridge:
   gateway_id: my_esp         # (default: this device's name)
   name: "My ESP"             # (default: this device's friendly_name)
   keep_last_state_on_disconnect: false
+  sync_entities: false      # true = remove HA entities this device no longer declares
   ping_interval: 60s
   pong_timeout: 15s
   reconnect_timeout: 30s
@@ -127,6 +128,7 @@ update:
 | `gateway_id` | | device name | Unique client identifier (becomes the HA gateway device) |
 | `name` | | device friendly name | Display name for the gateway device |
 | `keep_last_state_on_disconnect` | | `false` | If `true`, this gateway's entities keep their last state in HA instead of going `unavailable` when the connection drops (including an ungraceful disconnect) |
+| `sync_entities` | | `false` | If `true`, sends `ws_bridge/sync` with every declared `unique_id` right after connecting, so HA removes entities this gateway no longer provides. Entities still declared keep their `entity_id`, history and long-term statistics — nothing is wiped and recreated. See [Removing stale entities](#removing-stale-entities) |
 | `ping_interval` | | `60s` | How often to send an app-level `ping` once connected, to detect a peer that dropped without a clean WebSocket close |
 | `pong_timeout` | | `15s` | How long to wait for a `pong` reply before assuming the connection is dead and forcing a reconnect |
 | `reconnect_timeout` | | `30s` | Cap for the reconnect backoff: while disconnected, we retry starting at 2s and doubling on each failure up to this value (matches the companion hass-ble-android client), rather than waiting on `esp_websocket_client`'s own auto-reconnect indefinitely |
@@ -355,6 +357,42 @@ interval:
 See the integration's
 [PROTOCOL.md](https://github.com/eigger/hass-ws-bridge/blob/main/docs/PROTOCOL.md)
 for the full set of declarable platforms and their fields.
+
+## Removing stale entities
+
+Home Assistant keeps every entity this gateway has ever declared. Deleting a
+sensor from your YAML does **not** remove it from HA — it just stops being
+updated, and with `keep_last_state_on_disconnect: true` it even keeps looking
+alive after a restart, because the integration restores it from its stored
+definition.
+
+Set `sync_entities: true` and the component sends `ws_bridge/sync` with every
+`unique_id` it declared, right after connecting. HA removes the ones that are
+no longer in the list:
+
+```yaml
+ws_bridge:
+  host: 192.168.0.10
+  token: !secret ha_token
+  sync_entities: true
+```
+
+Entities that *are* still declared are left completely alone — their
+`entity_id`, history, and long-term statistics survive. That is why the
+component syncs rather than removing everything and redeclaring.
+
+**When not to enable it.** The list is built from everything declared during
+the connect pass: `platform: ws_bridge` entities, `trackers:`, and lambdas in
+`on_declare:` or `on_connected:`. Anything that declares itself *later* — from
+an `interval:`, a button press, a sensor callback — will be missing from the
+list and get deleted from HA. Leave `sync_entities` off in that case and remove
+those entities by hand instead.
+
+The sync is sent once per connection, not on every `reannounce_interval`. If
+nothing has gone stale, HA does nothing and no entity is touched.
+
+Requires the `ws_bridge` integration v1.3.0 or newer on the HA side. Older
+versions reject the unknown command and log an error; nothing else breaks.
 
 ## Behavior / Limitations
 

--- a/components/ws_bridge/__init__.py
+++ b/components/ws_bridge/__init__.py
@@ -20,6 +20,7 @@ from .const import (
     CONF_TOKEN,
     CONF_GATEWAY_ID,
     CONF_KEEP_LAST_STATE_ON_DISCONNECT,
+    CONF_SYNC_ENTITIES,
     CONF_UNIQUE_ID,
     CONF_WS_DEVICE_ID,
     CONF_WS_DEVICE_NAME,
@@ -85,6 +86,18 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_GATEWAY_ID, default=lambda: CORE.name): cv.string_strict,
             cv.Optional(CONF_NAME, default=lambda: CORE.friendly_name or CORE.name): cv.string_strict,
             cv.Optional(CONF_KEEP_LAST_STATE_ON_DISCONNECT, default=False): cv.boolean,
+            # After declaring everything on connect, send ws_bridge/sync with the
+            # full set of unique_ids so HA drops entities this gateway no longer
+            # provides. Entities still in the list keep their entity_id, history
+            # and statistics — nothing is wiped and recreated.
+            #
+            # Off by default because it deletes HA-side entities. Safe to turn on
+            # when every entity is declared by a ws_bridge platform, an
+            # on_declare: lambda, or an on_connected: lambda — all three are
+            # collected. Leave it off if anything declares itself later (from an
+            # interval:, a button press, ...), since those would be absent from
+            # the list and removed.
+            cv.Optional(CONF_SYNC_ENTITIES, default=False): cv.boolean,
             # See ws_bridge.cpp's check_liveness_() for what these govern: an
             # app-level ping/pong that detects a peer that dropped without a
             # clean WS close, and a backstop that keeps retrying (2s doubling
@@ -164,6 +177,7 @@ async def to_code(config):
     cg.add(var.set_gateway_id(config[CONF_GATEWAY_ID]))
     cg.add(var.set_gateway_name(config[CONF_NAME]))
     cg.add(var.set_keep_last_state_on_disconnect(config[CONF_KEEP_LAST_STATE_ON_DISCONNECT]))
+    cg.add(var.set_sync_entities(config[CONF_SYNC_ENTITIES]))
     cg.add(var.set_ping_interval(config[CONF_PING_INTERVAL].total_milliseconds))
     cg.add(var.set_pong_timeout(config[CONF_PONG_TIMEOUT].total_milliseconds))
     cg.add(var.set_reconnect_timeout(config[CONF_RECONNECT_TIMEOUT].total_milliseconds))

--- a/components/ws_bridge/const.py
+++ b/components/ws_bridge/const.py
@@ -5,6 +5,7 @@ CONF_SSL = "ssl"
 CONF_TOKEN = "token"
 CONF_GATEWAY_ID = "gateway_id"
 CONF_KEEP_LAST_STATE_ON_DISCONNECT = "keep_last_state_on_disconnect"
+CONF_SYNC_ENTITIES = "sync_entities"
 
 CONF_UNIQUE_ID = "unique_id"
 # Prefixed with ws_ to avoid colliding with ESPHome's own reserved

--- a/components/ws_bridge/ws_bridge.cpp
+++ b/components/ws_bridge/ws_bridge.cpp
@@ -260,8 +260,13 @@ void WsBridgeComponent::handle_message_(const std::string &raw) {
     this->reconnect_backoff_ms_ = RECONNECT_BACKOFF_BASE_MS;
     this->last_ping_sent_ms_ = millis();
     this->last_reannounce_ms_ = this->last_ping_sent_ms_;
+    // Collect across both the declare pass and on_connected:, so a lambda that
+    // declares from either trigger is counted before the list is sent.
+    this->collecting_declared_ids_ = this->sync_entities_;
+    this->declared_ids_.clear();
     this->declare_all_entities_();
     this->connected_cb_.call();
+    this->flush_sync_();
   } else if (msg.type == "auth_invalid") {
     ESP_LOGE(TAG, "Home Assistant rejected the access token");
   } else if (msg.type == "pong") {
@@ -295,6 +300,21 @@ void WsBridgeComponent::declare_all_entities_() {
   this->declare_cb_.call();
 }
 
+void WsBridgeComponent::flush_sync_() {
+  this->collecting_declared_ids_ = false;
+  if (!this->sync_entities_) return;
+  // HA rejects an empty list (it would mean "delete everything"), and a
+  // gateway that declared nothing has nothing to reconcile against anyway.
+  if (this->declared_ids_.empty()) {
+    ESP_LOGW(TAG, "sync_entities is on but nothing was declared — skipping ws_bridge/sync");
+    return;
+  }
+  ESP_LOGD(TAG, "Syncing %u declared entities with HA", (unsigned) this->declared_ids_.size());
+  this->send_raw_(build_sync(this->next_id_(), this->declared_ids_));
+  this->declared_ids_.clear();
+  this->declared_ids_.shrink_to_fit();
+}
+
 void WsBridgeComponent::send_raw_(const std::string &msg) {
   if (this->client_ == nullptr || !esp_websocket_client_is_connected(this->client_)) return;
   esp_websocket_client_send_text(this->client_, msg.c_str(), msg.size(), pdMS_TO_TICKS(1000));
@@ -305,6 +325,10 @@ void WsBridgeComponent::send_entity_declare(const std::string &unique_id, const 
                                             const std::string &device_name,
                                             const std::function<void(JsonObject)> &extra) {
   if (!this->is_connected()) return;
+  // Every declaration funnels through here — registered platform entities and
+  // hand-built lambda ones alike — so this is the one place that sees the full
+  // set for ws_bridge/sync. See sync_entities_.
+  if (this->collecting_declared_ids_) this->declared_ids_.push_back(unique_id);
   this->send_raw_(build_entity_declare(this->next_id_(), unique_id, platform, name, device_id, device_name, extra));
 }
 

--- a/components/ws_bridge/ws_bridge.h
+++ b/components/ws_bridge/ws_bridge.h
@@ -51,6 +51,7 @@ class WsBridgeComponent : public Component {
   void set_gateway_id(const std::string &id) { this->gateway_id_ = id; }
   void set_gateway_name(const std::string &name) { this->gateway_name_ = name; }
   void set_keep_last_state_on_disconnect(bool v) { this->keep_last_state_on_disconnect_ = v; }
+  void set_sync_entities(bool v) { this->sync_entities_ = v; }
   // See check_liveness_() for what these govern.
   void set_ping_interval(uint32_t ms) { this->ping_interval_ms_ = ms; }
   void set_pong_timeout(uint32_t ms) { this->pong_timeout_ms_ = ms; }
@@ -99,6 +100,7 @@ class WsBridgeComponent : public Component {
   void handle_message_(const std::string &raw);
   void route_command_(const WsCommand &command);
   void declare_all_entities_();
+  void flush_sync_();
   void send_raw_(const std::string &msg);
   uint32_t next_id_() { return ++this->msg_id_; }
   void set_state_(WsBridgeState s);
@@ -115,6 +117,23 @@ class WsBridgeComponent : public Component {
   std::string gateway_id_;
   std::string gateway_name_;
   bool keep_last_state_on_disconnect_{false};
+
+  // Opt-in (sync_entities:). After declaring everything on connect, tell HA the
+  // full set of unique_ids we provide so it can drop entities we no longer
+  // declare — see build_sync(). Off by default because it deletes HA-side
+  // entities: the list has to genuinely be everything this gateway offers, and
+  // only the config author can promise that. Entities declared from anywhere
+  // other than the declare/connect pass (say, an interval or a button press)
+  // would be missing from it and get removed.
+  //
+  // Collection runs for the whole declare window and is closed by flush_sync_(),
+  // so it captures on_declare: AND on_connected: lambdas, not just the
+  // registered platform entities. Sent once per connection, not on every
+  // periodic re-announce — a stale entity is not urgent enough to make HA scan
+  // its entity registry every reannounce_interval.
+  bool sync_entities_{false};
+  bool collecting_declared_ids_{false};
+  std::vector<std::string> declared_ids_{};
 
   std::atomic<WsBridgeState> state_{WS_BRIDGE_DISCONNECTED};
   uint32_t msg_id_{0};

--- a/components/ws_bridge/ws_protocol.cpp
+++ b/components/ws_bridge/ws_protocol.cpp
@@ -75,6 +75,15 @@ std::string build_entity_declare(uint32_t id, const std::string &unique_id, cons
   });
 }
 
+std::string build_sync(uint32_t id, const std::vector<std::string> &unique_ids) {
+  return json::build_json([&](JsonObject root) {
+    root["id"] = id;
+    root["type"] = "ws_bridge/sync";
+    JsonArray ids = root["unique_ids"].to<JsonArray>();
+    for (const auto &unique_id : unique_ids) ids.add(unique_id);
+  });
+}
+
 std::string build_ping(uint32_t id) {
   return json::build_json([&](JsonObject root) {
     root["id"] = id;

--- a/components/ws_bridge/ws_protocol.h
+++ b/components/ws_bridge/ws_protocol.h
@@ -2,6 +2,7 @@
 #include <cstdint>
 #include <functional>
 #include <string>
+#include <vector>
 #include "esphome/components/json/json_util.h"
 
 namespace esphome {
@@ -41,6 +42,13 @@ std::string build_connect(uint32_t id, const std::string &gateway_id, const std:
 // layer itself doesn't notice (e.g. HA process killed without a clean WS
 // close, so the socket never sees a FIN/RST).
 std::string build_ping(uint32_t id);
+
+// Tells HA the complete set of unique_ids this gateway currently provides, so
+// it can drop entities we no longer declare (PROTOCOL.md §3.5). Entities that
+// ARE in the list are left untouched, so their entity_id, history and
+// long-term statistics survive — unlike removing everything and redeclaring.
+// HA rejects an empty list, so callers must not send one.
+std::string build_sync(uint32_t id, const std::vector<std::string> &unique_ids);
 
 // `extra` (may be empty) is called with the message's root JsonObject to add
 // platform-specific declare fields (device_class, options, min/max/step, ...).

--- a/tests/components/ws_bridge/test.esp32-idf.yaml
+++ b/tests/components/ws_bridge/test.esp32-idf.yaml
@@ -25,6 +25,7 @@ ws_bridge:
   gateway_id: my_esp
   name: "My ESP"
   keep_last_state_on_disconnect: true
+  sync_entities: true
   on_connected:
     - logger.log: "ws_bridge connected"
   on_disconnected:


### PR DESCRIPTION
Client side of [hass-ws-bridge#32](https://github.com/eigger/hass-ws-bridge/pull/32) (integration v1.3.0+).

## Problem

Home Assistant keeps every entity this gateway has ever declared. Deleting a sensor from the YAML does not remove it from HA — it just stops updating. With `keep_last_state_on_disconnect: true` it is worse: the integration restores it from its stored definition on every HA restart, so it keeps looking alive, and HA offers no delete button because the UI only allows deleting *unavailable* entities.

## Change

`sync_entities: true` sends `ws_bridge/sync` with every `unique_id` the component declared, right after connecting. HA removes the ones no longer in the list.

Entities that *are* still declared are left completely alone, so their `entity_id`, history, and long-term statistics survive. That is the reason to sync rather than remove everything and redeclare.

```yaml
ws_bridge:
  host: 192.168.0.10
  token: !secret ha_token
  sync_entities: true
```

## How the list is built

`send_entity_declare()` is the single funnel for every declaration — registered platform entities and hand-built lambda ones alike — so collecting there captures the full set.

The collection window stays open across `declare_all_entities_()` **and** `connected_cb_`, so `on_declare:` and `on_connected:` lambdas are both counted before the list is sent; `flush_sync_()` closes it. That matters because `trackers:` and other hand-declared entity types would otherwise be missing from the list and get deleted.

Sent once per connection, not on every re-announce — a stale entity is not worth making HA scan its entity registry every `reannounce_interval`.

## Default

Off. It deletes HA-side entities, and anything that declares itself outside the connect pass (an `interval:`, a button press, a sensor callback) would be absent from the list and removed. Only the config author knows whether that applies. The README documents exactly when it is safe to enable.

Empty lists are never sent — HA rejects them, since an empty list would mean "delete everything".

## Test plan

- `tests/components/ws_bridge/test.esp32-idf.yaml` sets `sync_entities: true`, so CI compiles the new path.
- Config schema and README (options table + a "Removing stale entities" section) updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
