### PR TITLE
feat(ws_bridge): C2 — light / cover / fan

### DIFF
--- a/components/ws_bridge/IMPLEMENTATION_PLAN_ko.md
+++ b/components/ws_bridge/IMPLEMENTATION_PLAN_ko.md
@@ -161,19 +161,10 @@ if (!params.isNull()) {
 
 > **메모리 주의**: `params`는 최대 10개 남짓이지만 `std::vector<WsParam>`은 힙을 쓴다. ESP32에서 명령은 저빈도(사용자 조작)라 문제없다. 다만 **상태 전송 경로에는 절대 같은 패턴을 쓰지 말 것** — 그쪽은 고빈도다.
 
-### 3.2 선언에 `features` 첨부 헬퍼
+### 3.2 선언에 `features` 첨부
 
-`ws_bridge_entity_json.h`에 추가:
-
-```cpp
-// features: ["open","close","stop"] 형태로 첨부. 빈 목록이면 아무것도 안 보낸다
-// (서버가 플랫폼별 기본값을 쓴다).
-inline void add_features(JsonObject root, std::initializer_list<const char *> names) {
-  if (names.size() == 0) return;
-  JsonArray arr = root["features"].to<JsonArray>();
-  for (const char *n : names) arr.add(n);
-}
-```
+플랫폼별로 traits를 읽어 `JsonArray`에 직접 넣는다. C0의 `add_features(initializer_list)`는
+조건부 feature 목록에 맞지 않아 **삭제**했다 — cover/fan/light 모두 런타임 traits 기반이다.
 
 ### 3.3 객체 상태 전송 — 기존 것을 쓴다
 
@@ -195,7 +186,7 @@ this->parent_->send_state_object(this->unique_id_, [this](JsonObject v) {
 ### 3.5 Phase C0 완료 조건
 
 - [x] `WsCommand::params` 파싱 + 조회 헬퍼 5종
-- [x] `add_features()` 헬퍼
+- [x] 선언 `features`는 각 플랫폼이 traits에서 직접 첨부 (공통 `add_features` 헬퍼는 제거)
 - [ ] 기존 플랫폼 **동작 변화 0** — `params`는 추가 필드일 뿐 기존 `value` 경로 불변 (리뷰/실기)
 - [ ] 실제 기기 1대로 기존 엔티티 회귀 확인 (§6)
 

--- a/components/ws_bridge/IMPLEMENTATION_PLAN_ko.md
+++ b/components/ws_bridge/IMPLEMENTATION_PLAN_ko.md
@@ -3,9 +3,9 @@
 > **대상**: 이 컴포넌트에서 작업할 다른 AI 에이전트 또는 개발자
 > **목적**: HA 통합(`hass-ws-bridge`)이 Phase 0~4에서 확장한 프로토콜에 클라이언트를 맞춘다
 > **서버 기준**: `hass-ws-bridge` main (Phase 4 + 공통 계층 정리 완료, 플랫폼 27종)
-> **클라이언트 현재**: 플랫폼 8종(+ tracker) — `update`·`ws_bridge/sync`·엔티티 래핑은 master에 이미 있음. **남은 프로토콜 공백은 `WsCommand.params` / `features`.**
+> **클라이언트 현재**: 플랫폼 11종(+ tracker) — C0 `params`/`features`·C1 `update`·C2 `light`/`cover`/`fan` 반영. 남은 Tier A는 C3+.
 > **작성일**: 2026-08-13
-> **갱신**: 2026-08-13 — master pull 후 C1/`sync` 반영
+> **갱신**: 2026-08-13 — C0 머지 + C2 구현
 
 ---
 
@@ -38,9 +38,9 @@
 
 구조는 이미 좋다 — §1.3의 기존 자산을 그대로 활용한다. 엔티티 래핑(`sensor_id` / `entities:`)과 `ws_bridge/sync`도 master에 있다.
 
-### 1.2 서버가 지원하지만 클라이언트에 없는 것 (18종)
+### 1.2 서버가 지원하지만 클라이언트에 없는 것 (15종)
 
-`light`, `cover`, `fan`, `text`, `lock`, `date`, `time`, `datetime`,
+`text`, `lock`, `date`, `time`, `datetime`,
 `event`, `valve`, `climate`, `humidifier`, `water_heater`, `siren`,
 `alarm_control_panel`, `media_player`, `image`, `camera`
 
@@ -58,11 +58,9 @@
 
 | 공백 | 위치 | 영향 |
 |:---|:---|:---|
-| `WsCommand`에 `params` 없음 | `ws_protocol.h` | light `turn_on(brightness, rgb_color)` 등 **다중 인자 명령 수신 불가** |
-| 선언에 `features` 미전송 | 각 플랫폼 `ws_bridge_declare()` | cover/climate 등의 기능 플래그 선언 불가 |
 | 상태 배치 전송 없음 | `build_state_*` 각각 1건씩 | 복합 상태 갱신 시 메시지 수 증가 (선택) |
 
-> `ws_bridge/sync`는 #298로 이미 구현됨 — 더 이상 공백이 아니다.
+> `WsCommand.params` / `add_features`는 C0(#300)로 구현. `ws_bridge/sync`는 #298.
 
 ---
 
@@ -247,7 +245,7 @@ this->parent_->send_state_object(this->unique_id_, [this](JsonObject v) {
 |:---|:---|:---|
 | **C0** | 프로토콜 계층 (§3) | 전제 — `params` + `add_features` |
 | **C1** | `update` | **완료** (#296). OTA 직결 |
-| **C2** | `light`, `cover`, `fan` | 수요 최다. `params` 수신을 처음 실제로 쓴다 |
+| **C2** | `light`, `cover`, `fan` | **이번 PR**. 수요 최다. `params` 수신을 처음 실제로 씀 |
 | **C3** | `text`, `lock`, `valve`, `event`, `datetime`(date/time/datetime) | 스칼라 위주, 난도 낮음 |
 | **C4** | `climate` | 단독. 상태·명령 표면이 가장 넓다 |
 | **C5** | `alarm_control_panel`, `media_player` | 수요 확인 후 |

--- a/components/ws_bridge/README.md
+++ b/components/ws_bridge/README.md
@@ -102,6 +102,31 @@ button:
     unique_id: restart1
     name: "Restart"
 
+# light is wrap-only (light_id: required) — YAML id on a light is LightState.
+output:
+  - platform: gpio
+    pin: GPIO2
+    id: status_led_out
+light:
+  - platform: binary
+    id: status_led
+    name: "Status LED"
+    output: status_led_out
+  - platform: ws_bridge
+    unique_id: status_led_ha
+    name: "Status LED"
+    light_id: status_led
+
+cover:
+  - platform: ws_bridge
+    unique_id: gate1
+    name: "Gate"
+
+fan:
+  - platform: ws_bridge
+    unique_id: ceiling_fan
+    name: "Ceiling Fan"
+
 # Firmware update entity in HA — wraps ESPHome's http_request update.
 # See "Remote OTA updates" below.
 http_request:
@@ -136,16 +161,16 @@ update:
 | `trackers` | | - | List of GPS `device_tracker` entities — see [GPS device trackers](#gps-device-trackers) below |
 | `entities` | | - | Existing ESPHome entities to expose without a parallel `platform: ws_bridge` entity — see [Exposing existing entities](#exposing-existing-entities) |
 
-### Platform options (all of `sensor`/`binary_sensor`/`text_sensor`/`switch`/`number`/`select`/`button`/`update`)
+### Platform options (all of `sensor`/`binary_sensor`/`text_sensor`/`switch`/`number`/`select`/`button`/`update`/`light`/`cover`/`fan`)
 
 | Option | Required | Description |
 |--------|:--------:|-------------|
 | `unique_id` | ✓ | Identifier for this entity, unique within the gateway. **Changing it creates a new HA entity** (the old one is left behind; `sync_entities: true` then deletes it) |
 | `ws_device_id` | | Groups this entity under a sub-device in HA (e.g. multiple sensors on one physical board) |
 | `ws_device_name` | | Display name for that sub-device |
-| `sensor_id` / `binary_sensor_id` / `text_sensor_id` / `switch_id` / `number_id` / `select_id` / `button_id` | | ID of an existing ESPHome entity to wrap — see [Exposing existing entities](#exposing-existing-entities) |
-| `update_id` | ✓ (`update` only) | ID of the ESPHome `update:` entity to wrap — typically `platform: http_request` |
-| `name` | (`update`) | HA-facing name. If omitted, uses the wrapped entity's name when that entity has its own `name:`; otherwise the `unique_id` |
+| `sensor_id` / `binary_sensor_id` / `text_sensor_id` / `switch_id` / `number_id` / `select_id` / `button_id` / `cover_id` / `fan_id` | | ID of an existing ESPHome entity to wrap — see [Exposing existing entities](#exposing-existing-entities) |
+| `update_id` / `light_id` | ✓ (`update` / `light` only) | ID of the ESPHome entity to wrap (`update:` typically `platform: http_request`; `light:` any `LightState`) |
+| `name` | (`update` / `light`) | HA-facing name. If omitted, uses the wrapped entity's name when that entity has its own `name:`; otherwise the `unique_id` |
 
 Plus each platform's normal ESPHome options (`name`, `device_class`, `icon`,
 `entity_category`, `unit_of_measurement`/`state_class` for `sensor`,
@@ -207,16 +232,18 @@ number:
   source. Anything written on the ws_bridge platform still wins, field by
   field — a number that sets only `min_value`/`max_value` keeps the
   source's `step`, and vice versa.
-- **Commands** on `switch` / `number` / `select` / `button` / `update` are
-  applied to the wrapped entity, not to the wrapper. On-device automations
-  should keep targeting the source (`switch.turn_on: relay`).
+- **Commands** on `switch` / `number` / `select` / `button` / `update` /
+  `light` / `cover` / `fan` are applied to the wrapped entity, not to the
+  wrapper. On-device automations should keep targeting the source
+  (`switch.turn_on: relay`).
 - ESPHome still requires `id:` or `name:` on the wrapper YAML (`unique_id`
   alone is not enough).
 - `unique_id` is still required. Changing it (or first adding wrapping
   under a new id) is a **new HA entity** — history stays on the old
   `entity_id`.
-- `update:` wrapping (`update_id:`) is required, not optional — that
-  platform has no state of its own. See [Remote OTA updates](#remote-ota-updates-no-vpn-no-mqtt).
+- `update:` / `light:` wrapping (`update_id:` / `light_id:`) is required,
+  not optional — those platforms have no useful standalone state of their
+  own. See [Remote OTA updates](#remote-ota-updates-no-vpn-no-mqtt).
 
 ### Hub `entities:` list
 

--- a/components/ws_bridge/__init__.py
+++ b/components/ws_bridge/__init__.py
@@ -255,17 +255,7 @@ async def register_ws_bridge_device(var, config):
 
 
 async def to_code(config):
-    # Newer ESPHome accepts the IDF component registry form (name="espressif/...");
-    # older builds require an explicit git repo=.
-    try:
-        esp32.add_idf_component(name="espressif/esp_websocket_client", ref=ESP_WEBSOCKET_CLIENT_VERSION)
-    except TypeError:
-        esp32.add_idf_component(
-            name="esp_websocket_client",
-            repo="https://github.com/espressif/esp-protocols.git",
-            path="components/esp_websocket_client",
-            ref=f"websocket-v{ESP_WEBSOCKET_CLIENT_VERSION}",
-        )
+    esp32.add_idf_component(name="espressif/esp_websocket_client", ref=ESP_WEBSOCKET_CLIENT_VERSION)
 
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)

--- a/components/ws_bridge/__init__.py
+++ b/components/ws_bridge/__init__.py
@@ -11,6 +11,9 @@ from esphome.components import (
     select,
     button,
     update,
+    light,
+    cover,
+    fan,
 )
 from esphome.const import (
     CONF_ID,
@@ -97,6 +100,9 @@ _ENTITY_REF_DOMAINS = [
     (select.Select, ws_bridge_ns.class_("WsBridgeSelectRef", WsBridgeEntityRefBase)),
     (button.Button, ws_bridge_ns.class_("WsBridgeButtonRef", WsBridgeEntityRefBase)),
     (update.UpdateEntity, ws_bridge_ns.class_("WsBridgeUpdateRef", WsBridgeEntityRefBase)),
+    (light.LightState, ws_bridge_ns.class_("WsBridgeLightRef", WsBridgeEntityRefBase)),
+    (cover.Cover, ws_bridge_ns.class_("WsBridgeCoverRef", WsBridgeEntityRefBase)),
+    (fan.Fan, ws_bridge_ns.class_("WsBridgeFanRef", WsBridgeEntityRefBase)),
 ]
 
 ENTITY_SCHEMA = cv.Schema(
@@ -130,7 +136,7 @@ async def to_code_entity_ref(hub_var, conf):
         raise cv.Invalid(
             f"'{source_id.id}' (type {full_id.type}) is not an entity domain ws_bridge "
             "can expose via entities: — supported: sensor, binary_sensor, text_sensor, "
-            "switch, number, select, button, update"
+            "switch, number, select, button, update, light, cover, fan"
         )
 
     id_ = conf[CONF_ID]
@@ -249,7 +255,17 @@ async def register_ws_bridge_device(var, config):
 
 
 async def to_code(config):
-    esp32.add_idf_component(name="espressif/esp_websocket_client", ref=ESP_WEBSOCKET_CLIENT_VERSION)
+    # Newer ESPHome accepts the IDF component registry form (name="espressif/...");
+    # older builds require an explicit git repo=.
+    try:
+        esp32.add_idf_component(name="espressif/esp_websocket_client", ref=ESP_WEBSOCKET_CLIENT_VERSION)
+    except TypeError:
+        esp32.add_idf_component(
+            name="esp_websocket_client",
+            repo="https://github.com/espressif/esp-protocols.git",
+            path="components/esp_websocket_client",
+            ref=f"websocket-v{ESP_WEBSOCKET_CLIENT_VERSION}",
+        )
 
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)

--- a/components/ws_bridge/const.py
+++ b/components/ws_bridge/const.py
@@ -27,6 +27,9 @@ CONF_TEXT_SENSOR_ID = "text_sensor_id"
 CONF_SWITCH_ID = "switch_id"
 CONF_NUMBER_ID = "number_id"
 CONF_SELECT_ID = "select_id"
+CONF_LIGHT_ID = "light_id"
+CONF_COVER_ID = "cover_id"
+CONF_FAN_ID = "fan_id"
 
 # Hub-side `entities:` list — exposes an already-existing ESPHome entity
 # without a parallel `platform: ws_bridge` entity. See WsBridgeEntityRefBase.

--- a/components/ws_bridge/cover/__init__.py
+++ b/components/ws_bridge/cover/__init__.py
@@ -1,0 +1,30 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import cover, ws_bridge
+
+from .. import ws_bridge_ns
+from ..const import CONF_COVER_ID
+
+DEPENDENCIES = ["ws_bridge"]
+WsBridgeCover = ws_bridge_ns.class_("WsBridgeCover", cover.Cover, cg.Component, ws_bridge.WsBridgeDevice)
+
+CONFIG_SCHEMA = (
+    cover.cover_schema(WsBridgeCover)
+    .extend(ws_bridge.WS_BRIDGE_DEVICE_SCHEMA)
+    .extend(cv.COMPONENT_SCHEMA)
+    .extend(
+        {
+            # Wrap and drive an existing ESPHome cover. HA commands are
+            # applied to it, and its state changes are what get reported back.
+            cv.Optional(CONF_COVER_ID): cv.use_id(cover.Cover),
+        }
+    )
+)
+
+
+async def to_code(config):
+    var = await cover.new_cover(config)
+    await cg.register_component(var, config)
+    await ws_bridge.register_ws_bridge_device(var, config)
+    if CONF_COVER_ID in config:
+        cg.add(var.set_source(await cg.get_variable(config[CONF_COVER_ID])))

--- a/components/ws_bridge/cover/ws_bridge_cover.cpp
+++ b/components/ws_bridge/cover/ws_bridge_cover.cpp
@@ -1,0 +1,51 @@
+#include "ws_bridge_cover.h"
+#include "../ws_bridge_domains.h"
+
+namespace esphome {
+namespace ws_bridge {
+
+static const char *const TAG = "ws_bridge.cover";
+
+void WsBridgeCover::setup() { ws_subscribe_cover(this, this->source_ != nullptr ? this->source_ : this); }
+
+void WsBridgeCover::dump_config() {
+  LOG_COVER("", "WS Bridge Cover", this);
+  if (this->source_ != nullptr)
+    ESP_LOGCONFIG(TAG, "  Wrapped: '%s'", this->source_->get_name().str().c_str());
+}
+
+cover::CoverTraits WsBridgeCover::get_traits() {
+  if (this->source_ != nullptr)
+    return this->source_->get_traits();
+  cover::CoverTraits traits;
+  traits.set_supports_position(true);
+  traits.set_supports_stop(true);
+  return traits;
+}
+
+// Only reached when NOT wrapping — see WsBridgeSwitch::write_state().
+void WsBridgeCover::control(const cover::CoverCall &call) {
+  if (call.get_stop()) {
+    this->current_operation = cover::COVER_OPERATION_IDLE;
+  } else if (call.get_position().has_value()) {
+    this->position = *call.get_position();
+    this->current_operation = cover::COVER_OPERATION_IDLE;
+  }
+  if (call.get_tilt().has_value())
+    this->tilt = *call.get_tilt();
+  this->publish_state();
+}
+
+void WsBridgeCover::ws_bridge_handle_command(const WsCommand &command) {
+  ws_handle_command_cover(this->source_ != nullptr ? this->source_ : this, command);
+}
+
+void WsBridgeCover::ws_bridge_declare() {
+  cover::Cover &src = this->source_ != nullptr ? *this->source_ : *this;
+  const std::string own_name = this->has_own_name() ? this->get_name().str() : "";
+  ws_declare_cover(this, src, this, ws_ha_name(src, own_name, this->unique_id_));
+  ws_push_state_cover(this, src);
+}
+
+}  // namespace ws_bridge
+}  // namespace esphome

--- a/components/ws_bridge/cover/ws_bridge_cover.h
+++ b/components/ws_bridge/cover/ws_bridge_cover.h
@@ -1,0 +1,27 @@
+#pragma once
+#include "esphome/components/cover/cover.h"
+#include "esphome/core/component.h"
+#include "../ws_bridge_device.h"
+
+namespace esphome {
+namespace ws_bridge {
+
+class WsBridgeCover : public cover::Cover, public Component, public WsBridgeDevice {
+ public:
+  // Optional: mirror and drive an existing cover. HA commands go to the wrapped
+  // cover; its state changes are what get reported back.
+  void set_source(cover::Cover *source) { this->source_ = source; }
+  const EntityBase *get_ws_bridge_source() const override { return this->source_; }
+  void setup() override;
+  void dump_config() override;
+  cover::CoverTraits get_traits() override;
+  void ws_bridge_declare() override;
+  void ws_bridge_handle_command(const WsCommand &command) override;
+
+ protected:
+  void control(const cover::CoverCall &call) override;
+  cover::Cover *source_{nullptr};
+};
+
+}  // namespace ws_bridge
+}  // namespace esphome

--- a/components/ws_bridge/fan/__init__.py
+++ b/components/ws_bridge/fan/__init__.py
@@ -1,0 +1,30 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import fan, ws_bridge
+
+from .. import ws_bridge_ns
+from ..const import CONF_FAN_ID
+
+DEPENDENCIES = ["ws_bridge"]
+WsBridgeFan = ws_bridge_ns.class_("WsBridgeFan", fan.Fan, cg.Component, ws_bridge.WsBridgeDevice)
+
+CONFIG_SCHEMA = (
+    fan.fan_schema(WsBridgeFan)
+    .extend(ws_bridge.WS_BRIDGE_DEVICE_SCHEMA)
+    .extend(cv.COMPONENT_SCHEMA)
+    .extend(
+        {
+            # Wrap and drive an existing ESPHome fan. HA commands are applied
+            # to it, and its state changes are what get reported back.
+            cv.Optional(CONF_FAN_ID): cv.use_id(fan.Fan),
+        }
+    )
+)
+
+
+async def to_code(config):
+    var = await fan.new_fan(config)
+    await cg.register_component(var, config)
+    await ws_bridge.register_ws_bridge_device(var, config)
+    if CONF_FAN_ID in config:
+        cg.add(var.set_source(await cg.get_variable(config[CONF_FAN_ID])))

--- a/components/ws_bridge/fan/ws_bridge_fan.cpp
+++ b/components/ws_bridge/fan/ws_bridge_fan.cpp
@@ -1,0 +1,50 @@
+#include "ws_bridge_fan.h"
+#include "../ws_bridge_domains.h"
+
+namespace esphome {
+namespace ws_bridge {
+
+static const char *const TAG = "ws_bridge.fan";
+
+void WsBridgeFan::setup() { ws_subscribe_fan(this, this->source_ != nullptr ? this->source_ : this); }
+
+void WsBridgeFan::dump_config() {
+  LOG_FAN("", "WS Bridge Fan", this);
+  if (this->source_ != nullptr)
+    ESP_LOGCONFIG(TAG, "  Wrapped: '%s'", this->source_->get_name().str().c_str());
+}
+
+fan::FanTraits WsBridgeFan::get_traits() {
+  if (this->source_ != nullptr)
+    return this->source_->get_traits();
+  return fan::FanTraits(false, true, false, 100);
+}
+
+// Only reached when NOT wrapping — see WsBridgeSwitch::write_state().
+void WsBridgeFan::control(const fan::FanCall &call) {
+  if (call.get_state().has_value())
+    this->state = *call.get_state();
+  if (call.get_speed().has_value())
+    this->speed = *call.get_speed();
+  if (call.get_oscillating().has_value())
+    this->oscillating = *call.get_oscillating();
+  if (call.get_direction().has_value())
+    this->direction = *call.get_direction();
+  if (!call.get_preset_mode().empty())
+    this->preset_mode = call.get_preset_mode();
+  this->publish_state();
+}
+
+void WsBridgeFan::ws_bridge_handle_command(const WsCommand &command) {
+  ws_handle_command_fan(this->source_ != nullptr ? this->source_ : this, command);
+}
+
+void WsBridgeFan::ws_bridge_declare() {
+  fan::Fan &src = this->source_ != nullptr ? *this->source_ : *this;
+  const std::string own_name = this->has_own_name() ? this->get_name().str() : "";
+  ws_declare_fan(this, src, this, ws_ha_name(src, own_name, this->unique_id_));
+  ws_push_state_fan(this, src);
+}
+
+}  // namespace ws_bridge
+}  // namespace esphome

--- a/components/ws_bridge/fan/ws_bridge_fan.cpp
+++ b/components/ws_bridge/fan/ws_bridge_fan.cpp
@@ -30,8 +30,8 @@ void WsBridgeFan::control(const fan::FanCall &call) {
     this->oscillating = *call.get_oscillating();
   if (call.get_direction().has_value())
     this->direction = *call.get_direction();
-  if (!call.get_preset_mode().empty())
-    this->preset_mode = call.get_preset_mode();
+  if (call.has_preset_mode())
+    this->set_preset_mode_(call.get_preset_mode());
   this->publish_state();
 }
 

--- a/components/ws_bridge/fan/ws_bridge_fan.h
+++ b/components/ws_bridge/fan/ws_bridge_fan.h
@@ -1,0 +1,27 @@
+#pragma once
+#include "esphome/components/fan/fan.h"
+#include "esphome/core/component.h"
+#include "../ws_bridge_device.h"
+
+namespace esphome {
+namespace ws_bridge {
+
+class WsBridgeFan : public fan::Fan, public Component, public WsBridgeDevice {
+ public:
+  // Optional: mirror and drive an existing fan. HA commands go to the wrapped
+  // fan; its state changes are what get reported back.
+  void set_source(fan::Fan *source) { this->source_ = source; }
+  const EntityBase *get_ws_bridge_source() const override { return this->source_; }
+  void setup() override;
+  void dump_config() override;
+  fan::FanTraits get_traits() override;
+  void ws_bridge_declare() override;
+  void ws_bridge_handle_command(const WsCommand &command) override;
+
+ protected:
+  void control(const fan::FanCall &call) override;
+  fan::Fan *source_{nullptr};
+};
+
+}  // namespace ws_bridge
+}  // namespace esphome

--- a/components/ws_bridge/light/__init__.py
+++ b/components/ws_bridge/light/__init__.py
@@ -1,0 +1,34 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import light, ws_bridge
+from esphome.const import CONF_ID, CONF_NAME
+
+from .. import ws_bridge_ns
+from ..const import CONF_LIGHT_ID
+
+DEPENDENCIES = ["ws_bridge"]
+
+# Wraps an existing ESPHome LightState and exposes it to Home Assistant.
+# light_id: is required — inheriting LightOutput would create a second state.
+WsBridgeLight = ws_bridge_ns.class_("WsBridgeLight", cg.Component, ws_bridge.WsBridgeDevice)
+
+CONFIG_SCHEMA = (
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(WsBridgeLight),
+            cv.Required(CONF_LIGHT_ID): cv.use_id(light.LightState),
+            cv.Optional(CONF_NAME): cv.string_strict,
+        }
+    )
+    .extend(ws_bridge.WS_BRIDGE_DEVICE_SCHEMA)
+    .extend(cv.COMPONENT_SCHEMA)
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await ws_bridge.register_ws_bridge_device(var, config)
+    cg.add(var.set_light(await cg.get_variable(config[CONF_LIGHT_ID])))
+    if CONF_NAME in config:
+        cg.add(var.set_name(config[CONF_NAME]))

--- a/components/ws_bridge/light/ws_bridge_light.cpp
+++ b/components/ws_bridge/light/ws_bridge_light.cpp
@@ -7,7 +7,7 @@ namespace ws_bridge {
 
 static const char *const TAG = "ws_bridge.light";
 
-void WsBridgeLight::setup() { ws_subscribe_light(this, this->light_); }
+void WsBridgeLight::setup() { ws_subscribe_light(this->light_, this); }
 
 std::string WsBridgeLight::ha_name_() const {
   return ws_ha_name(*this->light_, this->name_, this->unique_id_);
@@ -18,6 +18,8 @@ void WsBridgeLight::dump_config() {
   ESP_LOGCONFIG(TAG, "  Unique ID: %s", this->unique_id_.c_str());
   ESP_LOGCONFIG(TAG, "  Wrapped: '%s'", this->light_->get_name().str().c_str());
 }
+
+void WsBridgeLight::on_light_remote_values_update() { ws_send_state_light(this, *this->light_); }
 
 void WsBridgeLight::ws_bridge_handle_command(const WsCommand &command) {
   ws_handle_command_light(this->light_, command);

--- a/components/ws_bridge/light/ws_bridge_light.cpp
+++ b/components/ws_bridge/light/ws_bridge_light.cpp
@@ -1,0 +1,32 @@
+#include "ws_bridge_light.h"
+#include "esphome/core/log.h"
+#include "../ws_bridge_domains.h"
+
+namespace esphome {
+namespace ws_bridge {
+
+static const char *const TAG = "ws_bridge.light";
+
+void WsBridgeLight::setup() { ws_subscribe_light(this, this->light_); }
+
+std::string WsBridgeLight::ha_name_() const {
+  return ws_ha_name(*this->light_, this->name_, this->unique_id_);
+}
+
+void WsBridgeLight::dump_config() {
+  ESP_LOGCONFIG(TAG, "WS Bridge Light '%s'", this->ha_name_().c_str());
+  ESP_LOGCONFIG(TAG, "  Unique ID: %s", this->unique_id_.c_str());
+  ESP_LOGCONFIG(TAG, "  Wrapped: '%s'", this->light_->get_name().str().c_str());
+}
+
+void WsBridgeLight::ws_bridge_handle_command(const WsCommand &command) {
+  ws_handle_command_light(this->light_, command);
+}
+
+void WsBridgeLight::ws_bridge_declare() {
+  ws_declare_light(this, *this->light_, this->ha_name_());
+  ws_push_state_light(this, *this->light_);
+}
+
+}  // namespace ws_bridge
+}  // namespace esphome

--- a/components/ws_bridge/light/ws_bridge_light.h
+++ b/components/ws_bridge/light/ws_bridge_light.h
@@ -9,7 +9,11 @@ namespace ws_bridge {
 // Bridges an existing ESPHome LightState to Home Assistant. Wrap-only (like
 // update): YAML `id:` on a light is the LightState, and inheriting LightOutput
 // would create a second LightState via new_light().
-class WsBridgeLight : public Component, public WsBridgeDevice {
+// Implements LightRemoteValuesListener — ESPHome 2026+ replaced the old
+// std::function remote-values callback with this interface.
+class WsBridgeLight : public Component,
+                      public WsBridgeDevice,
+                      public light::LightRemoteValuesListener {
  public:
   void set_light(light::LightState *light) { this->light_ = light; }
   const EntityBase *get_ws_bridge_source() const override { return this->light_; }
@@ -18,6 +22,7 @@ class WsBridgeLight : public Component, public WsBridgeDevice {
   void dump_config() override;
   void ws_bridge_declare() override;
   void ws_bridge_handle_command(const WsCommand &command) override;
+  void on_light_remote_values_update() override;
 
  protected:
   std::string ha_name_() const;

--- a/components/ws_bridge/light/ws_bridge_light.h
+++ b/components/ws_bridge/light/ws_bridge_light.h
@@ -1,0 +1,30 @@
+#pragma once
+#include "esphome/components/light/light_state.h"
+#include "esphome/core/component.h"
+#include "../ws_bridge_device.h"
+
+namespace esphome {
+namespace ws_bridge {
+
+// Bridges an existing ESPHome LightState to Home Assistant. Wrap-only (like
+// update): YAML `id:` on a light is the LightState, and inheriting LightOutput
+// would create a second LightState via new_light().
+class WsBridgeLight : public Component, public WsBridgeDevice {
+ public:
+  void set_light(light::LightState *light) { this->light_ = light; }
+  const EntityBase *get_ws_bridge_source() const override { return this->light_; }
+  void set_name(const std::string &name) { this->name_ = name; }
+  void setup() override;
+  void dump_config() override;
+  void ws_bridge_declare() override;
+  void ws_bridge_handle_command(const WsCommand &command) override;
+
+ protected:
+  std::string ha_name_() const;
+
+  light::LightState *light_{nullptr};
+  std::string name_;
+};
+
+}  // namespace ws_bridge
+}  // namespace esphome

--- a/components/ws_bridge/ws_bridge_domains.h
+++ b/components/ws_bridge/ws_bridge_domains.h
@@ -32,6 +32,15 @@
 #ifdef USE_UPDATE
 #include "esphome/components/update/update_entity.h"
 #endif
+#ifdef USE_LIGHT
+#include "esphome/components/light/light_state.h"
+#endif
+#ifdef USE_COVER
+#include "esphome/components/cover/cover.h"
+#endif
+#ifdef USE_FAN
+#include "esphome/components/fan/fan.h"
+#endif
 
 namespace esphome {
 namespace ws_bridge {
@@ -325,6 +334,453 @@ inline void ws_handle_command_update(update::UpdateEntity *target, const WsComma
   }
 }
 #endif  // USE_UPDATE
+
+#ifdef USE_COVER
+inline void ws_fill_state_cover(cover::Cover &src, JsonObject value) {
+  switch (src.current_operation) {
+    case cover::COVER_OPERATION_OPENING:
+      value["state"] = "opening";
+      break;
+    case cover::COVER_OPERATION_CLOSING:
+      value["state"] = "closing";
+      break;
+    case cover::COVER_OPERATION_IDLE:
+    default:
+      value["state"] = src.position > 0.5f ? "open" : "closed";
+      break;
+  }
+  value["position"] = static_cast<int>(roundf(src.position * 100.0f));
+  auto traits = src.get_traits();
+  if (traits.get_supports_tilt())
+    value["tilt_position"] = static_cast<int>(roundf(src.tilt * 100.0f));
+}
+
+inline void ws_send_state_cover(WsBridgeDevice *dev, cover::Cover &src) {
+  dev->get_ws_bridge_parent()->send_state_object(dev->get_ws_bridge_unique_id(),
+                                                 [&src](JsonObject value) { ws_fill_state_cover(src, value); });
+}
+
+inline void ws_declare_cover(WsBridgeDevice *dev, cover::Cover &src, cover::Cover *ovr, const std::string &name) {
+  dev->get_ws_bridge_parent()->send_entity_declare(
+      dev->get_ws_bridge_unique_id(), "cover", name, dev->get_ws_bridge_device_id(),
+      dev->get_ws_bridge_device_name(), [&src, ovr](JsonObject root) {
+        add_common_entity_fields(root, src, ovr);
+        auto traits = src.get_traits();
+        JsonArray features = root["features"].to<JsonArray>();
+        features.add("open");
+        features.add("close");
+        if (traits.get_supports_stop())
+          features.add("stop");
+        if (traits.get_supports_position())
+          features.add("set_position");
+        if (traits.get_supports_tilt()) {
+          features.add("open_tilt");
+          features.add("close_tilt");
+          features.add("set_tilt_position");
+          if (traits.get_supports_stop())
+            features.add("stop_tilt");
+        }
+      });
+}
+
+inline void ws_push_state_cover(WsBridgeDevice *dev, cover::Cover &src) { ws_send_state_cover(dev, src); }
+
+inline void ws_subscribe_cover(WsBridgeDevice *dev, cover::Cover *src) {
+  src->add_on_state_callback([dev, src]() { ws_send_state_cover(dev, *src); });
+}
+
+inline void ws_handle_command_cover(cover::Cover *target, const WsCommand &command) {
+  if (command.action == "open_cover") {
+    target->make_call().set_command_open().perform();
+  } else if (command.action == "close_cover") {
+    target->make_call().set_command_close().perform();
+  } else if (command.action == "stop_cover" || command.action == "stop_cover_tilt") {
+    target->make_call().set_command_stop().perform();
+  } else if (command.action == "set_cover_position") {
+    float position;
+    if (command.param_float("position", position))
+      target->make_call().set_position(position / 100.0f).perform();
+  } else if (command.action == "open_cover_tilt") {
+    target->make_call().set_tilt(cover::COVER_OPEN).perform();
+  } else if (command.action == "close_cover_tilt") {
+    target->make_call().set_tilt(cover::COVER_CLOSED).perform();
+  } else if (command.action == "set_cover_tilt_position") {
+    float tilt;
+    if (command.param_float("tilt_position", tilt))
+      target->make_call().set_tilt(tilt / 100.0f).perform();
+  }
+}
+#endif  // USE_COVER
+
+#ifdef USE_FAN
+inline int ws_fan_percentage_(fan::Fan &src) {
+  auto traits = src.get_traits();
+  int count = traits.supported_speed_count();
+  if (!src.state || !traits.supports_speed() || count <= 0)
+    return 0;
+  return static_cast<int>(roundf(100.0f * src.speed / count));
+}
+
+inline void ws_fill_state_fan(fan::Fan &src, JsonObject value) {
+  value["state"] = src.state ? "on" : "off";
+  auto traits = src.get_traits();
+  if (traits.supports_speed())
+    value["percentage"] = ws_fan_percentage_(src);
+  if (traits.supports_oscillation())
+    value["oscillating"] = src.oscillating;
+  if (traits.supports_direction())
+    value["direction"] = src.direction == fan::FanDirection::REVERSE ? "reverse" : "forward";
+  if (traits.supports_preset_modes() && !src.preset_mode.empty())
+    value["preset_mode"] = src.preset_mode;
+}
+
+inline void ws_send_state_fan(WsBridgeDevice *dev, fan::Fan &src) {
+  dev->get_ws_bridge_parent()->send_state_object(dev->get_ws_bridge_unique_id(),
+                                                 [&src](JsonObject value) { ws_fill_state_fan(src, value); });
+}
+
+inline void ws_declare_fan(WsBridgeDevice *dev, fan::Fan &src, fan::Fan *ovr, const std::string &name) {
+  dev->get_ws_bridge_parent()->send_entity_declare(
+      dev->get_ws_bridge_unique_id(), "fan", name, dev->get_ws_bridge_device_id(),
+      dev->get_ws_bridge_device_name(), [&src, ovr](JsonObject root) {
+        add_common_entity_fields(root, src, ovr);
+        auto traits = src.get_traits();
+        JsonArray features = root["features"].to<JsonArray>();
+        features.add("turn_on");
+        features.add("turn_off");
+        if (traits.supports_speed()) {
+          features.add("set_speed");
+          root["speed_count"] = traits.supported_speed_count();
+        }
+        if (traits.supports_oscillation())
+          features.add("oscillate");
+        if (traits.supports_direction())
+          features.add("direction");
+        if (traits.supports_preset_modes()) {
+          features.add("preset_mode");
+          JsonArray presets = root["preset_modes"].to<JsonArray>();
+          for (const auto &mode : traits.supported_preset_modes())
+            presets.add(mode);
+        }
+      });
+}
+
+inline void ws_push_state_fan(WsBridgeDevice *dev, fan::Fan &src) { ws_send_state_fan(dev, src); }
+
+inline void ws_subscribe_fan(WsBridgeDevice *dev, fan::Fan *src) {
+  src->add_on_state_callback([dev, src]() { ws_send_state_fan(dev, *src); });
+}
+
+inline void ws_fan_apply_percentage_(fan::Fan *target, float percentage) {
+  auto traits = target->get_traits();
+  int count = traits.supported_speed_count();
+  if (percentage <= 0.0f || count <= 0) {
+    target->turn_off().perform();
+    return;
+  }
+  int speed = static_cast<int>(roundf(percentage / 100.0f * count));
+  if (speed < 1)
+    speed = 1;
+  if (speed > count)
+    speed = count;
+  target->make_call().set_state(true).set_speed(speed).perform();
+}
+
+inline void ws_handle_command_fan(fan::Fan *target, const WsCommand &command) {
+  if (command.action == "turn_on") {
+    float percentage;
+    std::string preset;
+    auto call = target->make_call().set_state(true);
+    if (command.param_float("percentage", percentage)) {
+      auto traits = target->get_traits();
+      int count = traits.supported_speed_count();
+      if (count > 0) {
+        int speed = static_cast<int>(roundf(percentage / 100.0f * count));
+        if (speed < 1)
+          speed = 1;
+        if (speed > count)
+          speed = count;
+        call.set_speed(speed);
+      }
+    }
+    if (command.param_string("preset_mode", preset))
+      call.set_preset_mode(preset);
+    call.perform();
+  } else if (command.action == "turn_off") {
+    target->turn_off().perform();
+  } else if (command.action == "set_percentage") {
+    float percentage;
+    if (command.param_float("percentage", percentage))
+      ws_fan_apply_percentage_(target, percentage);
+  } else if (command.action == "set_preset_mode") {
+    std::string preset;
+    if (command.param_string("preset_mode", preset))
+      target->make_call().set_preset_mode(preset).perform();
+  } else if (command.action == "oscillate") {
+    bool oscillating;
+    if (command.param_bool("oscillating", oscillating))
+      target->make_call().set_oscillating(oscillating).perform();
+  } else if (command.action == "set_direction") {
+    std::string direction;
+    if (command.param_string("direction", direction)) {
+      auto dir = direction == "reverse" ? fan::FanDirection::REVERSE : fan::FanDirection::FORWARD;
+      target->make_call().set_direction(dir).perform();
+    }
+  }
+}
+#endif  // USE_FAN
+
+#ifdef USE_LIGHT
+inline const char *ws_light_color_mode_to_ha_(light::ColorMode mode) {
+  using light::ColorMode;
+  switch (mode) {
+    case ColorMode::ON_OFF:
+      return "onoff";
+    case ColorMode::BRIGHTNESS:
+      return "brightness";
+    case ColorMode::WHITE:
+      return "white";
+    case ColorMode::COLOR_TEMPERATURE:
+    case ColorMode::COLD_WARM_WHITE:
+      return "color_temp";
+    case ColorMode::RGB:
+      return "rgb";
+    case ColorMode::RGB_WHITE:
+      return "rgbw";
+    case ColorMode::RGB_COLOR_TEMPERATURE:
+    case ColorMode::RGB_COLD_WARM_WHITE:
+      return "rgbww";
+    default:
+      return nullptr;
+  }
+}
+
+inline void ws_fill_state_light(light::LightState &src, JsonObject value) {
+  const auto &v = src.remote_values;
+  bool on = v.is_on();
+  value["state"] = on ? "on" : "off";
+  if (!on)
+    return;
+
+  auto traits = src.get_traits();
+  if (traits.supports_color_capability(light::ColorCapability::BRIGHTNESS))
+    value["brightness"] = light::to_uint8_scale(v.get_brightness());
+
+  if (const char *mode = ws_light_color_mode_to_ha_(v.get_color_mode()))
+    value["color_mode"] = mode;
+
+  using light::ColorMode;
+  switch (v.get_color_mode()) {
+    case ColorMode::COLOR_TEMPERATURE:
+    case ColorMode::RGB_COLOR_TEMPERATURE: {
+      float mireds = v.get_color_temperature();
+      if (mireds > 0.0f)
+        value["color_temp_kelvin"] = static_cast<int>(roundf(1000000.0f / mireds));
+      break;
+    }
+    case ColorMode::COLD_WARM_WHITE:
+    case ColorMode::RGB_COLD_WARM_WHITE: {
+      float min_m = traits.get_min_mireds();
+      float max_m = traits.get_max_mireds();
+      float cold = v.get_cold_white();
+      float warm = v.get_warm_white();
+      float sum = cold + warm;
+      if (sum > 0.0f && max_m > min_m) {
+        float mireds = min_m + (1.0f - cold / sum) * (max_m - min_m);
+        if (mireds > 0.0f)
+          value["color_temp_kelvin"] = static_cast<int>(roundf(1000000.0f / mireds));
+      }
+      if (v.get_color_mode() == ColorMode::RGB_COLD_WARM_WHITE) {
+        JsonArray rgbww = value["rgbww_color"].to<JsonArray>();
+        rgbww.add(light::to_uint8_scale(v.get_red()));
+        rgbww.add(light::to_uint8_scale(v.get_green()));
+        rgbww.add(light::to_uint8_scale(v.get_blue()));
+        rgbww.add(light::to_uint8_scale(v.get_cold_white()));
+        rgbww.add(light::to_uint8_scale(v.get_warm_white()));
+      }
+      break;
+    }
+    case ColorMode::RGB: {
+      JsonArray rgb = value["rgb_color"].to<JsonArray>();
+      rgb.add(light::to_uint8_scale(v.get_red()));
+      rgb.add(light::to_uint8_scale(v.get_green()));
+      rgb.add(light::to_uint8_scale(v.get_blue()));
+      break;
+    }
+    case ColorMode::RGB_WHITE: {
+      JsonArray rgbw = value["rgbw_color"].to<JsonArray>();
+      rgbw.add(light::to_uint8_scale(v.get_red()));
+      rgbw.add(light::to_uint8_scale(v.get_green()));
+      rgbw.add(light::to_uint8_scale(v.get_blue()));
+      rgbw.add(light::to_uint8_scale(v.get_white()));
+      break;
+    }
+    case ColorMode::WHITE:
+      value["brightness"] = light::to_uint8_scale(v.get_white() * v.get_brightness());
+      break;
+    default:
+      break;
+  }
+
+  std::string effect = src.get_effect_name();
+  if (!effect.empty() && effect != "None")
+    value["effect"] = effect;
+}
+
+inline void ws_send_state_light(WsBridgeDevice *dev, light::LightState &src) {
+  dev->get_ws_bridge_parent()->send_state_object(dev->get_ws_bridge_unique_id(),
+                                                 [&src](JsonObject value) { ws_fill_state_light(src, value); });
+}
+
+inline void ws_declare_light(WsBridgeDevice *dev, light::LightState &src, const std::string &name) {
+  dev->get_ws_bridge_parent()->send_entity_declare(
+      dev->get_ws_bridge_unique_id(), "light", name, dev->get_ws_bridge_device_id(),
+      dev->get_ws_bridge_device_name(), [&src](JsonObject root) {
+        add_common_entity_fields(root, src, nullptr);
+        auto traits = src.get_traits();
+        JsonArray modes = root["supported_color_modes"].to<JsonArray>();
+        bool has_colorful = false;
+        for (auto mode : traits.get_supported_color_modes()) {
+          if (mode == light::ColorMode::ON_OFF || mode == light::ColorMode::BRIGHTNESS)
+            continue;
+          if (const char *ha = ws_light_color_mode_to_ha_(mode)) {
+            modes.add(ha);
+            has_colorful = true;
+          }
+        }
+        if (!has_colorful) {
+          if (traits.supports_color_mode(light::ColorMode::BRIGHTNESS))
+            modes.add("brightness");
+          else
+            modes.add("onoff");
+        }
+
+        float min_m = traits.get_min_mireds();
+        float max_m = traits.get_max_mireds();
+        if (min_m > 0.0f && max_m > 0.0f) {
+          // HA wants kelvin; ESPHome traits store mireds (min mireds = max kelvin).
+          root["max_color_temp_kelvin"] = static_cast<int>(roundf(1000000.0f / min_m));
+          root["min_color_temp_kelvin"] = static_cast<int>(roundf(1000000.0f / max_m));
+        }
+
+        if (src.supports_effects()) {
+          JsonArray effects = root["effect_list"].to<JsonArray>();
+          for (auto *effect : src.get_effects())
+            effects.add(effect->get_name());
+        }
+
+        JsonArray features = root["features"].to<JsonArray>();
+        if (traits.supports_color_capability(light::ColorCapability::BRIGHTNESS)) {
+          features.add("transition");
+          features.add("flash");
+        }
+        if (src.supports_effects())
+          features.add("effect");
+        if (features.size() == 0)
+          root.remove("features");
+      });
+}
+
+inline void ws_push_state_light(WsBridgeDevice *dev, light::LightState &src) { ws_send_state_light(dev, src); }
+
+inline void ws_subscribe_light(WsBridgeDevice *dev, light::LightState *src) {
+  src->add_new_remote_values_callback([dev, src]() { ws_send_state_light(dev, *src); });
+}
+
+inline void ws_hs_to_rgb_(float h, float s_pct, float &r, float &g, float &b) {
+  float s = s_pct / 100.0f;
+  float c = s;
+  float x = c * (1.0f - fabsf(fmodf(h / 60.0f, 2.0f) - 1.0f));
+  float m = 1.0f - c;
+  float rp = 0, gp = 0, bp = 0;
+  if (h < 60.0f) {
+    rp = c;
+    gp = x;
+  } else if (h < 120.0f) {
+    rp = x;
+    gp = c;
+  } else if (h < 180.0f) {
+    gp = c;
+    bp = x;
+  } else if (h < 240.0f) {
+    gp = x;
+    bp = c;
+  } else if (h < 300.0f) {
+    rp = x;
+    bp = c;
+  } else {
+    rp = c;
+    bp = x;
+  }
+  r = rp + m;
+  g = gp + m;
+  b = bp + m;
+}
+
+inline void ws_handle_command_light(light::LightState *target, const WsCommand &command) {
+  if (command.action == "turn_off") {
+    auto call = target->turn_off();
+    float transition;
+    if (command.param_float("transition", transition))
+      call.set_transition_length(static_cast<uint32_t>(transition * 1000.0f));
+    call.perform();
+    return;
+  }
+  if (command.action != "turn_on")
+    return;
+
+  auto call = target->turn_on();
+  float brightness;
+  if (command.param_float("brightness", brightness))
+    call.set_brightness(brightness / 255.0f);
+
+  float kelvin;
+  if (command.param_float("color_temp_kelvin", kelvin) && kelvin > 0.0f)
+    call.set_color_temperature(1000000.0f / kelvin);
+
+  std::vector<float> hs;
+  if (command.param_array("hs_color", hs, 2)) {
+    float r, g, b;
+    ws_hs_to_rgb_(hs[0], hs[1], r, g, b);
+    call.set_rgb(r, g, b);
+  }
+
+  std::vector<float> rgb;
+  if (command.param_array("rgb_color", rgb, 3))
+    call.set_rgb(rgb[0] / 255.0f, rgb[1] / 255.0f, rgb[2] / 255.0f);
+
+  std::vector<float> rgbw;
+  if (command.param_array("rgbw_color", rgbw, 4))
+    call.set_rgbw(rgbw[0] / 255.0f, rgbw[1] / 255.0f, rgbw[2] / 255.0f, rgbw[3] / 255.0f);
+
+  std::vector<float> rgbww;
+  if (command.param_array("rgbww_color", rgbww, 5)) {
+    call.set_rgb(rgbww[0] / 255.0f, rgbww[1] / 255.0f, rgbww[2] / 255.0f);
+    call.set_cold_white(rgbww[3] / 255.0f);
+    call.set_warm_white(rgbww[4] / 255.0f);
+  }
+
+  float white;
+  if (command.param_float("white", white))
+    call.set_white(white / 255.0f);
+
+  std::string effect;
+  if (command.param_string("effect", effect))
+    call.set_effect(effect);
+
+  float transition;
+  if (command.param_float("transition", transition))
+    call.set_transition_length(static_cast<uint32_t>(transition * 1000.0f));
+
+  std::string flash;
+  if (command.param_string("flash", flash)) {
+    uint32_t ms = flash == "long" ? 5000 : 1000;
+    call.set_flash_length(ms);
+  }
+
+  call.perform();
+}
+#endif  // USE_LIGHT
 
 }  // namespace ws_bridge
 }  // namespace esphome

--- a/components/ws_bridge/ws_bridge_domains.h
+++ b/components/ws_bridge/ws_bridge_domains.h
@@ -346,7 +346,8 @@ inline void ws_fill_state_cover(cover::Cover &src, JsonObject value) {
       break;
     case cover::COVER_OPERATION_IDLE:
     default:
-      value["state"] = src.position > 0.5f ? "open" : "closed";
+      // ESPHome treats only position==0 as closed (cover.cpp); anything else is open.
+      value["state"] = src.is_fully_closed() ? "closed" : "open";
       break;
   }
   value["position"] = static_cast<int>(roundf(src.position * 100.0f));
@@ -430,8 +431,8 @@ inline void ws_fill_state_fan(fan::Fan &src, JsonObject value) {
     value["oscillating"] = src.oscillating;
   if (traits.supports_direction())
     value["direction"] = src.direction == fan::FanDirection::REVERSE ? "reverse" : "forward";
-  if (traits.supports_preset_modes() && !src.preset_mode.empty())
-    value["preset_mode"] = src.preset_mode;
+  if (traits.supports_preset_modes() && src.has_preset_mode())
+    value["preset_mode"] = src.get_preset_mode();
 }
 
 inline void ws_send_state_fan(WsBridgeDevice *dev, fan::Fan &src) {
@@ -569,6 +570,10 @@ inline void ws_fill_state_light(light::LightState &src, JsonObject value) {
   if (const char *mode = ws_light_color_mode_to_ha_(v.get_color_mode()))
     value["color_mode"] = mode;
 
+  // ESPHome stores RGB normalized with color_brightness separate — HA wants
+  // scaled 0–255 channels (see homeassistant/components/esphome/light.py).
+  const float color_bri = v.get_color_brightness();
+
   using light::ColorMode;
   switch (v.get_color_mode()) {
     case ColorMode::COLOR_TEMPERATURE:
@@ -576,6 +581,12 @@ inline void ws_fill_state_light(light::LightState &src, JsonObject value) {
       float mireds = v.get_color_temperature();
       if (mireds > 0.0f)
         value["color_temp_kelvin"] = static_cast<int>(roundf(1000000.0f / mireds));
+      if (v.get_color_mode() == ColorMode::RGB_COLOR_TEMPERATURE) {
+        JsonArray rgb = value["rgb_color"].to<JsonArray>();
+        rgb.add(light::to_uint8_scale(v.get_red() * color_bri));
+        rgb.add(light::to_uint8_scale(v.get_green() * color_bri));
+        rgb.add(light::to_uint8_scale(v.get_blue() * color_bri));
+      }
       break;
     }
     case ColorMode::COLD_WARM_WHITE:
@@ -592,9 +603,9 @@ inline void ws_fill_state_light(light::LightState &src, JsonObject value) {
       }
       if (v.get_color_mode() == ColorMode::RGB_COLD_WARM_WHITE) {
         JsonArray rgbww = value["rgbww_color"].to<JsonArray>();
-        rgbww.add(light::to_uint8_scale(v.get_red()));
-        rgbww.add(light::to_uint8_scale(v.get_green()));
-        rgbww.add(light::to_uint8_scale(v.get_blue()));
+        rgbww.add(light::to_uint8_scale(v.get_red() * color_bri));
+        rgbww.add(light::to_uint8_scale(v.get_green() * color_bri));
+        rgbww.add(light::to_uint8_scale(v.get_blue() * color_bri));
         rgbww.add(light::to_uint8_scale(v.get_cold_white()));
         rgbww.add(light::to_uint8_scale(v.get_warm_white()));
       }
@@ -602,16 +613,16 @@ inline void ws_fill_state_light(light::LightState &src, JsonObject value) {
     }
     case ColorMode::RGB: {
       JsonArray rgb = value["rgb_color"].to<JsonArray>();
-      rgb.add(light::to_uint8_scale(v.get_red()));
-      rgb.add(light::to_uint8_scale(v.get_green()));
-      rgb.add(light::to_uint8_scale(v.get_blue()));
+      rgb.add(light::to_uint8_scale(v.get_red() * color_bri));
+      rgb.add(light::to_uint8_scale(v.get_green() * color_bri));
+      rgb.add(light::to_uint8_scale(v.get_blue() * color_bri));
       break;
     }
     case ColorMode::RGB_WHITE: {
       JsonArray rgbw = value["rgbw_color"].to<JsonArray>();
-      rgbw.add(light::to_uint8_scale(v.get_red()));
-      rgbw.add(light::to_uint8_scale(v.get_green()));
-      rgbw.add(light::to_uint8_scale(v.get_blue()));
+      rgbw.add(light::to_uint8_scale(v.get_red() * color_bri));
+      rgbw.add(light::to_uint8_scale(v.get_green() * color_bri));
+      rgbw.add(light::to_uint8_scale(v.get_blue() * color_bri));
       rgbw.add(light::to_uint8_scale(v.get_white()));
       break;
     }
@@ -622,9 +633,9 @@ inline void ws_fill_state_light(light::LightState &src, JsonObject value) {
       break;
   }
 
-  std::string effect = src.get_effect_name();
+  StringRef effect = src.get_effect_name();
   if (!effect.empty() && effect != "None")
-    value["effect"] = effect;
+    value["effect"] = effect;  // ArduinoJson has convertToJson(StringRef)
 }
 
 inline void ws_send_state_light(WsBridgeDevice *dev, light::LightState &src) {
@@ -683,8 +694,23 @@ inline void ws_declare_light(WsBridgeDevice *dev, light::LightState &src, const 
 
 inline void ws_push_state_light(WsBridgeDevice *dev, light::LightState &src) { ws_send_state_light(dev, src); }
 
-inline void ws_subscribe_light(WsBridgeDevice *dev, light::LightState *src) {
-  src->add_new_remote_values_callback([dev, src]() { ws_send_state_light(dev, *src); });
+// LightState no longer accepts std::function callbacks — platforms that want
+// state pushes must implement LightRemoteValuesListener and register `this`.
+inline void ws_subscribe_light(light::LightState *src, light::LightRemoteValuesListener *listener) {
+  src->add_remote_values_listener(listener);
+}
+
+inline void ws_apply_rgb_(light::LightCall &call, float r, float g, float b) {
+  // HA sends absolute 0–1 RGB; ESPHome normalizes channels and keeps the max
+  // in color_brightness (otherwise validate_()/normalize_color() discards it).
+  float color_bri = fmaxf(r, fmaxf(g, b));
+  if (color_bri > 0.0f) {
+    call.set_rgb(r / color_bri, g / color_bri, b / color_bri);
+    call.set_color_brightness(color_bri);
+  } else {
+    call.set_rgb(0.0f, 0.0f, 0.0f);
+    call.set_color_brightness(0.0f);
+  }
 }
 
 inline void ws_hs_to_rgb_(float h, float s_pct, float &r, float &g, float &b) {
@@ -742,20 +768,22 @@ inline void ws_handle_command_light(light::LightState *target, const WsCommand &
   if (command.param_array("hs_color", hs, 2)) {
     float r, g, b;
     ws_hs_to_rgb_(hs[0], hs[1], r, g, b);
-    call.set_rgb(r, g, b);
+    ws_apply_rgb_(call, r, g, b);
   }
 
   std::vector<float> rgb;
   if (command.param_array("rgb_color", rgb, 3))
-    call.set_rgb(rgb[0] / 255.0f, rgb[1] / 255.0f, rgb[2] / 255.0f);
+    ws_apply_rgb_(call, rgb[0] / 255.0f, rgb[1] / 255.0f, rgb[2] / 255.0f);
 
   std::vector<float> rgbw;
-  if (command.param_array("rgbw_color", rgbw, 4))
-    call.set_rgbw(rgbw[0] / 255.0f, rgbw[1] / 255.0f, rgbw[2] / 255.0f, rgbw[3] / 255.0f);
+  if (command.param_array("rgbw_color", rgbw, 4)) {
+    ws_apply_rgb_(call, rgbw[0] / 255.0f, rgbw[1] / 255.0f, rgbw[2] / 255.0f);
+    call.set_white(rgbw[3] / 255.0f);
+  }
 
   std::vector<float> rgbww;
   if (command.param_array("rgbww_color", rgbww, 5)) {
-    call.set_rgb(rgbww[0] / 255.0f, rgbww[1] / 255.0f, rgbww[2] / 255.0f);
+    ws_apply_rgb_(call, rgbww[0] / 255.0f, rgbww[1] / 255.0f, rgbww[2] / 255.0f);
     call.set_cold_white(rgbww[3] / 255.0f);
     call.set_warm_white(rgbww[4] / 255.0f);
   }

--- a/components/ws_bridge/ws_bridge_entity_json.h
+++ b/components/ws_bridge/ws_bridge_entity_json.h
@@ -1,6 +1,5 @@
 #pragma once
 #include <array>
-#include <initializer_list>
 #include "esphome/core/entity_base.h"
 #include "ws_protocol.h"
 
@@ -52,14 +51,6 @@ inline void add_common_entity_fields(JsonObject root, const EntityBase &src, con
     default:
       break;
   }
-}
-
-// Attach features: ["open","close","stop", ...] on declare. An empty list
-// sends nothing so HA keeps its platform defaults.
-inline void add_features(JsonObject root, std::initializer_list<const char *> names) {
-  if (names.size() == 0) return;
-  JsonArray arr = root["features"].to<JsonArray>();
-  for (const char *n : names) arr.add(n);
 }
 
 }  // namespace ws_bridge

--- a/components/ws_bridge/ws_bridge_entity_ref.cpp
+++ b/components/ws_bridge/ws_bridge_entity_ref.cpp
@@ -124,5 +124,53 @@ void WsBridgeUpdateRef::ws_bridge_handle_command(const WsCommand &command) {
 }
 #endif
 
+#ifdef USE_LIGHT
+void WsBridgeLightRef::setup() { ws_subscribe_light(this, this->source_); }
+void WsBridgeLightRef::dump_config() {
+  ESP_LOGCONFIG(TAG, "WS Bridge Entity Ref '%s' -> light '%s'", this->get_ws_bridge_unique_id().c_str(),
+                this->source_->get_name().str().c_str());
+}
+void WsBridgeLightRef::ws_bridge_declare() {
+  ws_declare_light(this, *this->source_,
+                   ws_ha_name(*this->source_, this->name_override_, this->get_ws_bridge_unique_id()));
+  ws_push_state_light(this, *this->source_);
+}
+void WsBridgeLightRef::ws_bridge_handle_command(const WsCommand &command) {
+  ws_handle_command_light(this->source_, command);
+}
+#endif
+
+#ifdef USE_COVER
+void WsBridgeCoverRef::setup() { ws_subscribe_cover(this, this->source_); }
+void WsBridgeCoverRef::dump_config() {
+  ESP_LOGCONFIG(TAG, "WS Bridge Entity Ref '%s' -> cover '%s'", this->get_ws_bridge_unique_id().c_str(),
+                this->source_->get_name().str().c_str());
+}
+void WsBridgeCoverRef::ws_bridge_declare() {
+  ws_declare_cover(this, *this->source_, nullptr,
+                   ws_ha_name(*this->source_, this->name_override_, this->get_ws_bridge_unique_id()));
+  ws_push_state_cover(this, *this->source_);
+}
+void WsBridgeCoverRef::ws_bridge_handle_command(const WsCommand &command) {
+  ws_handle_command_cover(this->source_, command);
+}
+#endif
+
+#ifdef USE_FAN
+void WsBridgeFanRef::setup() { ws_subscribe_fan(this, this->source_); }
+void WsBridgeFanRef::dump_config() {
+  ESP_LOGCONFIG(TAG, "WS Bridge Entity Ref '%s' -> fan '%s'", this->get_ws_bridge_unique_id().c_str(),
+                this->source_->get_name().str().c_str());
+}
+void WsBridgeFanRef::ws_bridge_declare() {
+  ws_declare_fan(this, *this->source_, nullptr,
+                 ws_ha_name(*this->source_, this->name_override_, this->get_ws_bridge_unique_id()));
+  ws_push_state_fan(this, *this->source_);
+}
+void WsBridgeFanRef::ws_bridge_handle_command(const WsCommand &command) {
+  ws_handle_command_fan(this->source_, command);
+}
+#endif
+
 }  // namespace ws_bridge
 }  // namespace esphome

--- a/components/ws_bridge/ws_bridge_entity_ref.cpp
+++ b/components/ws_bridge/ws_bridge_entity_ref.cpp
@@ -125,7 +125,7 @@ void WsBridgeUpdateRef::ws_bridge_handle_command(const WsCommand &command) {
 #endif
 
 #ifdef USE_LIGHT
-void WsBridgeLightRef::setup() { ws_subscribe_light(this, this->source_); }
+void WsBridgeLightRef::setup() { ws_subscribe_light(this->source_, this); }
 void WsBridgeLightRef::dump_config() {
   ESP_LOGCONFIG(TAG, "WS Bridge Entity Ref '%s' -> light '%s'", this->get_ws_bridge_unique_id().c_str(),
                 this->source_->get_name().str().c_str());
@@ -138,6 +138,7 @@ void WsBridgeLightRef::ws_bridge_declare() {
 void WsBridgeLightRef::ws_bridge_handle_command(const WsCommand &command) {
   ws_handle_command_light(this->source_, command);
 }
+void WsBridgeLightRef::on_light_remote_values_update() { ws_send_state_light(this, *this->source_); }
 #endif
 
 #ifdef USE_COVER

--- a/components/ws_bridge/ws_bridge_entity_ref.h
+++ b/components/ws_bridge/ws_bridge_entity_ref.h
@@ -28,6 +28,15 @@
 #ifdef USE_UPDATE
 #include "esphome/components/update/update_entity.h"
 #endif
+#ifdef USE_LIGHT
+#include "esphome/components/light/light_state.h"
+#endif
+#ifdef USE_COVER
+#include "esphome/components/cover/cover.h"
+#endif
+#ifdef USE_FAN
+#include "esphome/components/fan/fan.h"
+#endif
 
 namespace esphome {
 namespace ws_bridge {
@@ -167,6 +176,51 @@ class WsBridgeUpdateRef : public WsBridgeEntityRefBase {
 
  protected:
   update::UpdateEntity *source_{nullptr};
+};
+#endif
+
+#ifdef USE_LIGHT
+class WsBridgeLightRef : public WsBridgeEntityRefBase {
+ public:
+  void set_source(light::LightState *source) { this->source_ = source; }
+  const EntityBase *get_ws_bridge_source() const override { return this->source_; }
+  void setup() override;
+  void dump_config() override;
+  void ws_bridge_declare() override;
+  void ws_bridge_handle_command(const WsCommand &command) override;
+
+ protected:
+  light::LightState *source_{nullptr};
+};
+#endif
+
+#ifdef USE_COVER
+class WsBridgeCoverRef : public WsBridgeEntityRefBase {
+ public:
+  void set_source(cover::Cover *source) { this->source_ = source; }
+  const EntityBase *get_ws_bridge_source() const override { return this->source_; }
+  void setup() override;
+  void dump_config() override;
+  void ws_bridge_declare() override;
+  void ws_bridge_handle_command(const WsCommand &command) override;
+
+ protected:
+  cover::Cover *source_{nullptr};
+};
+#endif
+
+#ifdef USE_FAN
+class WsBridgeFanRef : public WsBridgeEntityRefBase {
+ public:
+  void set_source(fan::Fan *source) { this->source_ = source; }
+  const EntityBase *get_ws_bridge_source() const override { return this->source_; }
+  void setup() override;
+  void dump_config() override;
+  void ws_bridge_declare() override;
+  void ws_bridge_handle_command(const WsCommand &command) override;
+
+ protected:
+  fan::Fan *source_{nullptr};
 };
 #endif
 

--- a/components/ws_bridge/ws_bridge_entity_ref.h
+++ b/components/ws_bridge/ws_bridge_entity_ref.h
@@ -180,7 +180,7 @@ class WsBridgeUpdateRef : public WsBridgeEntityRefBase {
 #endif
 
 #ifdef USE_LIGHT
-class WsBridgeLightRef : public WsBridgeEntityRefBase {
+class WsBridgeLightRef : public WsBridgeEntityRefBase, public light::LightRemoteValuesListener {
  public:
   void set_source(light::LightState *source) { this->source_ = source; }
   const EntityBase *get_ws_bridge_source() const override { return this->source_; }
@@ -188,6 +188,7 @@ class WsBridgeLightRef : public WsBridgeEntityRefBase {
   void dump_config() override;
   void ws_bridge_declare() override;
   void ws_bridge_handle_command(const WsCommand &command) override;
+  void on_light_remote_values_update() override;
 
  protected:
   light::LightState *source_{nullptr};

--- a/tests/components/ws_bridge/test.esp32-idf.yaml
+++ b/tests/components/ws_bridge/test.esp32-idf.yaml
@@ -64,6 +64,9 @@ ws_bridge:
     - source_id: local_button2
     - source_id: my_update
       unique_id: firmware_ref
+    - source_id: local_light
+    - source_id: local_cover
+    - source_id: local_fan
 
 sensor:
   - platform: ws_bridge
@@ -214,3 +217,45 @@ update:
     update_id: my_update
 
 safe_mode:
+
+output:
+  - platform: gpio
+    pin: GPIO2
+    id: local_led_out
+
+light:
+  - platform: binary
+    id: local_light
+    name: "Local Light"
+    output: local_led_out
+  - platform: ws_bridge
+    unique_id: light_bridged
+    name: "Light (bridged)"
+    light_id: local_light
+
+cover:
+  - platform: ws_bridge
+    unique_id: cover1
+    name: "Cover"
+  - platform: template
+    id: local_cover
+    name: "Local Cover"
+    optimistic: true
+    assumed_state: true
+  - platform: ws_bridge
+    unique_id: cover_bridged
+    name: "Cover (bridged)"
+    cover_id: local_cover
+
+fan:
+  - platform: ws_bridge
+    unique_id: fan1
+    name: "Fan"
+  - platform: template
+    id: local_fan
+    name: "Local Fan"
+    speed_count: 100
+  - platform: ws_bridge
+    unique_id: fan_bridged
+    name: "Fan (bridged)"
+    fan_id: local_fan


### PR DESCRIPTION
## Summary
- Phase **C2**: `light` (wrap-only via `light_id:`), `cover` and `fan` (standalone or `cover_id:`/`fan_id:`).
- Domain helpers declare `features` / color modes / speed presets from ESPHome traits, push object state, and apply HA commands through `params`.
- Hub `entities:` can also expose light/cover/fan; README + compile test YAML updated.
- Small compat: `add_idf_component` falls back to git `repo=` on older ESPHome APIs.

## Test plan
- [x] `esphome config tests/components/ws_bridge/test.esp32-idf.yaml` (valid)
- [ ] `esphome compile` on ESPHome 2025.7+ (local 2025.5.2 lacks `event_pool.h` used by current ws_bridge)
- [ ] Device: declare light/cover/fan → HA entities appear with expected features
- [ ] Commands: light `turn_on` with brightness/rgb; cover open/position; fan percentage/direction
- [ ] Reconnect re-declare; existing platforms still work

Next: **C3** (text/lock/valve/event/datetime).


Made with [Cursor](https://cursor.com)