### PR TITLE
feat(ws_bridge): wrap existing entities via sensor_id and entities:

### DIFF
--- a/components/ws_bridge/README.md
+++ b/components/ws_bridge/README.md
@@ -134,24 +134,133 @@ update:
 | `reconnect_timeout` | | `30s` | Cap for the reconnect backoff: while disconnected, we retry starting at 2s and doubling on each failure up to this value (matches the companion hass-ble-android client), rather than waiting on `esp_websocket_client`'s own auto-reconnect indefinitely |
 | `reannounce_interval` | | `60s` | How often to resend `ws_bridge/connect` + all entity/state declarations while nominally connected. Guards against the HA-side integration losing track of this gateway (e.g. its config entry reloaded) while the raw connection and ping/pong stay healthy — that scenario is otherwise invisible, since HA answers pings regardless of our integration's state. If a re-announce goes unanswered, forces a full reconnect rather than repeating the same no-op |
 | `trackers` | | - | List of GPS `device_tracker` entities — see [GPS device trackers](#gps-device-trackers) below |
+| `entities` | | - | Existing ESPHome entities to expose without a parallel `platform: ws_bridge` entity — see [Exposing existing entities](#exposing-existing-entities) |
 
 ### Platform options (all of `sensor`/`binary_sensor`/`text_sensor`/`switch`/`number`/`select`/`button`/`update`)
 
 | Option | Required | Description |
 |--------|:--------:|-------------|
-| `unique_id` | ✓ | Identifier for this entity, unique within the gateway |
+| `unique_id` | ✓ | Identifier for this entity, unique within the gateway. **Changing it creates a new HA entity** (the old one is left behind; `sync_entities: true` then deletes it) |
 | `ws_device_id` | | Groups this entity under a sub-device in HA (e.g. multiple sensors on one physical board) |
 | `ws_device_name` | | Display name for that sub-device |
+| `sensor_id` / `binary_sensor_id` / `text_sensor_id` / `switch_id` / `number_id` / `select_id` / `button_id` | | ID of an existing ESPHome entity to wrap — see [Exposing existing entities](#exposing-existing-entities) |
 | `update_id` | ✓ (`update` only) | ID of the ESPHome `update:` entity to wrap — typically `platform: http_request` |
-| `button_id` | (`button`) | ID of an existing ESPHome `button:` to wrap (e.g. `ota_flash_button` from `ota_server/flash_button.yaml`). HA press forwards to that button |
 | `name` | (`update`) | HA-facing name. If omitted, uses the wrapped entity's name when that entity has its own `name:`; otherwise the `unique_id` |
 
 Plus each platform's normal ESPHome options (`name`, `device_class`, `icon`,
 `entity_category`, `unit_of_measurement`/`state_class` for `sensor`,
-`min_value`/`max_value`/`step` for `number`, `options` for `select`). An
-id-only `http_request` update is `internal` and named after its id — set
-`name:` on the `ws_bridge` wrapper so Home Assistant does not show
-`"ota_update"`.
+`min_value`/`max_value`/`step` for `number`, `options` for `select`). When
+wrapping, those inherit from the source unless also set here —
+`min_value`/`max_value` (and `options` on `select`) are required only when
+*not* wrapping. An id-only `http_request` update is `internal` and named
+after its id — set `name:` on the `ws_bridge` wrapper so Home Assistant does
+not show `"ota_update"`.
+
+## Exposing existing entities
+
+Two ways to put an already-declared ESPHome entity onto Home Assistant.
+Pick **one** per source — using both (`sensor_id:` *and* `entities:`)
+exposes it twice. `dump_config()` warns at boot if that happens, or if two
+devices share a `unique_id`.
+
+### `platform: ws_bridge` wrapping (`sensor_id:` / `switch_id:` / …)
+
+Creates a parallel ws_bridge entity that mirrors (and, for writable
+domains, *drives*) the source. Use this when you want a distinct
+`unique_id`, or to override `name:` / `device_class:` / `icon:` / etc.
+
+```yaml
+sensor:
+  - platform: uptime
+    id: uptime_sensor
+  - platform: ws_bridge
+    unique_id: uptime
+    sensor_id: uptime_sensor
+    # device_class / unit_of_measurement / state_class / accuracy_decimals
+    # inherit from uptime_sensor unless also set here
+    name: "Uptime"                 # ESPHome requires id: or name: (unique_id is not enough)
+
+switch:
+  - platform: gpio
+    pin: GPIO12
+    id: relay
+  - platform: ws_bridge
+    unique_id: relay_ha
+    name: "Relay"
+    switch_id: relay               # HA on/off is applied to `relay`, not this entity
+
+number:
+  - platform: template
+    id: setpoint
+    optimistic: true
+    min_value: 0
+    max_value: 10
+    step: 1
+  - platform: ws_bridge
+    unique_id: setpoint_ha
+    name: "Setpoint"
+    number_id: setpoint            # min_value / max_value / step inherited — omit them
+```
+
+- **Metadata** (`device_class`, `icon`, `entity_category`, sensor unit /
+  state class / accuracy, number range, select options) comes from the
+  source. Anything written on the ws_bridge platform still wins.
+- **Commands** on `switch` / `number` / `select` / `button` / `update` are
+  applied to the wrapped entity, not to the wrapper. On-device automations
+  should keep targeting the source (`switch.turn_on: relay`).
+- ESPHome still requires `id:` or `name:` on the wrapper YAML (`unique_id`
+  alone is not enough).
+- `unique_id` is still required. Changing it (or first adding wrapping
+  under a new id) is a **new HA entity** — history stays on the old
+  `entity_id`.
+- `update:` wrapping (`update_id:`) is required, not optional — that
+  platform has no state of its own. See [Remote OTA updates](#remote-ota-updates-no-vpn-no-mqtt).
+
+### Hub `entities:` list
+
+Exposes the source without a parallel `platform: ws_bridge` entity. The
+domain is taken from `source_id:` (no `platform:` key). Prefer this when
+you just want the entity in HA as-is.
+
+```yaml
+ws_bridge:
+  host: !secret ha_address
+  token: !secret ha_token
+  entities:
+    - source_id: uptime_sensor          # unique_id defaults to "uptime_sensor"
+    - source_id: relay
+      unique_id: relay_ha               # optional override
+      name: "Living Room Relay"         # optional; else the source's own name
+      ws_device_id: board_1
+      ws_device_name: "Sensor Hub"
+```
+
+| Option | Required | Description |
+|--------|:--------:|-------------|
+| `source_id` | ✓ | ESPHome `id:` of an existing sensor / binary_sensor / text_sensor / switch / number / select / button / update |
+| `unique_id` | | HA identifier. **Defaults to the source's YAML `id:`** (stable across `name:` edits, unlike an object_id) |
+| `name` | | HA-facing name. Defaults to the source's own `name:`; an id-only source (no `name:`) falls back to `unique_id` rather than leaking the ESPHome id |
+| `ws_device_id` / `ws_device_name` | | Same as every other platform |
+
+There is no per-field metadata override here — `device_class` and friends
+come entirely from the source. Use platform wrapping if you need to change
+them.
+
+**`id:` changes replace the HA entity.** When `unique_id` is omitted it
+tracks the source's YAML `id:`. Rename `id: uptime_sensor` → `id: uptime`
+and HA sees a brand-new entity; the old one is orphaned. Set `unique_id:`
+explicitly if you want to rename the ESPHome id without churning HA.
+The same applies to any platform entity whose `unique_id` you edit.
+
+### `sync_entities` interaction
+
+Both wrapping and `entities:` register as normal ws_bridge devices, so
+they are included in the `ws_bridge/sync` list when
+`sync_entities: true`. Switching a source from wrapping to `entities:`
+(or the other way) under a *different* `unique_id` will therefore delete
+the old HA entity on the next connect — including its `entity_id` and
+history attachment. Keep the `unique_id` stable across that migration, or
+leave `sync_entities` off and remove the leftover by hand.
 
 ## Remote OTA updates (no VPN, no MQTT)
 
@@ -382,11 +491,11 @@ Entities that *are* still declared are left completely alone — their
 component syncs rather than removing everything and redeclaring.
 
 **When not to enable it.** The list is built from everything declared during
-the connect pass: `platform: ws_bridge` entities, `trackers:`, and lambdas in
-`on_declare:` or `on_connected:`. Anything that declares itself *later* — from
-an `interval:`, a button press, a sensor callback — will be missing from the
-list and get deleted from HA. Leave `sync_entities` off in that case and remove
-those entities by hand instead.
+the connect pass: `platform: ws_bridge` entities (including `*_id:` wrapping),
+`entities:`, `trackers:`, and lambdas in `on_declare:` or `on_connected:`.
+Anything that declares itself *later* — from an `interval:`, a button press, a
+sensor callback — will be missing from the list and get deleted from HA. Leave
+`sync_entities` off in that case and remove those entities by hand instead.
 
 The sync is sent once per connection, not on every `reannounce_interval`. If
 nothing has gone stale, HA does nothing and no entity is touched.
@@ -399,10 +508,12 @@ versions reject the unknown command and log an error; nothing else breaks.
 - **Read-only platforms** (`sensor`, `binary_sensor`, `text_sensor`) push
   their state to Home Assistant automatically whenever it changes.
 - **Controllable platforms** (`switch`, `number`, `select`, `button`, `update`)
-  receive commands from Home Assistant and update their own state
-  optimistically (`publish_state`/`this->state`) — hook `on_turn_on`/`lambda:`/etc.
-  in your own YAML if you need to drive real hardware from the state. `update`
-  forwards `install`/`check` to the wrapped `http_request` update entity.
+  receive commands from Home Assistant. A plain (non-wrapping) entity updates
+  its own state optimistically (`publish_state`/`this->state`) — hook
+  `on_turn_on`/`lambda:`/etc. in your own YAML if you need to drive real
+  hardware from that. A wrapping entity (`switch_id:` / `number_id:` /
+  `select_id:` / `button_id:` / `update_id:`, or an `entities:` entry)
+  forwards the command to the source instead.
 - On every (re)connect, all declared entities and their current state are
   re-sent, per the protocol's reconnection guidance.
 - While connected, an application-level `ping`/`pong` (HA's standard

--- a/components/ws_bridge/README.md
+++ b/components/ws_bridge/README.md
@@ -204,7 +204,9 @@ number:
 
 - **Metadata** (`device_class`, `icon`, `entity_category`, sensor unit /
   state class / accuracy, number range, select options) comes from the
-  source. Anything written on the ws_bridge platform still wins.
+  source. Anything written on the ws_bridge platform still wins, field by
+  field — a number that sets only `min_value`/`max_value` keeps the
+  source's `step`, and vice versa.
 - **Commands** on `switch` / `number` / `select` / `button` / `update` are
   applied to the wrapped entity, not to the wrapper. On-device automations
   should keep targeting the source (`switch.turn_on: relay`).

--- a/components/ws_bridge/__init__.py
+++ b/components/ws_bridge/__init__.py
@@ -1,7 +1,17 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome import automation
-from esphome.components import esp32
+from esphome.components import (
+    esp32,
+    sensor,
+    binary_sensor,
+    text_sensor,
+    switch,
+    number,
+    select,
+    button,
+    update,
+)
 from esphome.const import (
     CONF_ID,
     CONF_PORT,
@@ -33,6 +43,8 @@ from .const import (
     CONF_PONG_TIMEOUT,
     CONF_RECONNECT_TIMEOUT,
     CONF_REANNOUNCE_INTERVAL,
+    CONF_ENTITIES,
+    CONF_SOURCE_ID,
 )
 
 CODEOWNERS = ["@eigger"]
@@ -67,6 +79,74 @@ TRACKER_SCHEMA = cv.Schema(
         cv.Optional(CONF_GPS_ACCURACY): cv.templatable(cv.float_),
     }
 ).extend(cv.polling_component_schema("60s"))
+
+# Hub-side `entities:` list — exposes an *existing* ESPHome entity (given by
+# `source_id:`) to Home Assistant without a parallel `platform: ws_bridge`
+# entity for it. One concrete *Ref class per domain, all sharing the same
+# WsBridgeEntityRefBase — see ws_bridge_entity_ref.h. The domain is not
+# something YAML declares; it's resolved from source_id's own registered type
+# in to_code_entity_ref() below, since ESPHome doesn't know which platform an
+# `id:` belongs to until that platform's own to_code has run.
+WsBridgeEntityRefBase = ws_bridge_ns.class_("WsBridgeEntityRefBase", cg.Component, WsBridgeDevice)
+_ENTITY_REF_DOMAINS = [
+    (sensor.Sensor, ws_bridge_ns.class_("WsBridgeSensorRef", WsBridgeEntityRefBase)),
+    (binary_sensor.BinarySensor, ws_bridge_ns.class_("WsBridgeBinarySensorRef", WsBridgeEntityRefBase)),
+    (text_sensor.TextSensor, ws_bridge_ns.class_("WsBridgeTextSensorRef", WsBridgeEntityRefBase)),
+    (switch.Switch, ws_bridge_ns.class_("WsBridgeSwitchRef", WsBridgeEntityRefBase)),
+    (number.Number, ws_bridge_ns.class_("WsBridgeNumberRef", WsBridgeEntityRefBase)),
+    (select.Select, ws_bridge_ns.class_("WsBridgeSelectRef", WsBridgeEntityRefBase)),
+    (button.Button, ws_bridge_ns.class_("WsBridgeButtonRef", WsBridgeEntityRefBase)),
+    (update.UpdateEntity, ws_bridge_ns.class_("WsBridgeUpdateRef", WsBridgeEntityRefBase)),
+]
+
+ENTITY_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(): cv.declare_id(WsBridgeEntityRefBase),
+        # Loosely typed on purpose: the real domain (sensor/switch/...) isn't
+        # known here, only that it must be *some* entity. ESPHome's own
+        # IDPassValidationStep still rejects an id that isn't an entity at all
+        # (e.g. pointing at the ws_bridge: hub itself) — see to_code_entity_ref().
+        cv.Required(CONF_SOURCE_ID): cv.use_id(cg.EntityBase),
+        # Both default to the source: unique_id to its YAML id (stable across
+        # `name:` edits, unlike an object_id would be), name to its own name.
+        cv.Optional(CONF_UNIQUE_ID): cv.string_strict,
+        cv.Optional(CONF_NAME): cv.string_strict,
+        cv.Optional(CONF_WS_DEVICE_ID): cv.string_strict,
+        cv.Optional(CONF_WS_DEVICE_NAME): cv.string_strict,
+    }
+)
+
+
+async def to_code_entity_ref(hub_var, conf):
+    source_id = conf[CONF_SOURCE_ID]
+    full_id, source_var = await cg.get_variable_with_full_id(source_id)
+
+    ref_cls = None
+    for domain_type, cls in _ENTITY_REF_DOMAINS:
+        if isinstance(full_id.type, cg.MockObjClass) and full_id.type.inherits_from(domain_type):
+            ref_cls = cls
+            break
+    if ref_cls is None:
+        raise cv.Invalid(
+            f"'{source_id.id}' (type {full_id.type}) is not an entity domain ws_bridge "
+            "can expose via entities: — supported: sensor, binary_sensor, text_sensor, "
+            "switch, number, select, button, update"
+        )
+
+    id_ = conf[CONF_ID]
+    id_.type = ref_cls
+    var = cg.new_Pvariable(id_)
+    await cg.register_component(var, {})
+    cg.add(var.set_ws_bridge_parent(hub_var))
+    cg.add(var.set_unique_id(conf.get(CONF_UNIQUE_ID, source_id.id)))
+    if CONF_WS_DEVICE_ID in conf:
+        cg.add(var.set_device_id(conf[CONF_WS_DEVICE_ID]))
+    if CONF_WS_DEVICE_NAME in conf:
+        cg.add(var.set_device_name(conf[CONF_WS_DEVICE_NAME]))
+    if CONF_NAME in conf:
+        cg.add(var.set_name_override(conf[CONF_NAME]))
+    cg.add(var.set_source(source_var))
+    cg.add(hub_var.register_device(var))
 
 
 def _validate_esp_idf(config):
@@ -136,6 +216,10 @@ CONFIG_SCHEMA = cv.All(
                 {cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(DeclareTrigger)}
             ),
             cv.Optional(CONF_TRACKERS, default=[]): cv.ensure_list(TRACKER_SCHEMA),
+            # Expose existing ESPHome entities without a parallel
+            # `platform: ws_bridge` entity per value — see ENTITY_SCHEMA above
+            # and the README's "Exposing existing entities" section.
+            cv.Optional(CONF_ENTITIES, default=[]): cv.ensure_list(ENTITY_SCHEMA),
         }
     ).extend(cv.COMPONENT_SCHEMA),
     _validate_esp_idf,
@@ -213,3 +297,6 @@ async def to_code(config):
         if CONF_GPS_ACCURACY in conf:
             acc_template = await cg.templatable(conf[CONF_GPS_ACCURACY], [], cg.float_)
             cg.add(tracker.set_gps_accuracy(acc_template))
+
+    for conf in config.get(CONF_ENTITIES, []):
+        await to_code_entity_ref(var, conf)

--- a/components/ws_bridge/binary_sensor/__init__.py
+++ b/components/ws_bridge/binary_sensor/__init__.py
@@ -3,6 +3,7 @@ import esphome.config_validation as cv
 from esphome.components import binary_sensor, ws_bridge
 
 from .. import ws_bridge_ns
+from ..const import CONF_BINARY_SENSOR_ID
 
 DEPENDENCIES = ["ws_bridge"]
 WsBridgeBinarySensor = ws_bridge_ns.class_(
@@ -13,6 +14,13 @@ CONFIG_SCHEMA = (
     binary_sensor.binary_sensor_schema(WsBridgeBinarySensor)
     .extend(ws_bridge.WS_BRIDGE_DEVICE_SCHEMA)
     .extend(cv.COMPONENT_SCHEMA)
+    .extend(
+        {
+            # Wrap an existing ESPHome binary_sensor and expose it to Home
+            # Assistant. device_class is inherited from it unless also set here.
+            cv.Optional(CONF_BINARY_SENSOR_ID): cv.use_id(binary_sensor.BinarySensor),
+        }
+    )
 )
 
 
@@ -20,3 +28,5 @@ async def to_code(config):
     var = await binary_sensor.new_binary_sensor(config)
     await cg.register_component(var, config)
     await ws_bridge.register_ws_bridge_device(var, config)
+    if CONF_BINARY_SENSOR_ID in config:
+        cg.add(var.set_source(await cg.get_variable(config[CONF_BINARY_SENSOR_ID])))

--- a/components/ws_bridge/binary_sensor/ws_bridge_binary_sensor.cpp
+++ b/components/ws_bridge/binary_sensor/ws_bridge_binary_sensor.cpp
@@ -6,13 +6,20 @@ namespace ws_bridge {
 
 static const char *const TAG = "ws_bridge.binary_sensor";
 
-void WsBridgeBinarySensor::setup() { ws_subscribe_binary_sensor(this, this); }
+void WsBridgeBinarySensor::setup() {
+  ws_subscribe_binary_sensor(this, this->source_ != nullptr ? this->source_ : this);
+}
 
-void WsBridgeBinarySensor::dump_config() { LOG_BINARY_SENSOR("", "WS Bridge Binary Sensor", this); }
+void WsBridgeBinarySensor::dump_config() {
+  LOG_BINARY_SENSOR("", "WS Bridge Binary Sensor", this);
+  if (this->source_ != nullptr) ESP_LOGCONFIG(TAG, "  Wrapped: '%s'", this->source_->get_name().str().c_str());
+}
 
 void WsBridgeBinarySensor::ws_bridge_declare() {
-  ws_declare_binary_sensor(this, *this, this, this->get_name().str());
-  ws_push_state_binary_sensor(this, *this);
+  binary_sensor::BinarySensor &src = this->source_ != nullptr ? *this->source_ : *this;
+  const std::string own_name = this->has_own_name() ? this->get_name().str() : "";
+  ws_declare_binary_sensor(this, src, this, ws_ha_name(src, own_name, this->unique_id_));
+  ws_push_state_binary_sensor(this, src);
 }
 
 }  // namespace ws_bridge

--- a/components/ws_bridge/binary_sensor/ws_bridge_binary_sensor.cpp
+++ b/components/ws_bridge/binary_sensor/ws_bridge_binary_sensor.cpp
@@ -1,23 +1,18 @@
 #include "ws_bridge_binary_sensor.h"
-#include "../ws_bridge.h"
-#include "../ws_bridge_entity_json.h"
+#include "../ws_bridge_domains.h"
 
 namespace esphome {
 namespace ws_bridge {
 
 static const char *const TAG = "ws_bridge.binary_sensor";
 
-void WsBridgeBinarySensor::setup() {
-  this->add_on_state_callback([this](bool state) { this->parent_->send_state_bool(this->unique_id_, state); });
-}
+void WsBridgeBinarySensor::setup() { ws_subscribe_binary_sensor(this, this); }
 
 void WsBridgeBinarySensor::dump_config() { LOG_BINARY_SENSOR("", "WS Bridge Binary Sensor", this); }
 
 void WsBridgeBinarySensor::ws_bridge_declare() {
-  this->parent_->send_entity_declare(this->unique_id_, "binary_sensor", this->get_name().str(), this->device_id_,
-                                     this->device_name_,
-                                     [this](JsonObject root) { add_common_entity_fields(root, *this); });
-  if (this->has_state()) this->parent_->send_state_bool(this->unique_id_, this->state);
+  ws_declare_binary_sensor(this, *this, this, this->get_name().str());
+  ws_push_state_binary_sensor(this, *this);
 }
 
 }  // namespace ws_bridge

--- a/components/ws_bridge/binary_sensor/ws_bridge_binary_sensor.h
+++ b/components/ws_bridge/binary_sensor/ws_bridge_binary_sensor.h
@@ -8,9 +8,17 @@ namespace ws_bridge {
 
 class WsBridgeBinarySensor : public binary_sensor::BinarySensor, public Component, public WsBridgeDevice {
  public:
+  // Optional: mirror an existing binary_sensor instead of expecting its own
+  // state pushed via lambdas. Metadata inherits from it field by field;
+  // anything set on this platform still wins.
+  void set_source(binary_sensor::BinarySensor *source) { this->source_ = source; }
+  const EntityBase *get_ws_bridge_source() const override { return this->source_; }
   void setup() override;
   void dump_config() override;
   void ws_bridge_declare() override;
+
+ protected:
+  binary_sensor::BinarySensor *source_{nullptr};
 };
 
 }  // namespace ws_bridge

--- a/components/ws_bridge/button/ws_bridge_button.cpp
+++ b/components/ws_bridge/button/ws_bridge_button.cpp
@@ -1,7 +1,6 @@
 #include "ws_bridge_button.h"
 #include "esphome/core/log.h"
-#include "../ws_bridge.h"
-#include "../ws_bridge_entity_json.h"
+#include "../ws_bridge_domains.h"
 
 namespace esphome {
 namespace ws_bridge {
@@ -19,14 +18,16 @@ void WsBridgeButton::press_action() {
     this->button_->press();
 }
 
-void WsBridgeButton::ws_bridge_handle_command(const WsCommand &command) {
-  if (command.action == "press") this->press();
-}
+void WsBridgeButton::ws_bridge_handle_command(const WsCommand &command) { ws_handle_command_button(this, command); }
 
 void WsBridgeButton::ws_bridge_declare() {
-  this->parent_->send_entity_declare(this->unique_id_, "button", this->get_name().str(), this->device_id_,
-                                     this->device_name_,
-                                     [this](JsonObject root) { add_common_entity_fields(root, *this); });
+  // When wrapping, metadata comes from the wrapped button and anything written
+  // on this platform overrides it field by field — same rule as every other
+  // ws_bridge wrapper. Name resolution follows the same order: this entity's
+  // own name, then the wrapped button's, then the unique_id.
+  button::Button &src = this->button_ != nullptr ? *this->button_ : *this;
+  const std::string own_name = this->has_own_name() ? this->get_name().str() : "";
+  ws_declare_button(this, src, this, ws_ha_name(src, own_name, this->unique_id_));
 }
 
 }  // namespace ws_bridge

--- a/components/ws_bridge/button/ws_bridge_button.h
+++ b/components/ws_bridge/button/ws_bridge_button.h
@@ -9,6 +9,7 @@ namespace ws_bridge {
 class WsBridgeButton : public button::Button, public Component, public WsBridgeDevice {
  public:
   void set_button(button::Button *button) { this->button_ = button; }
+  const EntityBase *get_ws_bridge_source() const override { return this->button_; }
   void setup() override {}
   void dump_config() override;
   void ws_bridge_declare() override;

--- a/components/ws_bridge/const.py
+++ b/components/ws_bridge/const.py
@@ -22,6 +22,11 @@ CONF_GPS_ACCURACY = "gps_accuracy"
 CONF_UPDATE_ID = "update_id"
 CONF_BUTTON_ID = "button_id"
 
+# Hub-side `entities:` list — exposes an already-existing ESPHome entity
+# without a parallel `platform: ws_bridge` entity. See WsBridgeEntityRefBase.
+CONF_ENTITIES = "entities"
+CONF_SOURCE_ID = "source_id"
+
 CONF_PING_INTERVAL = "ping_interval"
 CONF_PONG_TIMEOUT = "pong_timeout"
 CONF_RECONNECT_TIMEOUT = "reconnect_timeout"

--- a/components/ws_bridge/const.py
+++ b/components/ws_bridge/const.py
@@ -21,6 +21,12 @@ CONF_TRACKERS = "trackers"
 CONF_GPS_ACCURACY = "gps_accuracy"
 CONF_UPDATE_ID = "update_id"
 CONF_BUTTON_ID = "button_id"
+CONF_SENSOR_ID = "sensor_id"
+CONF_BINARY_SENSOR_ID = "binary_sensor_id"
+CONF_TEXT_SENSOR_ID = "text_sensor_id"
+CONF_SWITCH_ID = "switch_id"
+CONF_NUMBER_ID = "number_id"
+CONF_SELECT_ID = "select_id"
 
 # Hub-side `entities:` list — exposes an already-existing ESPHome entity
 # without a parallel `platform: ws_bridge` entity. See WsBridgeEntityRefBase.

--- a/components/ws_bridge/number/__init__.py
+++ b/components/ws_bridge/number/__init__.py
@@ -17,16 +17,10 @@ def validate_number_range(config):
         raise cv.Invalid("min_value and max_value must be set together")
     if not has_min:
         # No range of its own: only valid when wrapping, since the range then
-        # comes from number_id's own min/max/step at declare time (see
+        # comes from number_id's own min/max at declare time (see
         # ws_bridge_domains.h's ws_declare_number).
         if CONF_NUMBER_ID not in config:
             raise cv.Invalid("min_value and max_value are required unless number_id: is set")
-        if CONF_STEP in config:
-            # step alone (without min_value/max_value) would silently be
-            # dropped: ws_declare_number treats the trio as one atomic
-            # inherit-or-not decision keyed on min_value, so a lone step
-            # here would never take effect.
-            raise cv.Invalid("step requires min_value and max_value to also be set")
         return config
     if config[CONF_MAX_VALUE] <= config[CONF_MIN_VALUE]:
         raise cv.Invalid("max_value must be greater than min_value")
@@ -53,15 +47,15 @@ CONFIG_SCHEMA = cv.All(
 
 
 async def to_code(config):
-    has_own_range = CONF_MIN_VALUE in config
+    wrapping = CONF_NUMBER_ID in config
     var = await number.new_number(
         config,
+        # NaN means "inherit this field from number_id" (see ws_declare_number),
+        # so the 1.0 step default only applies when there is nothing to inherit
+        # from — otherwise overriding just the range would also force step 1.0.
         min_value=config.get(CONF_MIN_VALUE, float("nan")),
         max_value=config.get(CONF_MAX_VALUE, float("nan")),
-        # 1.0 matches the old unconditional default — only applied when this
-        # entity actually owns a range; a wrapper inheriting number_id's range
-        # must not clobber its step with this default (see ws_declare_number).
-        step=config.get(CONF_STEP, 1.0 if has_own_range else float("nan")),
+        step=config.get(CONF_STEP, float("nan") if wrapping else 1.0),
     )
     await cg.register_component(var, config)
     await ws_bridge.register_ws_bridge_device(var, config)

--- a/components/ws_bridge/number/__init__.py
+++ b/components/ws_bridge/number/__init__.py
@@ -4,12 +4,30 @@ from esphome.components import number, ws_bridge
 from esphome.const import CONF_MAX_VALUE, CONF_MIN_VALUE, CONF_STEP
 
 from .. import ws_bridge_ns
+from ..const import CONF_NUMBER_ID
 
 DEPENDENCIES = ["ws_bridge"]
 WsBridgeNumber = ws_bridge_ns.class_("WsBridgeNumber", number.Number, cg.Component, ws_bridge.WsBridgeDevice)
 
 
-def validate_min_max(config):
+def validate_number_range(config):
+    has_min = CONF_MIN_VALUE in config
+    has_max = CONF_MAX_VALUE in config
+    if has_min != has_max:
+        raise cv.Invalid("min_value and max_value must be set together")
+    if not has_min:
+        # No range of its own: only valid when wrapping, since the range then
+        # comes from number_id's own min/max/step at declare time (see
+        # ws_bridge_domains.h's ws_declare_number).
+        if CONF_NUMBER_ID not in config:
+            raise cv.Invalid("min_value and max_value are required unless number_id: is set")
+        if CONF_STEP in config:
+            # step alone (without min_value/max_value) would silently be
+            # dropped: ws_declare_number treats the trio as one atomic
+            # inherit-or-not decision keyed on min_value, so a lone step
+            # here would never take effect.
+            raise cv.Invalid("step requires min_value and max_value to also be set")
+        return config
     if config[CONF_MAX_VALUE] <= config[CONF_MIN_VALUE]:
         raise cv.Invalid("max_value must be greater than min_value")
     return config
@@ -19,23 +37,33 @@ CONFIG_SCHEMA = cv.All(
     number.number_schema(WsBridgeNumber)
     .extend(
         {
-            cv.Required(CONF_MIN_VALUE): cv.float_,
-            cv.Required(CONF_MAX_VALUE): cv.float_,
-            cv.Optional(CONF_STEP, default=1.0): cv.positive_float,
+            cv.Optional(CONF_MIN_VALUE): cv.float_,
+            cv.Optional(CONF_MAX_VALUE): cv.float_,
+            cv.Optional(CONF_STEP): cv.positive_float,
+            # Wrap and drive an existing ESPHome number. HA commands are
+            # applied to it (not to this entity), and its state changes are
+            # what get reported back.
+            cv.Optional(CONF_NUMBER_ID): cv.use_id(number.Number),
         }
     )
     .extend(ws_bridge.WS_BRIDGE_DEVICE_SCHEMA)
     .extend(cv.COMPONENT_SCHEMA),
-    validate_min_max,
+    validate_number_range,
 )
 
 
 async def to_code(config):
+    has_own_range = CONF_MIN_VALUE in config
     var = await number.new_number(
         config,
-        min_value=config[CONF_MIN_VALUE],
-        max_value=config[CONF_MAX_VALUE],
-        step=config[CONF_STEP],
+        min_value=config.get(CONF_MIN_VALUE, float("nan")),
+        max_value=config.get(CONF_MAX_VALUE, float("nan")),
+        # 1.0 matches the old unconditional default — only applied when this
+        # entity actually owns a range; a wrapper inheriting number_id's range
+        # must not clobber its step with this default (see ws_declare_number).
+        step=config.get(CONF_STEP, 1.0 if has_own_range else float("nan")),
     )
     await cg.register_component(var, config)
     await ws_bridge.register_ws_bridge_device(var, config)
+    if CONF_NUMBER_ID in config:
+        cg.add(var.set_source(await cg.get_variable(config[CONF_NUMBER_ID])))

--- a/components/ws_bridge/number/ws_bridge_number.cpp
+++ b/components/ws_bridge/number/ws_bridge_number.cpp
@@ -6,17 +6,25 @@ namespace ws_bridge {
 
 static const char *const TAG = "ws_bridge.number";
 
-void WsBridgeNumber::setup() { ws_subscribe_number(this, this); }
+void WsBridgeNumber::setup() { ws_subscribe_number(this, this->source_ != nullptr ? this->source_ : this); }
 
-void WsBridgeNumber::dump_config() { LOG_NUMBER("", "WS Bridge Number", this); }
+void WsBridgeNumber::dump_config() {
+  LOG_NUMBER("", "WS Bridge Number", this);
+  if (this->source_ != nullptr) ESP_LOGCONFIG(TAG, "  Wrapped: '%s'", this->source_->get_name().str().c_str());
+}
 
+// Only reached when NOT wrapping — see WsBridgeSwitch::write_state().
 void WsBridgeNumber::control(float value) { this->publish_state(value); }
 
-void WsBridgeNumber::ws_bridge_handle_command(const WsCommand &command) { ws_handle_command_number(this, command); }
+void WsBridgeNumber::ws_bridge_handle_command(const WsCommand &command) {
+  ws_handle_command_number(this->source_ != nullptr ? this->source_ : this, command);
+}
 
 void WsBridgeNumber::ws_bridge_declare() {
-  ws_declare_number(this, *this, this, this->get_name().str());
-  ws_push_state_number(this, *this);
+  number::Number &src = this->source_ != nullptr ? *this->source_ : *this;
+  const std::string own_name = this->has_own_name() ? this->get_name().str() : "";
+  ws_declare_number(this, src, this, ws_ha_name(src, own_name, this->unique_id_));
+  ws_push_state_number(this, src);
 }
 
 }  // namespace ws_bridge

--- a/components/ws_bridge/number/ws_bridge_number.cpp
+++ b/components/ws_bridge/number/ws_bridge_number.cpp
@@ -1,36 +1,22 @@
 #include "ws_bridge_number.h"
-#include "../ws_bridge.h"
-#include "../ws_bridge_entity_json.h"
+#include "../ws_bridge_domains.h"
 
 namespace esphome {
 namespace ws_bridge {
 
 static const char *const TAG = "ws_bridge.number";
 
-void WsBridgeNumber::setup() {
-  this->add_on_state_callback([this](float state) { this->parent_->send_state_float(this->unique_id_, state); });
-}
+void WsBridgeNumber::setup() { ws_subscribe_number(this, this); }
 
 void WsBridgeNumber::dump_config() { LOG_NUMBER("", "WS Bridge Number", this); }
 
 void WsBridgeNumber::control(float value) { this->publish_state(value); }
 
-void WsBridgeNumber::ws_bridge_handle_command(const WsCommand &command) {
-  if (command.action == "set_value" && command.has_value) {
-    this->make_call().set_value(command.value_float).perform();
-  }
-}
+void WsBridgeNumber::ws_bridge_handle_command(const WsCommand &command) { ws_handle_command_number(this, command); }
 
 void WsBridgeNumber::ws_bridge_declare() {
-  this->parent_->send_entity_declare(
-      this->unique_id_, "number", this->get_name().str(), this->device_id_, this->device_name_,
-      [this](JsonObject root) {
-        add_common_entity_fields(root, *this);
-        root["min"] = this->traits.get_min_value();
-        root["max"] = this->traits.get_max_value();
-        root["step"] = this->traits.get_step();
-      });
-  if (this->has_state()) this->parent_->send_state_float(this->unique_id_, this->state);
+  ws_declare_number(this, *this, this, this->get_name().str());
+  ws_push_state_number(this, *this);
 }
 
 }  // namespace ws_bridge

--- a/components/ws_bridge/number/ws_bridge_number.h
+++ b/components/ws_bridge/number/ws_bridge_number.h
@@ -8,6 +8,13 @@ namespace ws_bridge {
 
 class WsBridgeNumber : public number::Number, public Component, public WsBridgeDevice {
  public:
+  // Optional: mirror and drive an existing number instead of this platform
+  // being the number itself. Commands from HA are applied to the wrapped
+  // number, and its own state changes are what get reported back. min/max/step
+  // inherit from it too unless this platform's own min_value/max_value are
+  // set (see ws_bridge_domains.h's ws_declare_number).
+  void set_source(number::Number *source) { this->source_ = source; }
+  const EntityBase *get_ws_bridge_source() const override { return this->source_; }
   void setup() override;
   void dump_config() override;
   void ws_bridge_declare() override;
@@ -15,6 +22,7 @@ class WsBridgeNumber : public number::Number, public Component, public WsBridgeD
 
  protected:
   void control(float value) override;
+  number::Number *source_{nullptr};
 };
 
 }  // namespace ws_bridge

--- a/components/ws_bridge/number/ws_bridge_number.h
+++ b/components/ws_bridge/number/ws_bridge_number.h
@@ -11,8 +11,8 @@ class WsBridgeNumber : public number::Number, public Component, public WsBridgeD
   // Optional: mirror and drive an existing number instead of this platform
   // being the number itself. Commands from HA are applied to the wrapped
   // number, and its own state changes are what get reported back. min/max/step
-  // inherit from it too unless this platform's own min_value/max_value are
-  // set (see ws_bridge_domains.h's ws_declare_number).
+  // inherit from it per field, each one unless overridden here (see
+  // ws_bridge_domains.h's ws_declare_number).
   void set_source(number::Number *source) { this->source_ = source; }
   const EntityBase *get_ws_bridge_source() const override { return this->source_; }
   void setup() override;

--- a/components/ws_bridge/select/__init__.py
+++ b/components/ws_bridge/select/__init__.py
@@ -4,23 +4,41 @@ from esphome.components import select, ws_bridge
 from esphome.const import CONF_OPTIONS
 
 from .. import ws_bridge_ns
+from ..const import CONF_SELECT_ID
 
 DEPENDENCIES = ["ws_bridge"]
 WsBridgeSelect = ws_bridge_ns.class_("WsBridgeSelect", select.Select, cg.Component, ws_bridge.WsBridgeDevice)
 
-CONFIG_SCHEMA = (
+
+def validate_select_options(config):
+    if CONF_OPTIONS not in config and CONF_SELECT_ID not in config:
+        raise cv.Invalid("options is required unless select_id: is set")
+    return config
+
+
+CONFIG_SCHEMA = cv.All(
     select.select_schema(WsBridgeSelect)
     .extend(
         {
-            cv.Required(CONF_OPTIONS): cv.All(cv.ensure_list(cv.string_strict), cv.Length(min=1)),
+            cv.Optional(CONF_OPTIONS): cv.All(cv.ensure_list(cv.string_strict), cv.Length(min=1)),
+            # Wrap and drive an existing ESPHome select. HA commands are
+            # applied to it (not to this entity), and its state changes are
+            # what get reported back.
+            cv.Optional(CONF_SELECT_ID): cv.use_id(select.Select),
         }
     )
     .extend(ws_bridge.WS_BRIDGE_DEVICE_SCHEMA)
-    .extend(cv.COMPONENT_SCHEMA)
+    .extend(cv.COMPONENT_SCHEMA),
+    validate_select_options,
 )
 
 
 async def to_code(config):
-    var = await select.new_select(config, options=config[CONF_OPTIONS])
+    # An omitted `options:` (only valid when wrapping) leaves this entity's
+    # own SelectTraits empty, which ws_declare_select reads as "inherit the
+    # wrapped select's options" — see ws_bridge_domains.h.
+    var = await select.new_select(config, options=config.get(CONF_OPTIONS, []))
     await cg.register_component(var, config)
     await ws_bridge.register_ws_bridge_device(var, config)
+    if CONF_SELECT_ID in config:
+        cg.add(var.set_source(await cg.get_variable(config[CONF_SELECT_ID])))

--- a/components/ws_bridge/select/ws_bridge_select.cpp
+++ b/components/ws_bridge/select/ws_bridge_select.cpp
@@ -6,17 +6,25 @@ namespace ws_bridge {
 
 static const char *const TAG = "ws_bridge.select";
 
-void WsBridgeSelect::setup() { ws_subscribe_select(this, this); }
+void WsBridgeSelect::setup() { ws_subscribe_select(this, this->source_ != nullptr ? this->source_ : this); }
 
-void WsBridgeSelect::dump_config() { LOG_SELECT("", "WS Bridge Select", this); }
+void WsBridgeSelect::dump_config() {
+  LOG_SELECT("", "WS Bridge Select", this);
+  if (this->source_ != nullptr) ESP_LOGCONFIG(TAG, "  Wrapped: '%s'", this->source_->get_name().str().c_str());
+}
 
+// Only reached when NOT wrapping — see WsBridgeSwitch::write_state().
 void WsBridgeSelect::control(const std::string &value) { this->publish_state(value); }
 
-void WsBridgeSelect::ws_bridge_handle_command(const WsCommand &command) { ws_handle_command_select(this, command); }
+void WsBridgeSelect::ws_bridge_handle_command(const WsCommand &command) {
+  ws_handle_command_select(this->source_ != nullptr ? this->source_ : this, command);
+}
 
 void WsBridgeSelect::ws_bridge_declare() {
-  ws_declare_select(this, *this, this, this->get_name().str());
-  ws_push_state_select(this, *this);
+  select::Select &src = this->source_ != nullptr ? *this->source_ : *this;
+  const std::string own_name = this->has_own_name() ? this->get_name().str() : "";
+  ws_declare_select(this, src, this, ws_ha_name(src, own_name, this->unique_id_));
+  ws_push_state_select(this, src);
 }
 
 }  // namespace ws_bridge

--- a/components/ws_bridge/select/ws_bridge_select.cpp
+++ b/components/ws_bridge/select/ws_bridge_select.cpp
@@ -1,37 +1,22 @@
 #include "ws_bridge_select.h"
-#include "../ws_bridge.h"
-#include "../ws_bridge_entity_json.h"
+#include "../ws_bridge_domains.h"
 
 namespace esphome {
 namespace ws_bridge {
 
 static const char *const TAG = "ws_bridge.select";
 
-void WsBridgeSelect::setup() {
-  this->add_on_state_callback([this](size_t index) {
-    this->parent_->send_state_string(this->unique_id_, this->option_at(index));
-  });
-}
+void WsBridgeSelect::setup() { ws_subscribe_select(this, this); }
 
 void WsBridgeSelect::dump_config() { LOG_SELECT("", "WS Bridge Select", this); }
 
 void WsBridgeSelect::control(const std::string &value) { this->publish_state(value); }
 
-void WsBridgeSelect::ws_bridge_handle_command(const WsCommand &command) {
-  if (command.action == "select_option" && command.has_value) {
-    this->make_call().set_option(command.value_string).perform();
-  }
-}
+void WsBridgeSelect::ws_bridge_handle_command(const WsCommand &command) { ws_handle_command_select(this, command); }
 
 void WsBridgeSelect::ws_bridge_declare() {
-  this->parent_->send_entity_declare(
-      this->unique_id_, "select", this->get_name().str(), this->device_id_, this->device_name_,
-      [this](JsonObject root) {
-        add_common_entity_fields(root, *this);
-        JsonArray options = root["options"].to<JsonArray>();
-        for (const char *option : this->traits.get_options()) options.add(option);
-      });
-  if (this->has_state()) this->parent_->send_state_string(this->unique_id_, this->current_option().str());
+  ws_declare_select(this, *this, this, this->get_name().str());
+  ws_push_state_select(this, *this);
 }
 
 }  // namespace ws_bridge

--- a/components/ws_bridge/select/ws_bridge_select.h
+++ b/components/ws_bridge/select/ws_bridge_select.h
@@ -8,6 +8,13 @@ namespace ws_bridge {
 
 class WsBridgeSelect : public select::Select, public Component, public WsBridgeDevice {
  public:
+  // Optional: mirror and drive an existing select instead of this platform
+  // being the select itself. Commands from HA are applied to the wrapped
+  // select, and its own state changes are what get reported back. The
+  // options list inherits from it too unless this platform's own `options:`
+  // is set (see ws_bridge_domains.h's ws_declare_select).
+  void set_source(select::Select *source) { this->source_ = source; }
+  const EntityBase *get_ws_bridge_source() const override { return this->source_; }
   void setup() override;
   void dump_config() override;
   void ws_bridge_declare() override;
@@ -15,6 +22,7 @@ class WsBridgeSelect : public select::Select, public Component, public WsBridgeD
 
  protected:
   void control(const std::string &value) override;
+  select::Select *source_{nullptr};
 };
 
 }  // namespace ws_bridge

--- a/components/ws_bridge/sensor/__init__.py
+++ b/components/ws_bridge/sensor/__init__.py
@@ -1,8 +1,10 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import sensor, ws_bridge
+from esphome.const import CONF_ACCURACY_DECIMALS
 
 from .. import ws_bridge_ns
+from ..const import CONF_SENSOR_ID
 
 DEPENDENCIES = ["ws_bridge"]
 WsBridgeSensor = ws_bridge_ns.class_("WsBridgeSensor", sensor.Sensor, cg.Component, ws_bridge.WsBridgeDevice)
@@ -11,6 +13,14 @@ CONFIG_SCHEMA = (
     sensor.sensor_schema(WsBridgeSensor)
     .extend(ws_bridge.WS_BRIDGE_DEVICE_SCHEMA)
     .extend(cv.COMPONENT_SCHEMA)
+    .extend(
+        {
+            # Wrap an existing ESPHome sensor and expose it to Home Assistant.
+            # device_class/unit_of_measurement/state_class/accuracy_decimals
+            # are inherited from it unless also set here.
+            cv.Optional(CONF_SENSOR_ID): cv.use_id(sensor.Sensor),
+        }
+    )
 )
 
 
@@ -18,3 +28,9 @@ async def to_code(config):
     var = await sensor.new_sensor(config)
     await cg.register_component(var, config)
     await ws_bridge.register_ws_bridge_device(var, config)
+    if CONF_SENSOR_ID in config:
+        cg.add(var.set_source(await cg.get_variable(config[CONF_SENSOR_ID])))
+    # 0 is both Sensor's default and a legitimate value, so presence in YAML
+    # has to be a separate flag — see ws_declare_sensor().
+    if CONF_ACCURACY_DECIMALS in config:
+        cg.add(var.set_accuracy_overridden(True))

--- a/components/ws_bridge/sensor/ws_bridge_sensor.cpp
+++ b/components/ws_bridge/sensor/ws_bridge_sensor.cpp
@@ -1,30 +1,18 @@
 #include "ws_bridge_sensor.h"
-#include "../ws_bridge.h"
-#include "../ws_bridge_entity_json.h"
+#include "../ws_bridge_domains.h"
 
 namespace esphome {
 namespace ws_bridge {
 
 static const char *const TAG = "ws_bridge.sensor";
 
-void WsBridgeSensor::setup() {
-  this->add_on_state_callback([this](float state) { this->parent_->send_state_float(this->unique_id_, state); });
-}
+void WsBridgeSensor::setup() { ws_subscribe_sensor(this, this); }
 
 void WsBridgeSensor::dump_config() { LOG_SENSOR("", "WS Bridge Sensor", this); }
 
 void WsBridgeSensor::ws_bridge_declare() {
-  this->parent_->send_entity_declare(
-      this->unique_id_, "sensor", this->get_name().str(), this->device_id_, this->device_name_,
-      [this](JsonObject root) {
-        add_common_entity_fields(root, *this);
-        StringRef uom = this->get_unit_of_measurement_ref();
-        if (!uom.empty()) root["unit_of_measurement"] = uom.str();
-        sensor::StateClass sc = this->get_state_class();
-        if (sc != sensor::STATE_CLASS_NONE) root["state_class"] = LOG_STR_ARG(sensor::state_class_to_string(sc));
-        root["suggested_display_precision"] = this->get_accuracy_decimals();
-      });
-  if (this->has_state()) this->parent_->send_state_float(this->unique_id_, this->state);
+  ws_declare_sensor(this, *this, this, this->get_name().str());
+  ws_push_state_sensor(this, *this);
 }
 
 }  // namespace ws_bridge

--- a/components/ws_bridge/sensor/ws_bridge_sensor.cpp
+++ b/components/ws_bridge/sensor/ws_bridge_sensor.cpp
@@ -6,13 +6,19 @@ namespace ws_bridge {
 
 static const char *const TAG = "ws_bridge.sensor";
 
-void WsBridgeSensor::setup() { ws_subscribe_sensor(this, this); }
+void WsBridgeSensor::setup() { ws_subscribe_sensor(this, this->source_ != nullptr ? this->source_ : this); }
 
-void WsBridgeSensor::dump_config() { LOG_SENSOR("", "WS Bridge Sensor", this); }
+void WsBridgeSensor::dump_config() {
+  LOG_SENSOR("", "WS Bridge Sensor", this);
+  if (this->source_ != nullptr) ESP_LOGCONFIG(TAG, "  Wrapped: '%s'", this->source_->get_name().str().c_str());
+}
 
 void WsBridgeSensor::ws_bridge_declare() {
-  ws_declare_sensor(this, *this, this, this->get_name().str());
-  ws_push_state_sensor(this, *this);
+  sensor::Sensor &src = this->source_ != nullptr ? *this->source_ : *this;
+  const std::string own_name = this->has_own_name() ? this->get_name().str() : "";
+  ws_declare_sensor(this, src, this, ws_ha_name(src, own_name, this->unique_id_),
+                    this->accuracy_overridden_);
+  ws_push_state_sensor(this, src);
 }
 
 }  // namespace ws_bridge

--- a/components/ws_bridge/sensor/ws_bridge_sensor.h
+++ b/components/ws_bridge/sensor/ws_bridge_sensor.h
@@ -8,9 +8,19 @@ namespace ws_bridge {
 
 class WsBridgeSensor : public sensor::Sensor, public Component, public WsBridgeDevice {
  public:
+  // Optional: mirror an existing sensor instead of expecting one's own state
+  // pushed via lambdas. Metadata (device_class, unit_of_measurement, ...)
+  // inherits from it field by field; anything set on this platform still wins.
+  void set_source(sensor::Sensor *source) { this->source_ = source; }
+  void set_accuracy_overridden(bool v) { this->accuracy_overridden_ = v; }
+  const EntityBase *get_ws_bridge_source() const override { return this->source_; }
   void setup() override;
   void dump_config() override;
   void ws_bridge_declare() override;
+
+ protected:
+  sensor::Sensor *source_{nullptr};
+  bool accuracy_overridden_{false};
 };
 
 }  // namespace ws_bridge

--- a/components/ws_bridge/switch/__init__.py
+++ b/components/ws_bridge/switch/__init__.py
@@ -3,6 +3,7 @@ import esphome.config_validation as cv
 from esphome.components import switch, ws_bridge
 
 from .. import ws_bridge_ns
+from ..const import CONF_SWITCH_ID
 
 DEPENDENCIES = ["ws_bridge"]
 WsBridgeSwitch = ws_bridge_ns.class_("WsBridgeSwitch", switch.Switch, cg.Component, ws_bridge.WsBridgeDevice)
@@ -11,6 +12,14 @@ CONFIG_SCHEMA = (
     switch.switch_schema(WsBridgeSwitch)
     .extend(ws_bridge.WS_BRIDGE_DEVICE_SCHEMA)
     .extend(cv.COMPONENT_SCHEMA)
+    .extend(
+        {
+            # Wrap and drive an existing ESPHome switch. HA commands are
+            # applied to it (not to this entity), and its state changes are
+            # what get reported back — see WsBridgeSwitch::ws_bridge_handle_command.
+            cv.Optional(CONF_SWITCH_ID): cv.use_id(switch.Switch),
+        }
+    )
 )
 
 
@@ -18,3 +27,5 @@ async def to_code(config):
     var = await switch.new_switch(config)
     await cg.register_component(var, config)
     await ws_bridge.register_ws_bridge_device(var, config)
+    if CONF_SWITCH_ID in config:
+        cg.add(var.set_source(await cg.get_variable(config[CONF_SWITCH_ID])))

--- a/components/ws_bridge/switch/ws_bridge_switch.cpp
+++ b/components/ws_bridge/switch/ws_bridge_switch.cpp
@@ -6,17 +6,27 @@ namespace ws_bridge {
 
 static const char *const TAG = "ws_bridge.switch";
 
-void WsBridgeSwitch::setup() { ws_subscribe_switch(this, this); }
+void WsBridgeSwitch::setup() { ws_subscribe_switch(this, this->source_ != nullptr ? this->source_ : this); }
 
-void WsBridgeSwitch::dump_config() { LOG_SWITCH("", "WS Bridge Switch", this); }
+void WsBridgeSwitch::dump_config() {
+  LOG_SWITCH("", "WS Bridge Switch", this);
+  if (this->source_ != nullptr) ESP_LOGCONFIG(TAG, "  Wrapped: '%s'", this->source_->get_name().str().c_str());
+}
 
+// Only reached when NOT wrapping: a wrapped switch's commands are routed to
+// source_ (see ws_bridge_handle_command below), so this object is never
+// commanded directly and its own write_state() never fires in that case.
 void WsBridgeSwitch::write_state(bool state) { this->publish_state(state); }
 
-void WsBridgeSwitch::ws_bridge_handle_command(const WsCommand &command) { ws_handle_command_switch(this, command); }
+void WsBridgeSwitch::ws_bridge_handle_command(const WsCommand &command) {
+  ws_handle_command_switch(this->source_ != nullptr ? this->source_ : this, command);
+}
 
 void WsBridgeSwitch::ws_bridge_declare() {
-  ws_declare_switch(this, *this, this, this->get_name().str());
-  ws_push_state_switch(this, *this);
+  switch_::Switch &src = this->source_ != nullptr ? *this->source_ : *this;
+  const std::string own_name = this->has_own_name() ? this->get_name().str() : "";
+  ws_declare_switch(this, src, this, ws_ha_name(src, own_name, this->unique_id_));
+  ws_push_state_switch(this, src);
 }
 
 }  // namespace ws_bridge

--- a/components/ws_bridge/switch/ws_bridge_switch.cpp
+++ b/components/ws_bridge/switch/ws_bridge_switch.cpp
@@ -1,33 +1,22 @@
 #include "ws_bridge_switch.h"
-#include "../ws_bridge.h"
-#include "../ws_bridge_entity_json.h"
+#include "../ws_bridge_domains.h"
 
 namespace esphome {
 namespace ws_bridge {
 
 static const char *const TAG = "ws_bridge.switch";
 
-void WsBridgeSwitch::setup() {
-  this->add_on_state_callback([this](bool state) { this->parent_->send_state_bool(this->unique_id_, state); });
-}
+void WsBridgeSwitch::setup() { ws_subscribe_switch(this, this); }
 
 void WsBridgeSwitch::dump_config() { LOG_SWITCH("", "WS Bridge Switch", this); }
 
 void WsBridgeSwitch::write_state(bool state) { this->publish_state(state); }
 
-void WsBridgeSwitch::ws_bridge_handle_command(const WsCommand &command) {
-  if (command.action == "turn_on") {
-    this->turn_on();
-  } else if (command.action == "turn_off") {
-    this->turn_off();
-  }
-}
+void WsBridgeSwitch::ws_bridge_handle_command(const WsCommand &command) { ws_handle_command_switch(this, command); }
 
 void WsBridgeSwitch::ws_bridge_declare() {
-  this->parent_->send_entity_declare(this->unique_id_, "switch", this->get_name().str(), this->device_id_,
-                                     this->device_name_,
-                                     [this](JsonObject root) { add_common_entity_fields(root, *this); });
-  if (this->has_state()) this->parent_->send_state_bool(this->unique_id_, this->state);
+  ws_declare_switch(this, *this, this, this->get_name().str());
+  ws_push_state_switch(this, *this);
 }
 
 }  // namespace ws_bridge

--- a/components/ws_bridge/switch/ws_bridge_switch.h
+++ b/components/ws_bridge/switch/ws_bridge_switch.h
@@ -8,6 +8,12 @@ namespace ws_bridge {
 
 class WsBridgeSwitch : public switch_::Switch, public Component, public WsBridgeDevice {
  public:
+  // Optional: mirror and drive an existing switch instead of this platform
+  // being the switch itself. Commands from HA are applied to the wrapped
+  // switch (turn_on()/turn_off() on it, not on this), and its own state
+  // changes are what get reported back — see ws_bridge_domains.h.
+  void set_source(switch_::Switch *source) { this->source_ = source; }
+  const EntityBase *get_ws_bridge_source() const override { return this->source_; }
   void setup() override;
   void dump_config() override;
   void ws_bridge_declare() override;
@@ -15,6 +21,7 @@ class WsBridgeSwitch : public switch_::Switch, public Component, public WsBridge
 
  protected:
   void write_state(bool state) override;
+  switch_::Switch *source_{nullptr};
 };
 
 }  // namespace ws_bridge

--- a/components/ws_bridge/text_sensor/__init__.py
+++ b/components/ws_bridge/text_sensor/__init__.py
@@ -3,6 +3,7 @@ import esphome.config_validation as cv
 from esphome.components import text_sensor, ws_bridge
 
 from .. import ws_bridge_ns
+from ..const import CONF_TEXT_SENSOR_ID
 
 DEPENDENCIES = ["ws_bridge"]
 WsBridgeTextSensor = ws_bridge_ns.class_(
@@ -13,6 +14,12 @@ CONFIG_SCHEMA = (
     text_sensor.text_sensor_schema(WsBridgeTextSensor)
     .extend(ws_bridge.WS_BRIDGE_DEVICE_SCHEMA)
     .extend(cv.COMPONENT_SCHEMA)
+    .extend(
+        {
+            # Wrap an existing ESPHome text_sensor and expose it to Home Assistant.
+            cv.Optional(CONF_TEXT_SENSOR_ID): cv.use_id(text_sensor.TextSensor),
+        }
+    )
 )
 
 
@@ -20,3 +27,5 @@ async def to_code(config):
     var = await text_sensor.new_text_sensor(config)
     await cg.register_component(var, config)
     await ws_bridge.register_ws_bridge_device(var, config)
+    if CONF_TEXT_SENSOR_ID in config:
+        cg.add(var.set_source(await cg.get_variable(config[CONF_TEXT_SENSOR_ID])))

--- a/components/ws_bridge/text_sensor/ws_bridge_text_sensor.cpp
+++ b/components/ws_bridge/text_sensor/ws_bridge_text_sensor.cpp
@@ -1,24 +1,18 @@
 #include "ws_bridge_text_sensor.h"
-#include "../ws_bridge.h"
-#include "../ws_bridge_entity_json.h"
+#include "../ws_bridge_domains.h"
 
 namespace esphome {
 namespace ws_bridge {
 
 static const char *const TAG = "ws_bridge.text_sensor";
 
-void WsBridgeTextSensor::setup() {
-  this->add_on_state_callback(
-      [this](const std::string &state) { this->parent_->send_state_string(this->unique_id_, state); });
-}
+void WsBridgeTextSensor::setup() { ws_subscribe_text_sensor(this, this); }
 
 void WsBridgeTextSensor::dump_config() { LOG_TEXT_SENSOR("", "WS Bridge Text Sensor", this); }
 
 void WsBridgeTextSensor::ws_bridge_declare() {
-  this->parent_->send_entity_declare(this->unique_id_, "text_sensor", this->get_name().str(), this->device_id_,
-                                     this->device_name_,
-                                     [this](JsonObject root) { add_common_entity_fields(root, *this); });
-  if (this->has_state()) this->parent_->send_state_string(this->unique_id_, this->state);
+  ws_declare_text_sensor(this, *this, this, this->get_name().str());
+  ws_push_state_text_sensor(this, *this);
 }
 
 }  // namespace ws_bridge

--- a/components/ws_bridge/text_sensor/ws_bridge_text_sensor.cpp
+++ b/components/ws_bridge/text_sensor/ws_bridge_text_sensor.cpp
@@ -6,13 +6,20 @@ namespace ws_bridge {
 
 static const char *const TAG = "ws_bridge.text_sensor";
 
-void WsBridgeTextSensor::setup() { ws_subscribe_text_sensor(this, this); }
+void WsBridgeTextSensor::setup() {
+  ws_subscribe_text_sensor(this, this->source_ != nullptr ? this->source_ : this);
+}
 
-void WsBridgeTextSensor::dump_config() { LOG_TEXT_SENSOR("", "WS Bridge Text Sensor", this); }
+void WsBridgeTextSensor::dump_config() {
+  LOG_TEXT_SENSOR("", "WS Bridge Text Sensor", this);
+  if (this->source_ != nullptr) ESP_LOGCONFIG(TAG, "  Wrapped: '%s'", this->source_->get_name().str().c_str());
+}
 
 void WsBridgeTextSensor::ws_bridge_declare() {
-  ws_declare_text_sensor(this, *this, this, this->get_name().str());
-  ws_push_state_text_sensor(this, *this);
+  text_sensor::TextSensor &src = this->source_ != nullptr ? *this->source_ : *this;
+  const std::string own_name = this->has_own_name() ? this->get_name().str() : "";
+  ws_declare_text_sensor(this, src, this, ws_ha_name(src, own_name, this->unique_id_));
+  ws_push_state_text_sensor(this, src);
 }
 
 }  // namespace ws_bridge

--- a/components/ws_bridge/text_sensor/ws_bridge_text_sensor.h
+++ b/components/ws_bridge/text_sensor/ws_bridge_text_sensor.h
@@ -8,9 +8,17 @@ namespace ws_bridge {
 
 class WsBridgeTextSensor : public text_sensor::TextSensor, public Component, public WsBridgeDevice {
  public:
+  // Optional: mirror an existing text_sensor instead of expecting its own
+  // state pushed via lambdas. Metadata inherits from it field by field;
+  // anything set on this platform still wins.
+  void set_source(text_sensor::TextSensor *source) { this->source_ = source; }
+  const EntityBase *get_ws_bridge_source() const override { return this->source_; }
   void setup() override;
   void dump_config() override;
   void ws_bridge_declare() override;
+
+ protected:
+  text_sensor::TextSensor *source_{nullptr};
 };
 
 }  // namespace ws_bridge

--- a/components/ws_bridge/update/ws_bridge_update.cpp
+++ b/components/ws_bridge/update/ws_bridge_update.cpp
@@ -1,25 +1,16 @@
 #include "ws_bridge_update.h"
 #include "esphome/core/log.h"
-#include "../ws_bridge.h"
-#include "../ws_bridge_entity_json.h"
+#include "../ws_bridge_domains.h"
 
 namespace esphome {
 namespace ws_bridge {
 
 static const char *const TAG = "ws_bridge.update";
 
-void WsBridgeUpdate::setup() {
-  this->update_->add_on_state_callback([this]() { this->send_state_(); });
-}
+void WsBridgeUpdate::setup() { ws_subscribe_update(this, this->update_); }
 
 std::string WsBridgeUpdate::ha_name_() const {
-  if (!this->name_.empty())
-    return this->name_;
-  // http_request update with only `id:` gets name=id and internal: true —
-  // that id (e.g. "ota_update") must not become the HA entity name.
-  if (this->update_->has_own_name())
-    return this->update_->get_name().str();
-  return this->unique_id_;
+  return ws_ha_name(*this->update_, this->name_, this->unique_id_);
 }
 
 void WsBridgeUpdate::dump_config() {
@@ -29,44 +20,12 @@ void WsBridgeUpdate::dump_config() {
 }
 
 void WsBridgeUpdate::ws_bridge_handle_command(const WsCommand &command) {
-  if (command.action == "install") {
-    this->update_->perform();
-  } else if (command.action == "check") {
-    this->update_->check();
-  }
-}
-
-void WsBridgeUpdate::fill_state_(JsonObject value) {
-  const auto &info = this->update_->update_info;
-  if (!info.current_version.empty())
-    value["installed_version"] = info.current_version;
-  if (!info.latest_version.empty())
-    value["latest_version"] = info.latest_version;
-  value["in_progress"] = this->update_->state == update::UPDATE_STATE_INSTALLING;
-  if (info.has_progress)
-    value["progress"] = static_cast<int>(info.progress);
-  if (!info.title.empty())
-    value["title"] = info.title;
-  if (!info.summary.empty())
-    value["summary"] = info.summary;
-  if (!info.release_url.empty())
-    value["release_url"] = info.release_url;
-}
-
-void WsBridgeUpdate::send_state_() {
-  this->parent_->send_state_object(this->unique_id_, [this](JsonObject value) { this->fill_state_(value); });
+  ws_handle_command_update(this->update_, command);
 }
 
 void WsBridgeUpdate::ws_bridge_declare() {
-  this->parent_->send_entity_declare(
-      this->unique_id_, "update", this->ha_name_(), this->device_id_, this->device_name_,
-      [this](JsonObject root) {
-        add_common_entity_fields(root, *this->update_);
-        if (root["device_class"].isNull())
-          root["device_class"] = "firmware";
-      });
-  if (this->update_->has_state())
-    this->send_state_();
+  ws_declare_update(this, *this->update_, this->ha_name_());
+  ws_push_state_update(this, *this->update_);
 }
 
 }  // namespace ws_bridge

--- a/components/ws_bridge/update/ws_bridge_update.h
+++ b/components/ws_bridge/update/ws_bridge_update.h
@@ -12,6 +12,7 @@ namespace ws_bridge {
 class WsBridgeUpdate : public Component, public WsBridgeDevice {
  public:
   void set_update(update::UpdateEntity *update) { this->update_ = update; }
+  const EntityBase *get_ws_bridge_source() const override { return this->update_; }
   void set_name(const std::string &name) { this->name_ = name; }
   void setup() override;
   void dump_config() override;

--- a/components/ws_bridge/update/ws_bridge_update.h
+++ b/components/ws_bridge/update/ws_bridge_update.h
@@ -1,5 +1,4 @@
 #pragma once
-#include "esphome/components/json/json_util.h"
 #include "esphome/components/update/update_entity.h"
 #include "esphome/core/component.h"
 #include "../ws_bridge_device.h"
@@ -20,8 +19,6 @@ class WsBridgeUpdate : public Component, public WsBridgeDevice {
   void ws_bridge_handle_command(const WsCommand &command) override;
 
  protected:
-  void send_state_();
-  void fill_state_(JsonObject value);
   std::string ha_name_() const;
 
   update::UpdateEntity *update_{nullptr};

--- a/components/ws_bridge/ws_bridge.cpp
+++ b/components/ws_bridge/ws_bridge.cpp
@@ -3,6 +3,7 @@
 #include "esp_crt_bundle.h"
 #include "esp_transport_ws.h"
 #include "esphome/components/network/util.h"
+#include "esphome/core/entity_base.h"
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
@@ -143,6 +144,27 @@ void WsBridgeComponent::dump_config() {
   ESP_LOGCONFIG(TAG, "  Pong timeout: %u ms", static_cast<unsigned>(this->pong_timeout_ms_));
   ESP_LOGCONFIG(TAG, "  Reconnect backoff cap: %u ms", static_cast<unsigned>(this->reconnect_retry_ms_));
   ESP_LOGCONFIG(TAG, "  Re-announce interval: %u ms", static_cast<unsigned>(this->reannounce_interval_ms_));
+
+  for (size_t i = 0; i < this->devices_.size(); i++) {
+    const std::string &uid = this->devices_[i]->get_ws_bridge_unique_id();
+    for (size_t j = i + 1; j < this->devices_.size(); j++) {
+      if (uid == this->devices_[j]->get_ws_bridge_unique_id()) {
+        ESP_LOGW(TAG, "Duplicate unique_id '%s' — Home Assistant will treat these as one entity", uid.c_str());
+      }
+    }
+    const EntityBase *src = this->devices_[i]->get_ws_bridge_source();
+    if (src == nullptr)
+      continue;
+    for (size_t j = i + 1; j < this->devices_.size(); j++) {
+      if (this->devices_[j]->get_ws_bridge_source() != src)
+        continue;
+      ESP_LOGW(TAG,
+               "Entity '%s' is exposed twice (unique_ids '%s' and '%s') — pick either "
+               "`platform: ws_bridge` wrapping (*_id:) or `entities:`, not both",
+               src->get_name().str().c_str(), uid.c_str(),
+               this->devices_[j]->get_ws_bridge_unique_id().c_str());
+    }
+  }
 }
 
 // May be called from either the main loop task or the esp_websocket_client

--- a/components/ws_bridge/ws_bridge_device.h
+++ b/components/ws_bridge/ws_bridge_device.h
@@ -18,7 +18,15 @@ class WsBridgeDevice {
   void set_device_id(const std::string &id) { this->device_id_ = id; }
   void set_device_name(const std::string &name) { this->device_name_ = name; }
 
+  // Read side of the identity fields above. These exist so the per-domain
+  // helpers in ws_bridge_domains.h can be plain free functions taking a
+  // WsBridgeDevice — the same helper then serves both a `platform: ws_bridge`
+  // entity (which is its own source) and a wrapper pointing at a foreign
+  // entity, without either duplicating the declare/state/command logic.
   const std::string &get_ws_bridge_unique_id() const { return this->unique_id_; }
+  const std::string &get_ws_bridge_device_id() const { return this->device_id_; }
+  const std::string &get_ws_bridge_device_name() const { return this->device_name_; }
+  WsBridgeComponent *get_ws_bridge_parent() const { return this->parent_; }
 
   // Ask this entity to send its ws_bridge/entity declaration (and, if it has
   // one, its current state) over the parent connection. Called by the hub

--- a/components/ws_bridge/ws_bridge_device.h
+++ b/components/ws_bridge/ws_bridge_device.h
@@ -3,6 +3,9 @@
 #include "ws_protocol.h"
 
 namespace esphome {
+
+class EntityBase;
+
 namespace ws_bridge {
 
 class WsBridgeComponent;
@@ -37,6 +40,12 @@ class WsBridgeDevice {
   // Read-only platforms (sensor/binary_sensor) never receive commands and
   // keep the no-op default.
   virtual void ws_bridge_handle_command(const WsCommand &command) {}
+
+  // The ESPHome entity this device wraps, if any (`*_id:` / `entities:`
+  // `source_id:`). Null for a plain `platform: ws_bridge` entity that is its
+  // own source. Used by the hub's dump_config() to warn when the same source
+  // is exposed twice.
+  virtual const EntityBase *get_ws_bridge_source() const { return nullptr; }
 
  protected:
   WsBridgeComponent *parent_{nullptr};

--- a/components/ws_bridge/ws_bridge_domains.h
+++ b/components/ws_bridge/ws_bridge_domains.h
@@ -1,0 +1,311 @@
+#pragma once
+#include <string>
+#include "esphome/core/defines.h"
+#include "esphome/core/entity_base.h"
+#include "esphome/core/log.h"
+#include "ws_bridge.h"
+#include "ws_bridge_device.h"
+#include "ws_bridge_entity_json.h"
+
+#ifdef USE_SENSOR
+#include "esphome/components/sensor/sensor.h"
+#endif
+#ifdef USE_BINARY_SENSOR
+#include "esphome/components/binary_sensor/binary_sensor.h"
+#endif
+#ifdef USE_TEXT_SENSOR
+#include "esphome/components/text_sensor/text_sensor.h"
+#endif
+#ifdef USE_SWITCH
+#include "esphome/components/switch/switch.h"
+#endif
+#ifdef USE_NUMBER
+#include "esphome/components/number/number.h"
+#endif
+#ifdef USE_SELECT
+#include "esphome/components/select/select.h"
+#endif
+#ifdef USE_BUTTON
+#include "esphome/components/button/button.h"
+#endif
+#ifdef USE_UPDATE
+#include "esphome/components/update/update_entity.h"
+#endif
+
+namespace esphome {
+namespace ws_bridge {
+
+// Per-domain protocol logic, factored out of the platform classes so that the
+// *source* of an entity's state and metadata is a parameter rather than
+// baked-in `this`.
+//
+// Every helper takes the WsBridgeDevice that owns the protocol-facing identity
+// (unique_id, device grouping, the hub pointer) plus the ESPHome entity the
+// data actually comes from:
+//
+//   dev   the ws_bridge identity
+//   src   where state and metadata are read from — the wrapped entity when
+//         this is a wrapper, otherwise the ws_bridge entity itself
+//   ovr   (declare only, may be null) the ws_bridge-side entity holding what
+//         the YAML set explicitly; see add_common_entity_fields()
+//
+// For a plain `platform: ws_bridge` entity src and ovr are the same object and
+// the fallback collapses to a no-op. For a wrapper they differ, and that is
+// the point: device_class, unit_of_measurement, state_class, options and so on
+// come from the wrapped entity without being re-declared in YAML, while
+// anything written on the ws_bridge platform still wins.
+//
+// Sources are taken by non-const reference/pointer throughout: several ESPHome
+// entity getters (get_state_class(), traits accessors, ...) are not
+// const-qualified.
+//
+// Each domain provides up to four helpers:
+//   ws_declare_*         send the ws_bridge/entity declaration
+//   ws_push_state_*      send the current state, if the source has one
+//   ws_subscribe_*       forward every future state change to the hub
+//   ws_handle_command_*  apply an incoming HA command (writable domains only)
+
+// HA-facing name for a wrapped entity. An explicit `name:` on the ws_bridge
+// side always wins. Otherwise the source's own name is used — but only if it
+// really has one: an ESPHome entity declared with just `id:` gets name=id and
+// internal: true, and that id must not leak into HA as the entity name. The
+// unique_id is the last resort.
+inline std::string ws_ha_name(const EntityBase &src, const std::string &name_override, const std::string &fallback) {
+  if (!name_override.empty())
+    return name_override;
+  if (src.has_own_name())
+    return src.get_name().str();
+  return fallback;
+}
+
+#ifdef USE_SENSOR
+inline void ws_declare_sensor(WsBridgeDevice *dev, sensor::Sensor &src, sensor::Sensor *ovr,
+                              const std::string &name) {
+  dev->get_ws_bridge_parent()->send_entity_declare(
+      dev->get_ws_bridge_unique_id(), "sensor", name, dev->get_ws_bridge_device_id(),
+      dev->get_ws_bridge_device_name(), [&src, ovr](JsonObject root) {
+        add_common_entity_fields(root, src, ovr);
+
+        StringRef uom = src.get_unit_of_measurement_ref();
+        if (ovr != nullptr && !ovr->get_unit_of_measurement_ref().empty())
+          uom = ovr->get_unit_of_measurement_ref();
+        if (!uom.empty()) root["unit_of_measurement"] = uom.str();
+
+        sensor::StateClass sc = src.get_state_class();
+        if (ovr != nullptr && ovr->get_state_class() != sensor::STATE_CLASS_NONE) sc = ovr->get_state_class();
+        if (sc != sensor::STATE_CLASS_NONE) root["state_class"] = LOG_STR_ARG(sensor::state_class_to_string(sc));
+
+        // No "unset" value to test against — 0 is both the default and a
+        // legitimate precision — so this cannot fall back per-field like the
+        // ones above. Sensor wrapping will have to let codegen say whether the
+        // YAML wrote accuracy_decimals at all.
+        root["suggested_display_precision"] =
+            ovr != nullptr ? ovr->get_accuracy_decimals() : src.get_accuracy_decimals();
+      });
+}
+
+inline void ws_push_state_sensor(WsBridgeDevice *dev, sensor::Sensor &src) {
+  if (src.has_state()) dev->get_ws_bridge_parent()->send_state_float(dev->get_ws_bridge_unique_id(), src.state);
+}
+
+inline void ws_subscribe_sensor(WsBridgeDevice *dev, sensor::Sensor *src) {
+  src->add_on_state_callback(
+      [dev](float state) { dev->get_ws_bridge_parent()->send_state_float(dev->get_ws_bridge_unique_id(), state); });
+}
+#endif  // USE_SENSOR
+
+#ifdef USE_BINARY_SENSOR
+inline void ws_declare_binary_sensor(WsBridgeDevice *dev, binary_sensor::BinarySensor &src,
+                                     binary_sensor::BinarySensor *ovr, const std::string &name) {
+  dev->get_ws_bridge_parent()->send_entity_declare(
+      dev->get_ws_bridge_unique_id(), "binary_sensor", name, dev->get_ws_bridge_device_id(),
+      dev->get_ws_bridge_device_name(), [&src, ovr](JsonObject root) { add_common_entity_fields(root, src, ovr); });
+}
+
+inline void ws_push_state_binary_sensor(WsBridgeDevice *dev, binary_sensor::BinarySensor &src) {
+  if (src.has_state()) dev->get_ws_bridge_parent()->send_state_bool(dev->get_ws_bridge_unique_id(), src.state);
+}
+
+inline void ws_subscribe_binary_sensor(WsBridgeDevice *dev, binary_sensor::BinarySensor *src) {
+  src->add_on_state_callback(
+      [dev](bool state) { dev->get_ws_bridge_parent()->send_state_bool(dev->get_ws_bridge_unique_id(), state); });
+}
+#endif  // USE_BINARY_SENSOR
+
+#ifdef USE_TEXT_SENSOR
+inline void ws_declare_text_sensor(WsBridgeDevice *dev, text_sensor::TextSensor &src, text_sensor::TextSensor *ovr,
+                                   const std::string &name) {
+  dev->get_ws_bridge_parent()->send_entity_declare(
+      dev->get_ws_bridge_unique_id(), "text_sensor", name, dev->get_ws_bridge_device_id(),
+      dev->get_ws_bridge_device_name(), [&src, ovr](JsonObject root) { add_common_entity_fields(root, src, ovr); });
+}
+
+inline void ws_push_state_text_sensor(WsBridgeDevice *dev, text_sensor::TextSensor &src) {
+  if (src.has_state()) dev->get_ws_bridge_parent()->send_state_string(dev->get_ws_bridge_unique_id(), src.state);
+}
+
+inline void ws_subscribe_text_sensor(WsBridgeDevice *dev, text_sensor::TextSensor *src) {
+  src->add_on_state_callback([dev](const std::string &state) {
+    dev->get_ws_bridge_parent()->send_state_string(dev->get_ws_bridge_unique_id(), state);
+  });
+}
+#endif  // USE_TEXT_SENSOR
+
+#ifdef USE_SWITCH
+inline void ws_declare_switch(WsBridgeDevice *dev, switch_::Switch &src, switch_::Switch *ovr,
+                              const std::string &name) {
+  dev->get_ws_bridge_parent()->send_entity_declare(
+      dev->get_ws_bridge_unique_id(), "switch", name, dev->get_ws_bridge_device_id(),
+      dev->get_ws_bridge_device_name(), [&src, ovr](JsonObject root) { add_common_entity_fields(root, src, ovr); });
+}
+
+inline void ws_push_state_switch(WsBridgeDevice *dev, switch_::Switch &src) {
+  if (src.has_state()) dev->get_ws_bridge_parent()->send_state_bool(dev->get_ws_bridge_unique_id(), src.state);
+}
+
+inline void ws_subscribe_switch(WsBridgeDevice *dev, switch_::Switch *src) {
+  src->add_on_state_callback(
+      [dev](bool state) { dev->get_ws_bridge_parent()->send_state_bool(dev->get_ws_bridge_unique_id(), state); });
+}
+
+inline void ws_handle_command_switch(switch_::Switch *target, const WsCommand &command) {
+  if (command.action == "turn_on") {
+    target->turn_on();
+  } else if (command.action == "turn_off") {
+    target->turn_off();
+  }
+}
+#endif  // USE_SWITCH
+
+#ifdef USE_NUMBER
+inline void ws_declare_number(WsBridgeDevice *dev, number::Number &src, number::Number *ovr,
+                              const std::string &name) {
+  dev->get_ws_bridge_parent()->send_entity_declare(
+      dev->get_ws_bridge_unique_id(), "number", name, dev->get_ws_bridge_device_id(),
+      dev->get_ws_bridge_device_name(), [&src, ovr](JsonObject root) {
+        add_common_entity_fields(root, src, ovr);
+        // min/max/step have no "unset" value either, so they are taken as a
+        // set from whichever side is authoritative rather than field by field.
+        auto &traits = ovr != nullptr ? ovr->traits : src.traits;
+        root["min"] = traits.get_min_value();
+        root["max"] = traits.get_max_value();
+        root["step"] = traits.get_step();
+      });
+}
+
+inline void ws_push_state_number(WsBridgeDevice *dev, number::Number &src) {
+  if (src.has_state()) dev->get_ws_bridge_parent()->send_state_float(dev->get_ws_bridge_unique_id(), src.state);
+}
+
+inline void ws_subscribe_number(WsBridgeDevice *dev, number::Number *src) {
+  src->add_on_state_callback(
+      [dev](float state) { dev->get_ws_bridge_parent()->send_state_float(dev->get_ws_bridge_unique_id(), state); });
+}
+
+inline void ws_handle_command_number(number::Number *target, const WsCommand &command) {
+  if (command.action == "set_value" && command.has_value) {
+    target->make_call().set_value(command.value_float).perform();
+  }
+}
+#endif  // USE_NUMBER
+
+#ifdef USE_SELECT
+inline void ws_declare_select(WsBridgeDevice *dev, select::Select &src, select::Select *ovr,
+                              const std::string &name) {
+  dev->get_ws_bridge_parent()->send_entity_declare(
+      dev->get_ws_bridge_unique_id(), "select", name, dev->get_ws_bridge_device_id(),
+      dev->get_ws_bridge_device_name(), [&src, ovr](JsonObject root) {
+        add_common_entity_fields(root, src, ovr);
+        // Same as number's min/max: an options list is all-or-nothing.
+        auto &traits = ovr != nullptr ? ovr->traits : src.traits;
+        JsonArray options = root["options"].to<JsonArray>();
+        for (const char *option : traits.get_options()) options.add(option);
+      });
+}
+
+inline void ws_push_state_select(WsBridgeDevice *dev, select::Select &src) {
+  if (src.has_state())
+    dev->get_ws_bridge_parent()->send_state_string(dev->get_ws_bridge_unique_id(), src.current_option().str());
+}
+
+inline void ws_subscribe_select(WsBridgeDevice *dev, select::Select *src) {
+  src->add_on_state_callback([dev, src](size_t index) {
+    dev->get_ws_bridge_parent()->send_state_string(dev->get_ws_bridge_unique_id(), src->option_at(index));
+  });
+}
+
+inline void ws_handle_command_select(select::Select *target, const WsCommand &command) {
+  if (command.action == "select_option" && command.has_value) {
+    target->make_call().set_option(command.value_string).perform();
+  }
+}
+#endif  // USE_SELECT
+
+#ifdef USE_BUTTON
+inline void ws_declare_button(WsBridgeDevice *dev, button::Button &src, button::Button *ovr,
+                              const std::string &name) {
+  dev->get_ws_bridge_parent()->send_entity_declare(
+      dev->get_ws_bridge_unique_id(), "button", name, dev->get_ws_bridge_device_id(),
+      dev->get_ws_bridge_device_name(), [&src, ovr](JsonObject root) { add_common_entity_fields(root, src, ovr); });
+}
+
+inline void ws_handle_command_button(button::Button *target, const WsCommand &command) {
+  if (command.action == "press") target->press();
+}
+#endif  // USE_BUTTON
+
+#ifdef USE_UPDATE
+inline void ws_fill_state_update(update::UpdateEntity &src, JsonObject value) {
+  const auto &info = src.update_info;
+  if (!info.current_version.empty())
+    value["installed_version"] = info.current_version;
+  if (!info.latest_version.empty())
+    value["latest_version"] = info.latest_version;
+  value["in_progress"] = src.state == update::UPDATE_STATE_INSTALLING;
+  if (info.has_progress)
+    value["progress"] = static_cast<int>(info.progress);
+  if (!info.title.empty())
+    value["title"] = info.title;
+  if (!info.summary.empty())
+    value["summary"] = info.summary;
+  if (!info.release_url.empty())
+    value["release_url"] = info.release_url;
+}
+
+inline void ws_send_state_update(WsBridgeDevice *dev, update::UpdateEntity &src) {
+  dev->get_ws_bridge_parent()->send_state_object(dev->get_ws_bridge_unique_id(),
+                                                 [&src](JsonObject value) { ws_fill_state_update(src, value); });
+}
+
+// No `ovr`: WsBridgeUpdate is a bare Component rather than an UpdateEntity, so
+// it has no entity metadata of its own to override with — `name:` is its only
+// presentation option and that is resolved by the caller via ws_ha_name().
+inline void ws_declare_update(WsBridgeDevice *dev, update::UpdateEntity &src, const std::string &name) {
+  dev->get_ws_bridge_parent()->send_entity_declare(dev->get_ws_bridge_unique_id(), "update", name,
+                                                   dev->get_ws_bridge_device_id(), dev->get_ws_bridge_device_name(),
+                                                   [&src](JsonObject root) {
+                                                     add_common_entity_fields(root, src, nullptr);
+                                                     if (root["device_class"].isNull())
+                                                       root["device_class"] = "firmware";
+                                                   });
+}
+
+inline void ws_push_state_update(WsBridgeDevice *dev, update::UpdateEntity &src) {
+  if (src.has_state()) ws_send_state_update(dev, src);
+}
+
+inline void ws_subscribe_update(WsBridgeDevice *dev, update::UpdateEntity *src) {
+  src->add_on_state_callback([dev, src]() { ws_send_state_update(dev, *src); });
+}
+
+inline void ws_handle_command_update(update::UpdateEntity *target, const WsCommand &command) {
+  if (command.action == "install") {
+    target->perform();
+  } else if (command.action == "check") {
+    target->check();
+  }
+}
+#endif  // USE_UPDATE
+
+}  // namespace ws_bridge
+}  // namespace esphome

--- a/components/ws_bridge/ws_bridge_domains.h
+++ b/components/ws_bridge/ws_bridge_domains.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cmath>
 #include <string>
 #include "esphome/core/defines.h"
 #include "esphome/core/entity_base.h"
@@ -80,10 +81,10 @@ inline std::string ws_ha_name(const EntityBase &src, const std::string &name_ove
 
 #ifdef USE_SENSOR
 inline void ws_declare_sensor(WsBridgeDevice *dev, sensor::Sensor &src, sensor::Sensor *ovr,
-                              const std::string &name) {
+                              const std::string &name, bool accuracy_overridden = false) {
   dev->get_ws_bridge_parent()->send_entity_declare(
       dev->get_ws_bridge_unique_id(), "sensor", name, dev->get_ws_bridge_device_id(),
-      dev->get_ws_bridge_device_name(), [&src, ovr](JsonObject root) {
+      dev->get_ws_bridge_device_name(), [&src, ovr, accuracy_overridden](JsonObject root) {
         add_common_entity_fields(root, src, ovr);
 
         StringRef uom = src.get_unit_of_measurement_ref();
@@ -95,12 +96,17 @@ inline void ws_declare_sensor(WsBridgeDevice *dev, sensor::Sensor &src, sensor::
         if (ovr != nullptr && ovr->get_state_class() != sensor::STATE_CLASS_NONE) sc = ovr->get_state_class();
         if (sc != sensor::STATE_CLASS_NONE) root["state_class"] = LOG_STR_ARG(sensor::state_class_to_string(sc));
 
-        // No "unset" value to test against — 0 is both the default and a
-        // legitimate precision — so this cannot fall back per-field like the
-        // ones above. Sensor wrapping will have to let codegen say whether the
-        // YAML wrote accuracy_decimals at all.
-        root["suggested_display_precision"] =
-            ovr != nullptr ? ovr->get_accuracy_decimals() : src.get_accuracy_decimals();
+        // Sensor::get_accuracy_decimals() returns 0 both when never set and
+        // when genuinely set to 0 — ESPHome tracks the real "was it
+        // overridden" bit internally but doesn't expose it. Codegen sets
+        // accuracy_overridden when YAML contained `accuracy_decimals:`
+        // (including an explicit 0), so a wrapper can force fewer decimals
+        // than a more precise source. Number min/max/step and select options
+        // don't need this: their "unset" sentinels (NaN / empty list) are
+        // not legitimate values, so presence in YAML is already visible.
+        int8_t accuracy = src.get_accuracy_decimals();
+        if (ovr != nullptr && accuracy_overridden) accuracy = ovr->get_accuracy_decimals();
+        root["suggested_display_precision"] = accuracy;
       });
 }
 
@@ -184,9 +190,12 @@ inline void ws_declare_number(WsBridgeDevice *dev, number::Number &src, number::
       dev->get_ws_bridge_unique_id(), "number", name, dev->get_ws_bridge_device_id(),
       dev->get_ws_bridge_device_name(), [&src, ovr](JsonObject root) {
         add_common_entity_fields(root, src, ovr);
-        // min/max/step have no "unset" value either, so they are taken as a
-        // set from whichever side is authoritative rather than field by field.
-        auto &traits = ovr != nullptr ? ovr->traits : src.traits;
+        // min/max/step are taken as one atomic set rather than field by
+        // field: NumberTraits default-initializes all three to NAN, and
+        // codegen only ever calls set_min_value()/set_max_value()/set_step()
+        // together (see number/__init__.py's schema validation) — so a
+        // non-NaN min on ovr means the whole trio was explicitly given.
+        auto &traits = (ovr != nullptr && !std::isnan(ovr->traits.get_min_value())) ? ovr->traits : src.traits;
         root["min"] = traits.get_min_value();
         root["max"] = traits.get_max_value();
         root["step"] = traits.get_step();
@@ -216,8 +225,12 @@ inline void ws_declare_select(WsBridgeDevice *dev, select::Select &src, select::
       dev->get_ws_bridge_unique_id(), "select", name, dev->get_ws_bridge_device_id(),
       dev->get_ws_bridge_device_name(), [&src, ovr](JsonObject root) {
         add_common_entity_fields(root, src, ovr);
-        // Same as number's min/max: an options list is all-or-nothing.
-        auto &traits = ovr != nullptr ? ovr->traits : src.traits;
+        // An empty options list is SelectTraits' own default (see
+        // FixedVector's default constructor) and select_schema() requires
+        // `options:` whenever select_id: isn't set, so "ovr has options" is
+        // an unambiguous "was this explicitly given" signal — no separate
+        // flag needed, unlike accuracy_decimals.
+        auto &traits = (ovr != nullptr && !ovr->traits.get_options().empty()) ? ovr->traits : src.traits;
         JsonArray options = root["options"].to<JsonArray>();
         for (const char *option : traits.get_options()) options.add(option);
       });

--- a/components/ws_bridge/ws_bridge_domains.h
+++ b/components/ws_bridge/ws_bridge_domains.h
@@ -190,15 +190,21 @@ inline void ws_declare_number(WsBridgeDevice *dev, number::Number &src, number::
       dev->get_ws_bridge_unique_id(), "number", name, dev->get_ws_bridge_device_id(),
       dev->get_ws_bridge_device_name(), [&src, ovr](JsonObject root) {
         add_common_entity_fields(root, src, ovr);
-        // min/max/step are taken as one atomic set rather than field by
-        // field: NumberTraits default-initializes all three to NAN, and
-        // codegen only ever calls set_min_value()/set_max_value()/set_step()
-        // together (see number/__init__.py's schema validation) — so a
-        // non-NaN min on ovr means the whole trio was explicitly given.
-        auto &traits = (ovr != nullptr && !std::isnan(ovr->traits.get_min_value())) ? ovr->traits : src.traits;
-        root["min"] = traits.get_min_value();
-        root["max"] = traits.get_max_value();
-        root["step"] = traits.get_step();
+        // Each of min/max/step falls back to src independently, so a wrapper
+        // can override the range without also having to restate the step.
+        // NumberTraits default-initializes all three to NAN and codegen leaves
+        // them NaN when the YAML key was absent, so NaN means "inherit".
+        float min_value = src.traits.get_min_value();
+        float max_value = src.traits.get_max_value();
+        float step = src.traits.get_step();
+        if (ovr != nullptr) {
+          if (!std::isnan(ovr->traits.get_min_value())) min_value = ovr->traits.get_min_value();
+          if (!std::isnan(ovr->traits.get_max_value())) max_value = ovr->traits.get_max_value();
+          if (!std::isnan(ovr->traits.get_step())) step = ovr->traits.get_step();
+        }
+        root["min"] = min_value;
+        root["max"] = max_value;
+        root["step"] = step;
       });
 }
 

--- a/components/ws_bridge/ws_bridge_entity_json.h
+++ b/components/ws_bridge/ws_bridge_entity_json.h
@@ -21,10 +21,11 @@ namespace ws_bridge {
 // ws_bridge platform still win.
 //
 // Every field here has an unambiguous "unset" value (empty string, or
-// ENTITY_CATEGORY_NONE), so the fallback needs no extra flags. Fields where
-// the default is a legitimate value — sensor's accuracy_decimals, whose 0 is
-// indistinguishable from "not written" — cannot be resolved this way and need
-// codegen to say explicitly whether to inherit.
+// ENTITY_CATEGORY_NONE), so the fallback needs no extra flags. Sensor
+// accuracy_decimals is the exception (0 is both the default and a legitimate
+// value) and is resolved by ws_declare_sensor()'s accuracy_overridden flag
+// instead. Number min/max/step (NaN) and select options (empty list) have
+// usable sentinels, so those helpers key off the traits themselves.
 inline void add_common_entity_fields(JsonObject root, const EntityBase &src, const EntityBase *ovr) {
   std::array<char, MAX_DEVICE_CLASS_LENGTH> dc_ovr_buf;
   std::array<char, MAX_DEVICE_CLASS_LENGTH> dc_src_buf;

--- a/components/ws_bridge/ws_bridge_entity_json.h
+++ b/components/ws_bridge/ws_bridge_entity_json.h
@@ -11,16 +11,36 @@ namespace ws_bridge {
 // metadata. Platform-specific fields (unit_of_measurement/state_class for
 // sensor, options for select, min/max/step for number, ...) are added by each
 // platform's own ws_bridge_declare() on top of this.
-inline void add_common_entity_fields(JsonObject root, const EntityBase &entity) {
-  std::array<char, MAX_DEVICE_CLASS_LENGTH> dc_buf;
-  const char *dc = entity.get_device_class_to(dc_buf);
+//
+// `src` is where the metadata comes from — the wrapped entity when this
+// ws_bridge entity wraps a foreign one, otherwise the ws_bridge entity itself.
+// `ovr` (may be null) is the ws_bridge-side entity carrying whatever the YAML
+// set explicitly: each field is taken from `ovr` when set there and falls back
+// to `src` otherwise. So wrapping inherits the wrapped entity's presentation
+// for free, while `icon:`/`device_class:`/`entity_category:` written on the
+// ws_bridge platform still win.
+//
+// Every field here has an unambiguous "unset" value (empty string, or
+// ENTITY_CATEGORY_NONE), so the fallback needs no extra flags. Fields where
+// the default is a legitimate value — sensor's accuracy_decimals, whose 0 is
+// indistinguishable from "not written" — cannot be resolved this way and need
+// codegen to say explicitly whether to inherit.
+inline void add_common_entity_fields(JsonObject root, const EntityBase &src, const EntityBase *ovr) {
+  std::array<char, MAX_DEVICE_CLASS_LENGTH> dc_ovr_buf;
+  std::array<char, MAX_DEVICE_CLASS_LENGTH> dc_src_buf;
+  const char *dc = ovr != nullptr ? ovr->get_device_class_to(dc_ovr_buf) : nullptr;
+  if (dc == nullptr || dc[0] == '\0') dc = src.get_device_class_to(dc_src_buf);
   if (dc != nullptr && dc[0] != '\0') root["device_class"] = dc;
 
-  std::array<char, MAX_ICON_LENGTH> icon_buf;
-  const char *icon = entity.get_icon_to(icon_buf);
+  std::array<char, MAX_ICON_LENGTH> icon_ovr_buf;
+  std::array<char, MAX_ICON_LENGTH> icon_src_buf;
+  const char *icon = ovr != nullptr ? ovr->get_icon_to(icon_ovr_buf) : nullptr;
+  if (icon == nullptr || icon[0] == '\0') icon = src.get_icon_to(icon_src_buf);
   if (icon != nullptr && icon[0] != '\0') root["icon"] = icon;
 
-  switch (entity.get_entity_category()) {
+  EntityCategory category = ovr != nullptr ? ovr->get_entity_category() : ENTITY_CATEGORY_NONE;
+  if (category == ENTITY_CATEGORY_NONE) category = src.get_entity_category();
+  switch (category) {
     case ENTITY_CATEGORY_CONFIG:
       root["entity_category"] = "config";
       break;

--- a/components/ws_bridge/ws_bridge_entity_ref.cpp
+++ b/components/ws_bridge/ws_bridge_entity_ref.cpp
@@ -1,0 +1,128 @@
+#include "ws_bridge_entity_ref.h"
+#include "esphome/core/log.h"
+#include "ws_bridge_domains.h"
+
+namespace esphome {
+namespace ws_bridge {
+
+static const char *const TAG = "ws_bridge.entity_ref";
+
+#ifdef USE_SENSOR
+void WsBridgeSensorRef::setup() { ws_subscribe_sensor(this, this->source_); }
+void WsBridgeSensorRef::dump_config() {
+  ESP_LOGCONFIG(TAG, "WS Bridge Entity Ref '%s' -> sensor '%s'", this->get_ws_bridge_unique_id().c_str(),
+                this->source_->get_name().str().c_str());
+}
+void WsBridgeSensorRef::ws_bridge_declare() {
+  ws_declare_sensor(this, *this->source_, nullptr,
+                    ws_ha_name(*this->source_, this->name_override_, this->get_ws_bridge_unique_id()));
+  ws_push_state_sensor(this, *this->source_);
+}
+#endif
+
+#ifdef USE_BINARY_SENSOR
+void WsBridgeBinarySensorRef::setup() { ws_subscribe_binary_sensor(this, this->source_); }
+void WsBridgeBinarySensorRef::dump_config() {
+  ESP_LOGCONFIG(TAG, "WS Bridge Entity Ref '%s' -> binary_sensor '%s'", this->get_ws_bridge_unique_id().c_str(),
+                this->source_->get_name().str().c_str());
+}
+void WsBridgeBinarySensorRef::ws_bridge_declare() {
+  ws_declare_binary_sensor(this, *this->source_, nullptr,
+                           ws_ha_name(*this->source_, this->name_override_, this->get_ws_bridge_unique_id()));
+  ws_push_state_binary_sensor(this, *this->source_);
+}
+#endif
+
+#ifdef USE_TEXT_SENSOR
+void WsBridgeTextSensorRef::setup() { ws_subscribe_text_sensor(this, this->source_); }
+void WsBridgeTextSensorRef::dump_config() {
+  ESP_LOGCONFIG(TAG, "WS Bridge Entity Ref '%s' -> text_sensor '%s'", this->get_ws_bridge_unique_id().c_str(),
+                this->source_->get_name().str().c_str());
+}
+void WsBridgeTextSensorRef::ws_bridge_declare() {
+  ws_declare_text_sensor(this, *this->source_, nullptr,
+                         ws_ha_name(*this->source_, this->name_override_, this->get_ws_bridge_unique_id()));
+  ws_push_state_text_sensor(this, *this->source_);
+}
+#endif
+
+#ifdef USE_SWITCH
+void WsBridgeSwitchRef::setup() { ws_subscribe_switch(this, this->source_); }
+void WsBridgeSwitchRef::dump_config() {
+  ESP_LOGCONFIG(TAG, "WS Bridge Entity Ref '%s' -> switch '%s'", this->get_ws_bridge_unique_id().c_str(),
+                this->source_->get_name().str().c_str());
+}
+void WsBridgeSwitchRef::ws_bridge_declare() {
+  ws_declare_switch(this, *this->source_, nullptr,
+                    ws_ha_name(*this->source_, this->name_override_, this->get_ws_bridge_unique_id()));
+  ws_push_state_switch(this, *this->source_);
+}
+void WsBridgeSwitchRef::ws_bridge_handle_command(const WsCommand &command) {
+  ws_handle_command_switch(this->source_, command);
+}
+#endif
+
+#ifdef USE_NUMBER
+void WsBridgeNumberRef::setup() { ws_subscribe_number(this, this->source_); }
+void WsBridgeNumberRef::dump_config() {
+  ESP_LOGCONFIG(TAG, "WS Bridge Entity Ref '%s' -> number '%s'", this->get_ws_bridge_unique_id().c_str(),
+                this->source_->get_name().str().c_str());
+}
+void WsBridgeNumberRef::ws_bridge_declare() {
+  ws_declare_number(this, *this->source_, nullptr,
+                    ws_ha_name(*this->source_, this->name_override_, this->get_ws_bridge_unique_id()));
+  ws_push_state_number(this, *this->source_);
+}
+void WsBridgeNumberRef::ws_bridge_handle_command(const WsCommand &command) {
+  ws_handle_command_number(this->source_, command);
+}
+#endif
+
+#ifdef USE_SELECT
+void WsBridgeSelectRef::setup() { ws_subscribe_select(this, this->source_); }
+void WsBridgeSelectRef::dump_config() {
+  ESP_LOGCONFIG(TAG, "WS Bridge Entity Ref '%s' -> select '%s'", this->get_ws_bridge_unique_id().c_str(),
+                this->source_->get_name().str().c_str());
+}
+void WsBridgeSelectRef::ws_bridge_declare() {
+  ws_declare_select(this, *this->source_, nullptr,
+                    ws_ha_name(*this->source_, this->name_override_, this->get_ws_bridge_unique_id()));
+  ws_push_state_select(this, *this->source_);
+}
+void WsBridgeSelectRef::ws_bridge_handle_command(const WsCommand &command) {
+  ws_handle_command_select(this->source_, command);
+}
+#endif
+
+#ifdef USE_BUTTON
+void WsBridgeButtonRef::dump_config() {
+  ESP_LOGCONFIG(TAG, "WS Bridge Entity Ref '%s' -> button '%s'", this->get_ws_bridge_unique_id().c_str(),
+                this->source_->get_name().str().c_str());
+}
+void WsBridgeButtonRef::ws_bridge_declare() {
+  ws_declare_button(this, *this->source_, nullptr,
+                    ws_ha_name(*this->source_, this->name_override_, this->get_ws_bridge_unique_id()));
+}
+void WsBridgeButtonRef::ws_bridge_handle_command(const WsCommand &command) {
+  ws_handle_command_button(this->source_, command);
+}
+#endif
+
+#ifdef USE_UPDATE
+void WsBridgeUpdateRef::setup() { ws_subscribe_update(this, this->source_); }
+void WsBridgeUpdateRef::dump_config() {
+  ESP_LOGCONFIG(TAG, "WS Bridge Entity Ref '%s' -> update '%s'", this->get_ws_bridge_unique_id().c_str(),
+                this->source_->get_name().str().c_str());
+}
+void WsBridgeUpdateRef::ws_bridge_declare() {
+  ws_declare_update(this, *this->source_,
+                    ws_ha_name(*this->source_, this->name_override_, this->get_ws_bridge_unique_id()));
+  ws_push_state_update(this, *this->source_);
+}
+void WsBridgeUpdateRef::ws_bridge_handle_command(const WsCommand &command) {
+  ws_handle_command_update(this->source_, command);
+}
+#endif
+
+}  // namespace ws_bridge
+}  // namespace esphome

--- a/components/ws_bridge/ws_bridge_entity_ref.h
+++ b/components/ws_bridge/ws_bridge_entity_ref.h
@@ -1,0 +1,166 @@
+#pragma once
+#include <string>
+#include "esphome/core/component.h"
+#include "esphome/core/defines.h"
+#include "ws_bridge_device.h"
+
+#ifdef USE_SENSOR
+#include "esphome/components/sensor/sensor.h"
+#endif
+#ifdef USE_BINARY_SENSOR
+#include "esphome/components/binary_sensor/binary_sensor.h"
+#endif
+#ifdef USE_TEXT_SENSOR
+#include "esphome/components/text_sensor/text_sensor.h"
+#endif
+#ifdef USE_SWITCH
+#include "esphome/components/switch/switch.h"
+#endif
+#ifdef USE_NUMBER
+#include "esphome/components/number/number.h"
+#endif
+#ifdef USE_SELECT
+#include "esphome/components/select/select.h"
+#endif
+#ifdef USE_BUTTON
+#include "esphome/components/button/button.h"
+#endif
+#ifdef USE_UPDATE
+#include "esphome/components/update/update_entity.h"
+#endif
+
+namespace esphome {
+namespace ws_bridge {
+
+// Bridges an *existing* ESPHome entity (given by `source_id:`) to Home
+// Assistant over ws_bridge, configured from the hub's `entities:` list rather
+// than as its own `platform: ws_bridge` entity — see the README's "Exposing
+// existing entities" section. Declares straight off the source (device_class,
+// unit_of_measurement, state_class, options, min/max/step, ...): there is no
+// parallel entity here to hold YAML overrides for those, unlike the
+// `platform: ws_bridge` + `*_id:` wrapping form, so `add_common_entity_fields`
+// is always called with a null `ovr`.
+//
+// One concrete Ref class per domain (rather than a template) to match how
+// every other WsBridgeDevice in this component is a plain, un-templated class.
+class WsBridgeEntityRefBase : public Component, public WsBridgeDevice {
+ public:
+  // Empty means: use the source entity's own name, falling back to unique_id
+  // if the source has no name of its own (id-only entity) — see ws_ha_name().
+  void set_name_override(const std::string &name) { this->name_override_ = name; }
+
+ protected:
+  std::string name_override_;
+};
+
+#ifdef USE_SENSOR
+class WsBridgeSensorRef : public WsBridgeEntityRefBase {
+ public:
+  void set_source(sensor::Sensor *source) { this->source_ = source; }
+  void setup() override;
+  void dump_config() override;
+  void ws_bridge_declare() override;
+
+ protected:
+  sensor::Sensor *source_{nullptr};
+};
+#endif
+
+#ifdef USE_BINARY_SENSOR
+class WsBridgeBinarySensorRef : public WsBridgeEntityRefBase {
+ public:
+  void set_source(binary_sensor::BinarySensor *source) { this->source_ = source; }
+  void setup() override;
+  void dump_config() override;
+  void ws_bridge_declare() override;
+
+ protected:
+  binary_sensor::BinarySensor *source_{nullptr};
+};
+#endif
+
+#ifdef USE_TEXT_SENSOR
+class WsBridgeTextSensorRef : public WsBridgeEntityRefBase {
+ public:
+  void set_source(text_sensor::TextSensor *source) { this->source_ = source; }
+  void setup() override;
+  void dump_config() override;
+  void ws_bridge_declare() override;
+
+ protected:
+  text_sensor::TextSensor *source_{nullptr};
+};
+#endif
+
+#ifdef USE_SWITCH
+class WsBridgeSwitchRef : public WsBridgeEntityRefBase {
+ public:
+  void set_source(switch_::Switch *source) { this->source_ = source; }
+  void setup() override;
+  void dump_config() override;
+  void ws_bridge_declare() override;
+  void ws_bridge_handle_command(const WsCommand &command) override;
+
+ protected:
+  switch_::Switch *source_{nullptr};
+};
+#endif
+
+#ifdef USE_NUMBER
+class WsBridgeNumberRef : public WsBridgeEntityRefBase {
+ public:
+  void set_source(number::Number *source) { this->source_ = source; }
+  void setup() override;
+  void dump_config() override;
+  void ws_bridge_declare() override;
+  void ws_bridge_handle_command(const WsCommand &command) override;
+
+ protected:
+  number::Number *source_{nullptr};
+};
+#endif
+
+#ifdef USE_SELECT
+class WsBridgeSelectRef : public WsBridgeEntityRefBase {
+ public:
+  void set_source(select::Select *source) { this->source_ = source; }
+  void setup() override;
+  void dump_config() override;
+  void ws_bridge_declare() override;
+  void ws_bridge_handle_command(const WsCommand &command) override;
+
+ protected:
+  select::Select *source_{nullptr};
+};
+#endif
+
+#ifdef USE_BUTTON
+class WsBridgeButtonRef : public WsBridgeEntityRefBase {
+ public:
+  void set_source(button::Button *source) { this->source_ = source; }
+  void setup() override {}
+  void dump_config() override;
+  void ws_bridge_declare() override;
+  void ws_bridge_handle_command(const WsCommand &command) override;
+
+ protected:
+  button::Button *source_{nullptr};
+};
+#endif
+
+#ifdef USE_UPDATE
+class WsBridgeUpdateRef : public WsBridgeEntityRefBase {
+ public:
+  void set_source(update::UpdateEntity *source) { this->source_ = source; }
+  void setup() override;
+  void dump_config() override;
+  void ws_bridge_declare() override;
+  void ws_bridge_handle_command(const WsCommand &command) override;
+
+ protected:
+  update::UpdateEntity *source_{nullptr};
+};
+#endif
+
+}  // namespace ws_bridge
+}  // namespace esphome

--- a/components/ws_bridge/ws_bridge_entity_ref.h
+++ b/components/ws_bridge/ws_bridge_entity_ref.h
@@ -57,6 +57,7 @@ class WsBridgeEntityRefBase : public Component, public WsBridgeDevice {
 class WsBridgeSensorRef : public WsBridgeEntityRefBase {
  public:
   void set_source(sensor::Sensor *source) { this->source_ = source; }
+  const EntityBase *get_ws_bridge_source() const override { return this->source_; }
   void setup() override;
   void dump_config() override;
   void ws_bridge_declare() override;
@@ -70,6 +71,7 @@ class WsBridgeSensorRef : public WsBridgeEntityRefBase {
 class WsBridgeBinarySensorRef : public WsBridgeEntityRefBase {
  public:
   void set_source(binary_sensor::BinarySensor *source) { this->source_ = source; }
+  const EntityBase *get_ws_bridge_source() const override { return this->source_; }
   void setup() override;
   void dump_config() override;
   void ws_bridge_declare() override;
@@ -83,6 +85,7 @@ class WsBridgeBinarySensorRef : public WsBridgeEntityRefBase {
 class WsBridgeTextSensorRef : public WsBridgeEntityRefBase {
  public:
   void set_source(text_sensor::TextSensor *source) { this->source_ = source; }
+  const EntityBase *get_ws_bridge_source() const override { return this->source_; }
   void setup() override;
   void dump_config() override;
   void ws_bridge_declare() override;
@@ -96,6 +99,7 @@ class WsBridgeTextSensorRef : public WsBridgeEntityRefBase {
 class WsBridgeSwitchRef : public WsBridgeEntityRefBase {
  public:
   void set_source(switch_::Switch *source) { this->source_ = source; }
+  const EntityBase *get_ws_bridge_source() const override { return this->source_; }
   void setup() override;
   void dump_config() override;
   void ws_bridge_declare() override;
@@ -110,6 +114,7 @@ class WsBridgeSwitchRef : public WsBridgeEntityRefBase {
 class WsBridgeNumberRef : public WsBridgeEntityRefBase {
  public:
   void set_source(number::Number *source) { this->source_ = source; }
+  const EntityBase *get_ws_bridge_source() const override { return this->source_; }
   void setup() override;
   void dump_config() override;
   void ws_bridge_declare() override;
@@ -124,6 +129,7 @@ class WsBridgeNumberRef : public WsBridgeEntityRefBase {
 class WsBridgeSelectRef : public WsBridgeEntityRefBase {
  public:
   void set_source(select::Select *source) { this->source_ = source; }
+  const EntityBase *get_ws_bridge_source() const override { return this->source_; }
   void setup() override;
   void dump_config() override;
   void ws_bridge_declare() override;
@@ -138,6 +144,7 @@ class WsBridgeSelectRef : public WsBridgeEntityRefBase {
 class WsBridgeButtonRef : public WsBridgeEntityRefBase {
  public:
   void set_source(button::Button *source) { this->source_ = source; }
+  const EntityBase *get_ws_bridge_source() const override { return this->source_; }
   void setup() override {}
   void dump_config() override;
   void ws_bridge_declare() override;
@@ -152,6 +159,7 @@ class WsBridgeButtonRef : public WsBridgeEntityRefBase {
 class WsBridgeUpdateRef : public WsBridgeEntityRefBase {
  public:
   void set_source(update::UpdateEntity *source) { this->source_ = source; }
+  const EntityBase *get_ws_bridge_source() const override { return this->source_; }
   void setup() override;
   void dump_config() override;
   void ws_bridge_declare() override;

--- a/tests/components/ws_bridge/test.esp32-idf.yaml
+++ b/tests/components/ws_bridge/test.esp32-idf.yaml
@@ -42,6 +42,23 @@ ws_bridge:
       longitude: !lambda return 126.9780;
       gps_accuracy: 8
       update_interval: 30s
+  # Exposes existing, locally-declared entities (below) without a parallel
+  # `platform: ws_bridge` entity per value — see the README's "Exposing
+  # existing entities" section. unique_id/name default to the source's own
+  # id/name when omitted (uptime_sensor and my_update below have neither set
+  # here, so both fall back at runtime).
+  entities:
+    - source_id: uptime_sensor
+    - source_id: local_motion
+      unique_id: motion_ref
+      name: "Local Motion (bridged)"
+    - source_id: local_status
+    - source_id: local_relay
+    - source_id: local_number
+    - source_id: local_select
+    - source_id: local_button2
+    - source_id: my_update
+      unique_id: firmware_ref
 
 sensor:
   - platform: ws_bridge
@@ -53,22 +70,35 @@ sensor:
     accuracy_decimals: 1
     ws_device_id: sensor_hub_1
     ws_device_name: "Sensor Hub"
+  - platform: uptime
+    id: uptime_sensor
 
 binary_sensor:
   - platform: ws_bridge
     unique_id: motion1
     name: "Motion"
     device_class: motion
+  - platform: template
+    id: local_motion
+    name: "Local Motion"
+    device_class: motion
 
 text_sensor:
   - platform: ws_bridge
     unique_id: status1
     name: "Status"
+  - platform: template
+    id: local_status
+    name: "Local Status"
 
 switch:
   - platform: ws_bridge
     unique_id: relay1
     name: "Relay"
+  - platform: template
+    id: local_relay
+    name: "Local Relay"
+    optimistic: true
 
 number:
   - platform: ws_bridge
@@ -77,6 +107,13 @@ number:
     min_value: 0
     max_value: 100
     step: 0.5
+  - platform: template
+    id: local_number
+    name: "Local Number"
+    optimistic: true
+    min_value: 0
+    max_value: 10
+    step: 1
 
 select:
   - platform: ws_bridge
@@ -85,6 +122,13 @@ select:
     options:
       - "Auto"
       - "Manual"
+  - platform: template
+    id: local_select
+    name: "Local Select"
+    optimistic: true
+    options:
+      - "One"
+      - "Two"
 
 button:
   - platform: template
@@ -92,6 +136,11 @@ button:
     name: "Local Flash"
     on_press:
       - logger.log: "flash"
+  - platform: template
+    id: local_button2
+    name: "Local Button 2"
+    on_press:
+      - logger.log: "pressed"
   - platform: ws_bridge
     unique_id: restart1
     name: "Restart"

--- a/tests/components/ws_bridge/test.esp32-idf.yaml
+++ b/tests/components/ws_bridge/test.esp32-idf.yaml
@@ -47,6 +47,11 @@ ws_bridge:
   # existing entities" section. unique_id/name default to the source's own
   # id/name when omitted (uptime_sensor and my_update below have neither set
   # here, so both fall back at runtime).
+  #
+  # Several of these sources are *also* wrapped via `*_id:` below. That is
+  # intentional dual-path compile coverage (wrapping + entities:); dump_config
+  # warns about the double exposure at runtime. Don't copy this overlap into
+  # a real device.
   entities:
     - source_id: uptime_sensor
     - source_id: local_motion
@@ -72,6 +77,13 @@ sensor:
     ws_device_name: "Sensor Hub"
   - platform: uptime
     id: uptime_sensor
+  # sensor_id: wraps an existing sensor via a `platform: ws_bridge` entity
+  # instead of the hub's entities: list. accuracy_decimals: 0 is an explicit
+  # override (0 is also the unset default — codegen must pass a flag).
+  - platform: ws_bridge
+    unique_id: temp_bridged
+    sensor_id: uptime_sensor
+    accuracy_decimals: 0
 
 binary_sensor:
   - platform: ws_bridge
@@ -82,6 +94,9 @@ binary_sensor:
     id: local_motion
     name: "Local Motion"
     device_class: motion
+  - platform: ws_bridge
+    unique_id: motion_bridged
+    binary_sensor_id: local_motion
 
 text_sensor:
   - platform: ws_bridge
@@ -90,6 +105,9 @@ text_sensor:
   - platform: template
     id: local_status
     name: "Local Status"
+  - platform: ws_bridge
+    unique_id: status_bridged
+    text_sensor_id: local_status
 
 switch:
   - platform: ws_bridge
@@ -99,6 +117,9 @@ switch:
     id: local_relay
     name: "Local Relay"
     optimistic: true
+  - platform: ws_bridge
+    unique_id: relay_bridged
+    switch_id: local_relay
 
 number:
   - platform: ws_bridge
@@ -114,6 +135,11 @@ number:
     min_value: 0
     max_value: 10
     step: 1
+  # min_value/max_value omitted on purpose — wrapping inherits the source's
+  # range (schema-relaxation compile path).
+  - platform: ws_bridge
+    unique_id: number_bridged
+    number_id: local_number
 
 select:
   - platform: ws_bridge
@@ -129,6 +155,10 @@ select:
     options:
       - "One"
       - "Two"
+  # options omitted on purpose — wrapping inherits the source's list.
+  - platform: ws_bridge
+    unique_id: select_bridged
+    select_id: local_select
 
 button:
   - platform: template

--- a/tests/components/ws_bridge/test.esp32-idf.yaml
+++ b/tests/components/ws_bridge/test.esp32-idf.yaml
@@ -82,6 +82,7 @@ sensor:
   # override (0 is also the unset default — codegen must pass a flag).
   - platform: ws_bridge
     unique_id: temp_bridged
+    name: "Uptime (bridged)"
     sensor_id: uptime_sensor
     accuracy_decimals: 0
 
@@ -96,6 +97,7 @@ binary_sensor:
     device_class: motion
   - platform: ws_bridge
     unique_id: motion_bridged
+    name: "Motion (bridged)"
     binary_sensor_id: local_motion
 
 text_sensor:
@@ -107,6 +109,7 @@ text_sensor:
     name: "Local Status"
   - platform: ws_bridge
     unique_id: status_bridged
+    name: "Status (bridged)"
     text_sensor_id: local_status
 
 switch:
@@ -119,6 +122,7 @@ switch:
     optimistic: true
   - platform: ws_bridge
     unique_id: relay_bridged
+    name: "Relay (bridged)"
     switch_id: local_relay
 
 number:
@@ -139,6 +143,7 @@ number:
   # range (schema-relaxation compile path).
   - platform: ws_bridge
     unique_id: number_bridged
+    name: "Number (bridged)"
     number_id: local_number
 
 select:
@@ -158,6 +163,7 @@ select:
   # options omitted on purpose — wrapping inherits the source's list.
   - platform: ws_bridge
     unique_id: select_bridged
+    name: "Select (bridged)"
     select_id: local_select
 
 button:

--- a/tests/components/ws_bridge/test.esp32-idf.yaml
+++ b/tests/components/ws_bridge/test.esp32-idf.yaml
@@ -145,6 +145,14 @@ number:
     unique_id: number_bridged
     name: "Number (bridged)"
     number_id: local_number
+  # Overrides one range field only: min/max/step resolve per field, so this
+  # keeps local_number's min/max. local_number is exposed several times here
+  # on purpose, to exercise the dump_config() double-exposure warning.
+  - platform: ws_bridge
+    unique_id: number_step_bridged
+    name: "Number (finer step)"
+    number_id: local_number
+    step: 0.1
 
 select:
   - platform: ws_bridge


### PR DESCRIPTION
## Summary

Expose already-declared ESPHome entities to Home Assistant over `ws_bridge`, instead of requiring a parallel `platform: ws_bridge` entity per value.

Two YAML paths, both built on domain helpers that take the source entity as a parameter (so HA commands hit the wrapped switch/number/select, not the wrapper):

1. **`platform: ws_bridge` wrapping** (`sensor_id:` / `switch_id:` / …) — parallel entity, own `unique_id`, metadata overrides.
2. **Hub `entities:` list** (`source_id:`) — no parallel entity, domain inferred from the source, no metadata overrides.

`dump_config()` warns on duplicate `unique_id`s and on the same source being exposed twice. README and the ESP-IDF test YAML cover both paths.

## What landed

| Commit | What |
| --- | --- |
| `32b2afc` | Extract per-domain declare / state / command helpers (`ws_bridge_domains.h`) |
| `1c59341` | Hub `entities:` list (`WsBridge*Ref`) |
| `b2021d1` | `*_id:` wrapping on sensor / binary_sensor / text_sensor / switch / number / select |
| `06ca7fc` | Give wrapping test entities a `name:` (ESPHome requires `id:` or `name:`) |
| `6e02938` | Runtime warnings + README |
| `4c7285f` | Inherit wrapped number `min`/`max`/`step` **per field** (overriding range no longer forces `step: 1.0`) |

## Behavior notes

- Metadata (`device_class`, `icon`, `entity_category`, sensor unit / state class / accuracy, number range, select options) comes from the source. Anything written on the ws_bridge platform still wins, **field by field**.
- Commands on wrapping `switch` / `number` / `select` / `button` / `update` are applied to the source, not the wrapper.
- Changing `unique_id` (or first adding wrapping under a new id) is a **new HA entity**. `sync_entities: true` then deletes the old one.
- `hass-ws-bridge` is unchanged. Wrapping is an ESPHome-side concept; the wire declare/state/command shape is the same.

## Out of scope — `cover` / `fan` / `light` / `climate` / `lock` / `text`

These ESPHome domains have **no protocol or HA platform** yet. `hass-ws-bridge` accepts only `sensor`, `binary_sensor`, `text_sensor`, `device_tracker`, `switch`, `number`, `select`, `button`, `update` (`vol.In(ALL_PLATFORMS)`). Declaring anything else is rejected.

They cannot be added from the ESPHome side alone. A later change would start in `hass-ws-bridge` (PROTOCOL + platform + tests) and land here in lockstep, one domain at a time — not all six, and not in this PR. `text` / `lock` are the cheap end of that list; `light` / `climate` are object-state platforms in the same class as `update`.

## Testing

- `tests/components/ws_bridge/test.esp32-idf.yaml` covers plain platforms, `*_id:` wrapping (including omitted number range / select options, `accuracy_decimals: 0`, and a step-only number override), and hub `entities:`.
- CI: `esphome-validate` + `esphome-compile` on that YAML.
