### PR TITLE
feat(ws_bridge): C3 — text / lock / valve / event / datetime

### DIFF
--- a/components/ws_bridge/IMPLEMENTATION_PLAN_ko.md
+++ b/components/ws_bridge/IMPLEMENTATION_PLAN_ko.md
@@ -3,9 +3,9 @@
 > **대상**: 이 컴포넌트에서 작업할 다른 AI 에이전트 또는 개발자
 > **목적**: HA 통합(`hass-ws-bridge`)이 Phase 0~4에서 확장한 프로토콜에 클라이언트를 맞춘다
 > **서버 기준**: `hass-ws-bridge` main (Phase 4 + 공통 계층 정리 완료, 플랫폼 27종)
-> **클라이언트 현재**: 플랫폼 11종(+ tracker) — C0 `params`/`features`·C1 `update`·C2 `light`/`cover`/`fan` 반영. 남은 Tier A는 C3+.
+> **클라이언트 현재**: 플랫폼 18종(+ tracker) — C0 `params`/`features`·C1 `update`·C2 `light`/`cover`/`fan`·C3 `text`/`lock`/`valve`/`event`/`date`/`time`/`datetime` 반영. 남은 Tier A는 C4+.
 > **작성일**: 2026-08-13
-> **갱신**: 2026-08-13 — C0 머지 + C2 구현
+> **갱신**: 2026-08-13 — C0 머지 + C2 + C3 구현
 
 ---
 
@@ -22,7 +22,7 @@
 
 ## 1. 현재 격차
 
-### 1.1 구현 완료 (8종 + tracker)
+### 1.1 구현 완료 (18종 + tracker)
 
 | ESPHome 플랫폼 | 디렉터리 | 방향 |
 |:---|:---|:---:|
@@ -34,15 +34,24 @@
 | `select` | `select/` | 제어 |
 | `button` | `button/` | 제어 |
 | `update` | `update/` | 제어 (OTA, #296) |
+| `light` | `light/` | 제어 (C2) |
+| `cover` | `cover/` | 제어 (C2) |
+| `fan` | `fan/` | 제어 (C2) |
+| `text` | `text/` | 제어 (C3) |
+| `lock` | `lock/` | 제어 (C3) |
+| `valve` | `valve/` | 제어 (C3) |
+| `event` | `event/` | 읽기 (C3) |
+| `date` / `time` / `datetime` | `datetime/` (`type:` 분기, 3클래스) | 제어 (C3) |
 | `device_tracker` | 허브 `trackers:` 인라인 (`ws_bridge_tracker.*`) | 읽기 |
 
 구조는 이미 좋다 — §1.3의 기존 자산을 그대로 활용한다. 엔티티 래핑(`sensor_id` / `entities:`)과 `ws_bridge/sync`도 master에 있다.
 
-### 1.2 서버가 지원하지만 클라이언트에 없는 것 (15종)
+### 1.2 서버가 지원하지만 클라이언트에 없는 것 (8종)
 
-`text`, `lock`, `date`, `time`, `datetime`,
-`event`, `valve`, `climate`, `humidifier`, `water_heater`, `siren`,
+`climate`, `humidifier`, `water_heater`, `siren`,
 `alarm_control_panel`, `media_player`, `image`, `camera`
+
+이 중 Tier A(정식 플랫폼으로 만들 수 있는 것)는 `climate`(C4), `alarm_control_panel`·`media_player`(C5)뿐이다. 나머지 5종은 Tier B — §4.0 참고.
 
 ### 1.3 이미 갖춰진 자산 (새로 만들지 말 것)
 
@@ -236,11 +245,33 @@ this->parent_->send_state_object(this->unique_id_, [this](JsonObject v) {
 |:---|:---|:---|
 | **C0** | 프로토콜 계층 (§3) | 전제 — `params` + `add_features` |
 | **C1** | `update` | **완료** (#296). OTA 직결 |
-| **C2** | `light`, `cover`, `fan` | **이번 PR**. 수요 최다. `params` 수신을 처음 실제로 씀 |
-| **C3** | `text`, `lock`, `valve`, `event`, `datetime`(date/time/datetime) | 스칼라 위주, 난도 낮음 |
+| **C2** | `light`, `cover`, `fan` | **완료**. 수요 최다. `params` 수신을 처음 실제로 씀 |
+| **C3** | `text`, `lock`, `valve`, `event`, `datetime`(date/time/datetime) | **완료**. §4.2의 도메인별 함정을 먼저 읽을 것 |
 | **C4** | `climate` | 단독. 상태·명령 표면이 가장 넓다 |
 | **C5** | `alarm_control_panel`, `media_player` | 수요 확인 후 |
 | **C6** (보류) | Tier B 5종 | 요구 확인 전 착수 금지 |
+
+### 4.2 C3에서 실제로 밟은 것 (ESPHome 2026.7.4 기준)
+
+C4 이후에도 그대로 걸릴 항목들이다. 코드를 쓰기 전에 읽는다.
+
+1. **`text`의 `min`/`max`는 문자열 길이다.** `TextTraits`는 "미설정" 센티널이 없다 — `register_text()`가 항상 0/255를 써 넣으므로, `number`처럼 필드별 폴백(`ovr` → `src`)을 만들 수 없다. `cover`/`fan`/`light`의 traits와 같이 **`src`만 읽는다**. 래핑하면 감싼 엔티티의 길이 제한·pattern·mode가 그대로 선언된다.
+
+2. **`lock`의 `code_format`은 ESPHome에 대응물이 없다.** `LockTraits::requires_code`는 있어도 코드 값을 넘길 API가 없다. 그래서 `code_format:`은 ws_bridge YAML 전용 옵션이고, HA가 커맨드에 실어 보내는 `params.code`는 **버린다.** UI 확인 절차이지 인증이 아니라는 걸 문서에 못박을 것.
+
+3. **`Lock::open()`은 `control()`을 타지 않는다.** `open_latch()`로 빠지고, 기본 구현은 `unlock()`이다. 낙관적 상태를 내려면 `open_latch()`를 오버라이드해 `LOCK_STATE_OPEN`을 `publish_state()`해야 한다. 또 `traits.get_supports_open()`이 false면 `open()`이 경고만 남기고 아무것도 안 하고, `LockCall::validate_()`가 `supported_states_mask_` 밖의 상태를 조용히 버린다 — 비래핑 엔티티는 `setup()`에서 `set_supports_open(true)` + `add_supported_state(LOCK_STATE_OPEN)`이 필요하다.
+
+4. **`event`는 선언 시 상태를 보내지 않는다.** §7-12의 "선언 시 현재 상태를 함께 보낸다"의 **유일한 예외**다. 일회성이고 HA가 last state를 복원하지 않으므로, 재연결마다 마지막 `event_type`을 다시 밀면 이미 끝난 초인종이 다시 울린다.
+
+5. **`event_types`는 `src`에서 읽는다.** `select`의 options처럼 `ovr` 우선으로 하면, 래핑 시 감싼 엔티티가 실제로 발생시키는 타입이 선언 목록에서 빠질 수 있고 HA는 선언되지 않은 `event_type`을 조용히 버린다.
+
+6. **빈 리스트를 `set_event_types()`에 넘길 수 없다.** codegen이 빈 파이썬 리스트를 `{}`로 렌더링하고, `initializer_list` / `FixedVector` / `vector` 오버로드(+ 실수 방지용 `=delete` `std::string` 판) 사이에서 **모호**해진다. `cg.RawExpression("std::vector<const char *>{}")`로 타입을 명시한다. 진짜 목록은 `setup()`에서 소스의 것을 복사한다.
+
+7. **`date`/`time`은 `datetime` 컴포넌트 소속이다** (§7-8). 셋 다 `datetime/` 한 디렉터리에서 `cv.typed_schema({...}, upper=True)`로 분기하고, **클래스는 3개**다 (`DateEntity`/`TimeEntity`/`DateTimeEntity`는 서로 무관한 클래스다). `datetime_id:`는 분기마다 타입을 달리 준다 — 그러면 `type: date`에 `TimeEntity`를 붙이는 게 컴파일 에러가 아니라 설정 에러가 된다. `entities:`용 Ref도 공통 `DateTimeBase` 하나가 아니라 3개가 필요하다 (HA 쪽 플랫폼이 3개다).
+
+8. **`ESPTime::strptime()`은 ISO 8601을 다 못 먹는다.** `"YYYY-MM-DD[ HH:MM[:SS]]"`와 `"HH:MM[:SS]"`뿐 — `T` 구분자, 소수점 초, 타임존 접미사가 모두 실패한다. HA는 `"2026-08-13T21:30:00+09:00"`을 보낸다. 정규화할 때 **날짜의 `-`를 음수 오프셋으로 오인하지 않도록** 첫 `:` 이후부터 스캔한다.
+
+9. **날짜 상태는 tz-naive로 보낸다.** HA가 자기 로컬 타임존을 붙인다(UTC로 해석하지 않는다). `state_as_esptime()`은 자기 엔티티가 안 쓰는 필드를 채우지 않으므로(`DateEntity`는 시/분/초를 건드리지 않는다) `strftime` 포맷에 **자기 필드만** 넣어야 한다.
 
 ---
 
@@ -319,7 +350,9 @@ esphome compile <your-test-device>.yaml
 
 11. **ESP-IDF 전용**: 허브가 `_validate_esp_idf()`로 강제한다. Arduino 프레임워크 예제를 만들지 말 것.
 
-12. **선언 시 현재 상태를 함께 보낸다.** `ws_bridge_declare()` 끝에서 상태 1회 전송을 빼먹으면, 재연결 직후 HA가 엔티티는 만들지만 값이 비어 있다. `select.cpp` 참조.
+12. **선언 시 현재 상태를 함께 보낸다.** `ws_bridge_declare()` 끝에서 상태 1회 전송을 빼먹으면, 재연결 직후 HA가 엔티티는 만들지만 값이 비어 있다. `select.cpp` 참조. **`event`만 예외** — §4.2-4.
+
+13. **`text`와 `text_sensor`, `datetime`과 `time`을 섞지 말 것.** 전자는 §7-9, 후자는 §7-8. 둘 다 이름만 비슷하고 완전히 다른 컴포넌트다.
 
 ---
 

--- a/components/ws_bridge/README.md
+++ b/components/ws_bridge/README.md
@@ -127,6 +127,52 @@ fan:
     unique_id: ceiling_fan
     name: "Ceiling Fan"
 
+# HA's writable text domain — not the read-only text_sensor above.
+# min_length / max_length are string lengths, not a value range.
+text:
+  - platform: ws_bridge
+    unique_id: note1
+    name: "Note"
+    max_length: 64
+    mode: text                 # or password
+
+lock:
+  - platform: ws_bridge
+    unique_id: front_door
+    name: "Front Door"
+    code_format: '^\d{4}$'     # optional; HA-side prompt only, see below
+
+valve:
+  - platform: ws_bridge
+    unique_id: main_valve
+    name: "Main Valve"
+
+event:
+  - platform: ws_bridge
+    unique_id: doorbell
+    name: "Doorbell"
+    device_class: doorbell
+    event_types:               # required unless event_id: is set
+      - "single"
+      - "double"
+
+# HA's date, time and datetime are three platforms; ESPHome keeps all three in
+# one `datetime:` domain selected by `type:`. ESPHome's `time:` component is a
+# clock source (SNTP), not an entity domain — don't confuse the two.
+datetime:
+  - platform: ws_bridge
+    type: date
+    unique_id: alarm_date
+    name: "Alarm Date"
+  - platform: ws_bridge
+    type: time
+    unique_id: alarm_time
+    name: "Alarm Time"
+  - platform: ws_bridge
+    type: datetime
+    unique_id: next_run
+    name: "Next Run"
+
 # Firmware update entity in HA — wraps ESPHome's http_request update.
 # See "Remote OTA updates" below.
 http_request:
@@ -161,14 +207,14 @@ update:
 | `trackers` | | - | List of GPS `device_tracker` entities — see [GPS device trackers](#gps-device-trackers) below |
 | `entities` | | - | Existing ESPHome entities to expose without a parallel `platform: ws_bridge` entity — see [Exposing existing entities](#exposing-existing-entities) |
 
-### Platform options (all of `sensor`/`binary_sensor`/`text_sensor`/`switch`/`number`/`select`/`button`/`update`/`light`/`cover`/`fan`)
+### Platform options (all of `sensor`/`binary_sensor`/`text_sensor`/`switch`/`number`/`select`/`button`/`update`/`light`/`cover`/`fan`/`text`/`lock`/`valve`/`event`/`datetime`)
 
 | Option | Required | Description |
 |--------|:--------:|-------------|
 | `unique_id` | ✓ | Identifier for this entity, unique within the gateway. **Changing it creates a new HA entity** (the old one is left behind; `sync_entities: true` then deletes it) |
 | `ws_device_id` | | Groups this entity under a sub-device in HA (e.g. multiple sensors on one physical board) |
 | `ws_device_name` | | Display name for that sub-device |
-| `sensor_id` / `binary_sensor_id` / `text_sensor_id` / `switch_id` / `number_id` / `select_id` / `button_id` / `cover_id` / `fan_id` | | ID of an existing ESPHome entity to wrap — see [Exposing existing entities](#exposing-existing-entities) |
+| `sensor_id` / `binary_sensor_id` / `text_sensor_id` / `switch_id` / `number_id` / `select_id` / `button_id` / `cover_id` / `fan_id` / `text_id` / `lock_id` / `valve_id` / `event_id` / `datetime_id` | | ID of an existing ESPHome entity to wrap — see [Exposing existing entities](#exposing-existing-entities) |
 | `update_id` / `light_id` | ✓ (`update` / `light` only) | ID of the ESPHome entity to wrap (`update:` typically `platform: http_request`; `light:` any `LightState`) |
 | `name` | (`update` / `light`) | HA-facing name. If omitted, uses the wrapped entity's name when that entity has its own `name:`; otherwise the `unique_id` |
 
@@ -180,6 +226,31 @@ wrapping, those inherit from the source unless also set here —
 *not* wrapping. An id-only `http_request` update is `internal` and named
 after its id — set `name:` on the `ws_bridge` wrapper so Home Assistant does
 not show `"ota_update"`.
+
+A few platforms have options of their own:
+
+| Platform | Option | Required | Description |
+|----------|--------|:--------:|-------------|
+| `text` | `min_length` / `max_length` | | Allowed **string length** (0 / 255), not a value range |
+| `text` | `pattern` | | Regex HA validates the typed value against |
+| `text` | `mode` | | `text` (default) or `password` |
+| `lock` | `code_format` | | Regex for HA's code prompt, e.g. `'^\d{4}$'`. **Declare-only**: ESPHome's lock domain has no way to receive the code, so the `code` HA sends with the command is discarded. Treat this as a UI confirmation step, not authentication |
+| `event` | `event_types` | ✓ unless `event_id:` | The event types this entity can fire. HA discards any state whose `event_type` was not declared |
+| `datetime` | `type` | ✓ | `date`, `time` or `datetime` — picks which HA platform this becomes |
+
+Standalone (non-wrapping) `text`, `lock`, `valve` and `datetime` entities are
+optimistic, like `switch`: a command from HA is echoed straight back as the new
+state. A standalone `lock` also advertises the `open` (unlatch) feature, since
+there is no hardware here to constrain it.
+
+`text`, `valve` and `datetime` wrappers report the wrapped entity's own limits
+(`min_length`/`max_length`/`pattern`/`mode`, `reports_position`) and a wrapped
+`event` declares the wrapped entity's `event_types`, so those options can be
+left out. `datetime_id:` must point at an entity of the same `type:`.
+
+`date` / `time` / `datetime` states cross the wire as timezone-naive ISO 8601
+strings (`2026-08-13`, `21:30:00`, `2026-08-13T21:30:00`); Home Assistant
+attaches its own local timezone to them rather than reading them as UTC.
 
 ## Exposing existing entities
 
@@ -233,9 +304,10 @@ number:
   field — a number that sets only `min_value`/`max_value` keeps the
   source's `step`, and vice versa.
 - **Commands** on `switch` / `number` / `select` / `button` / `update` /
-  `light` / `cover` / `fan` are applied to the wrapped entity, not to the
-  wrapper. On-device automations should keep targeting the source
-  (`switch.turn_on: relay`).
+  `light` / `cover` / `fan` / `text` / `lock` / `valve` / `datetime` are
+  applied to the wrapped entity, not to the wrapper. On-device automations
+  should keep targeting the source (`switch.turn_on: relay`). `event` takes
+  no commands at all.
 - ESPHome still requires `id:` or `name:` on the wrapper YAML (`unique_id`
   alone is not enough).
 - `unique_id` is still required. Changing it (or first adding wrapping
@@ -266,7 +338,7 @@ ws_bridge:
 
 | Option | Required | Description |
 |--------|:--------:|-------------|
-| `source_id` | ✓ | ESPHome `id:` of an existing sensor / binary_sensor / text_sensor / switch / number / select / button / update |
+| `source_id` | ✓ | ESPHome `id:` of an existing sensor / binary_sensor / text_sensor / switch / number / select / button / update / light / cover / fan / text / lock / valve / event / date / time / datetime |
 | `unique_id` | | HA identifier. **Defaults to the source's YAML `id:`** (stable across `name:` edits, unlike an object_id) |
 | `name` | | HA-facing name. Defaults to the source's own `name:`; an id-only source (no `name:`) falls back to `unique_id` rather than leaking the ESPHome id |
 | `ws_device_id` / `ws_device_name` | | Same as every other platform |

--- a/components/ws_bridge/__init__.py
+++ b/components/ws_bridge/__init__.py
@@ -14,6 +14,11 @@ from esphome.components import (
     light,
     cover,
     fan,
+    text,
+    lock,
+    valve,
+    event,
+    datetime,
 )
 from esphome.const import (
     CONF_ID,
@@ -103,6 +108,16 @@ _ENTITY_REF_DOMAINS = [
     (light.LightState, ws_bridge_ns.class_("WsBridgeLightRef", WsBridgeEntityRefBase)),
     (cover.Cover, ws_bridge_ns.class_("WsBridgeCoverRef", WsBridgeEntityRefBase)),
     (fan.Fan, ws_bridge_ns.class_("WsBridgeFanRef", WsBridgeEntityRefBase)),
+    (text.Text, ws_bridge_ns.class_("WsBridgeTextRef", WsBridgeEntityRefBase)),
+    (lock.Lock, ws_bridge_ns.class_("WsBridgeLockRef", WsBridgeEntityRefBase)),
+    (valve.Valve, ws_bridge_ns.class_("WsBridgeValveRef", WsBridgeEntityRefBase)),
+    (event.Event, ws_bridge_ns.class_("WsBridgeEventRef", WsBridgeEntityRefBase)),
+    # ESPHome's three datetime entity types share one YAML domain but are
+    # unrelated classes, and HA sees them as three platforms — so each needs its
+    # own Ref rather than one on the common DateTimeBase.
+    (datetime.DateEntity, ws_bridge_ns.class_("WsBridgeDateRef", WsBridgeEntityRefBase)),
+    (datetime.TimeEntity, ws_bridge_ns.class_("WsBridgeTimeRef", WsBridgeEntityRefBase)),
+    (datetime.DateTimeEntity, ws_bridge_ns.class_("WsBridgeDateTimeRef", WsBridgeEntityRefBase)),
 ]
 
 ENTITY_SCHEMA = cv.Schema(
@@ -136,7 +151,8 @@ async def to_code_entity_ref(hub_var, conf):
         raise cv.Invalid(
             f"'{source_id.id}' (type {full_id.type}) is not an entity domain ws_bridge "
             "can expose via entities: — supported: sensor, binary_sensor, text_sensor, "
-            "switch, number, select, button, update, light, cover, fan"
+            "switch, number, select, button, update, light, cover, fan, text, lock, "
+            "valve, event, date, time, datetime"
         )
 
     id_ = conf[CONF_ID]
@@ -231,8 +247,8 @@ CONFIG_SCHEMA = cv.All(
     _validate_esp_idf,
 )
 
-# Shared schema every ws_bridge platform (sensor/binary_sensor/switch/number/
-# select/button/update) must extend, mirroring uartex's UARTEX_DEVICE_SCHEMA pattern.
+# Shared schema every ws_bridge platform must extend, mirroring uartex's
+# UARTEX_DEVICE_SCHEMA pattern.
 WS_BRIDGE_DEVICE_SCHEMA = cv.Schema(
     {
         cv.GenerateID(CONF_WS_BRIDGE_ID): cv.use_id(WsBridgeComponent),

--- a/components/ws_bridge/const.py
+++ b/components/ws_bridge/const.py
@@ -30,6 +30,17 @@ CONF_SELECT_ID = "select_id"
 CONF_LIGHT_ID = "light_id"
 CONF_COVER_ID = "cover_id"
 CONF_FAN_ID = "fan_id"
+CONF_TEXT_ID = "text_id"
+CONF_LOCK_ID = "lock_id"
+CONF_VALVE_ID = "valve_id"
+CONF_EVENT_ID = "event_id"
+CONF_DATETIME_ID = "datetime_id"
+
+# lock only, declare-only. HA validates the code the user types against this
+# regex before sending the command; ESPHome's lock domain has no code API at
+# all (LockTraits::requires_code exists but nothing carries the code through),
+# so this is written on the ws_bridge side and never reaches the device.
+CONF_CODE_FORMAT = "code_format"
 
 # Hub-side `entities:` list — exposes an already-existing ESPHome entity
 # without a parallel `platform: ws_bridge` entity. See WsBridgeEntityRefBase.

--- a/components/ws_bridge/datetime/__init__.py
+++ b/components/ws_bridge/datetime/__init__.py
@@ -1,0 +1,44 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import datetime, ws_bridge
+
+from .. import ws_bridge_ns
+from ..const import CONF_DATETIME_ID
+
+DEPENDENCIES = ["ws_bridge"]
+
+# HA's date / time / datetime are three separate platforms, but ESPHome keeps
+# all three in the single `datetime:` domain selected by `type:`. There is
+# deliberately no `time/` directory here — ESPHome's `time:` component is a
+# clock source (SNTP and friends), not an entity domain.
+WsBridgeDate = ws_bridge_ns.class_("WsBridgeDate", datetime.DateEntity, cg.Component, ws_bridge.WsBridgeDevice)
+WsBridgeTime = ws_bridge_ns.class_("WsBridgeTime", datetime.TimeEntity, cg.Component, ws_bridge.WsBridgeDevice)
+WsBridgeDateTime = ws_bridge_ns.class_(
+    "WsBridgeDateTime", datetime.DateTimeEntity, cg.Component, ws_bridge.WsBridgeDevice
+)
+
+_COMMON = ws_bridge.WS_BRIDGE_DEVICE_SCHEMA.extend(cv.COMPONENT_SCHEMA)
+
+
+def _schema(base, source_type):
+    # `datetime_id:` is typed per branch, so wrapping a TimeEntity from a
+    # `type: DATE` entity is a config error rather than a compile error.
+    return base.extend(_COMMON).extend({cv.Optional(CONF_DATETIME_ID): cv.use_id(source_type)})
+
+
+CONFIG_SCHEMA = cv.typed_schema(
+    {
+        "DATE": _schema(datetime.date_schema(WsBridgeDate), datetime.DateEntity),
+        "TIME": _schema(datetime.time_schema(WsBridgeTime), datetime.TimeEntity),
+        "DATETIME": _schema(datetime.datetime_schema(WsBridgeDateTime), datetime.DateTimeEntity),
+    },
+    upper=True,
+)
+
+
+async def to_code(config):
+    var = await datetime.new_datetime(config)
+    await cg.register_component(var, config)
+    await ws_bridge.register_ws_bridge_device(var, config)
+    if CONF_DATETIME_ID in config:
+        cg.add(var.set_source(await cg.get_variable(config[CONF_DATETIME_ID])))

--- a/components/ws_bridge/datetime/ws_bridge_datetime.cpp
+++ b/components/ws_bridge/datetime/ws_bridge_datetime.cpp
@@ -1,0 +1,113 @@
+#include "ws_bridge_datetime.h"
+#include "../ws_bridge_domains.h"
+
+namespace esphome {
+namespace ws_bridge {
+
+static const char *const TAG = "ws_bridge.datetime";
+
+// The three control() overrides below are only reached when NOT wrapping — see
+// WsBridgeSwitch::write_state(). They write the call's fields straight through
+// and publish, like `platform: template` in optimistic mode.
+
+#ifdef USE_DATETIME_DATE
+void WsBridgeDate::setup() { ws_subscribe_date(this, this->source_ != nullptr ? this->source_ : this); }
+
+void WsBridgeDate::dump_config() {
+  LOG_DATETIME_DATE("", "WS Bridge Date", this);
+  if (this->source_ != nullptr)
+    ESP_LOGCONFIG(TAG, "  Wrapped: '%s'", this->source_->get_name().str().c_str());
+}
+
+void WsBridgeDate::control(const datetime::DateCall &call) {
+  if (call.get_year().has_value())
+    this->year_ = *call.get_year();
+  if (call.get_month().has_value())
+    this->month_ = *call.get_month();
+  if (call.get_day().has_value())
+    this->day_ = *call.get_day();
+  this->publish_state();
+}
+
+void WsBridgeDate::ws_bridge_handle_command(const WsCommand &command) {
+  ws_handle_command_date(this->source_ != nullptr ? this->source_ : this, command);
+}
+
+void WsBridgeDate::ws_bridge_declare() {
+  datetime::DateEntity &src = this->source_ != nullptr ? *this->source_ : *this;
+  const std::string own_name = this->has_own_name() ? this->get_name().str() : "";
+  ws_declare_date(this, src, this, ws_ha_name(src, own_name, this->unique_id_));
+  ws_push_state_date(this, src);
+}
+#endif  // USE_DATETIME_DATE
+
+#ifdef USE_DATETIME_TIME
+void WsBridgeTime::setup() { ws_subscribe_time(this, this->source_ != nullptr ? this->source_ : this); }
+
+void WsBridgeTime::dump_config() {
+  LOG_DATETIME_TIME("", "WS Bridge Time", this);
+  if (this->source_ != nullptr)
+    ESP_LOGCONFIG(TAG, "  Wrapped: '%s'", this->source_->get_name().str().c_str());
+}
+
+void WsBridgeTime::control(const datetime::TimeCall &call) {
+  if (call.get_hour().has_value())
+    this->hour_ = *call.get_hour();
+  if (call.get_minute().has_value())
+    this->minute_ = *call.get_minute();
+  if (call.get_second().has_value())
+    this->second_ = *call.get_second();
+  this->publish_state();
+}
+
+void WsBridgeTime::ws_bridge_handle_command(const WsCommand &command) {
+  ws_handle_command_time(this->source_ != nullptr ? this->source_ : this, command);
+}
+
+void WsBridgeTime::ws_bridge_declare() {
+  datetime::TimeEntity &src = this->source_ != nullptr ? *this->source_ : *this;
+  const std::string own_name = this->has_own_name() ? this->get_name().str() : "";
+  ws_declare_time(this, src, this, ws_ha_name(src, own_name, this->unique_id_));
+  ws_push_state_time(this, src);
+}
+#endif  // USE_DATETIME_TIME
+
+#ifdef USE_DATETIME_DATETIME
+void WsBridgeDateTime::setup() { ws_subscribe_datetime(this, this->source_ != nullptr ? this->source_ : this); }
+
+void WsBridgeDateTime::dump_config() {
+  LOG_DATETIME_DATETIME("", "WS Bridge DateTime", this);
+  if (this->source_ != nullptr)
+    ESP_LOGCONFIG(TAG, "  Wrapped: '%s'", this->source_->get_name().str().c_str());
+}
+
+void WsBridgeDateTime::control(const datetime::DateTimeCall &call) {
+  if (call.get_year().has_value())
+    this->year_ = *call.get_year();
+  if (call.get_month().has_value())
+    this->month_ = *call.get_month();
+  if (call.get_day().has_value())
+    this->day_ = *call.get_day();
+  if (call.get_hour().has_value())
+    this->hour_ = *call.get_hour();
+  if (call.get_minute().has_value())
+    this->minute_ = *call.get_minute();
+  if (call.get_second().has_value())
+    this->second_ = *call.get_second();
+  this->publish_state();
+}
+
+void WsBridgeDateTime::ws_bridge_handle_command(const WsCommand &command) {
+  ws_handle_command_datetime(this->source_ != nullptr ? this->source_ : this, command);
+}
+
+void WsBridgeDateTime::ws_bridge_declare() {
+  datetime::DateTimeEntity &src = this->source_ != nullptr ? *this->source_ : *this;
+  const std::string own_name = this->has_own_name() ? this->get_name().str() : "";
+  ws_declare_datetime(this, src, this, ws_ha_name(src, own_name, this->unique_id_));
+  ws_push_state_datetime(this, src);
+}
+#endif  // USE_DATETIME_DATETIME
+
+}  // namespace ws_bridge
+}  // namespace esphome

--- a/components/ws_bridge/datetime/ws_bridge_datetime.h
+++ b/components/ws_bridge/datetime/ws_bridge_datetime.h
@@ -1,0 +1,78 @@
+#pragma once
+#include "esphome/core/component.h"
+#include "esphome/core/defines.h"
+#include "../ws_bridge_device.h"
+
+#ifdef USE_DATETIME_DATE
+#include "esphome/components/datetime/date_entity.h"
+#endif
+#ifdef USE_DATETIME_TIME
+#include "esphome/components/datetime/time_entity.h"
+#endif
+#ifdef USE_DATETIME_DATETIME
+#include "esphome/components/datetime/datetime_entity.h"
+#endif
+
+namespace esphome {
+namespace ws_bridge {
+
+// One class per `type:` — ESPHome's datetime component is three unrelated
+// entity types behind one YAML domain, and each has its own base class, call
+// object and state fields. HA sees them as the separate `date`, `time` and
+// `datetime` platforms.
+//
+// Each is guarded by its own USE_DATETIME_* define: a config that only uses
+// `type: DATE` never compiles the other two.
+
+#ifdef USE_DATETIME_DATE
+class WsBridgeDate : public datetime::DateEntity, public Component, public WsBridgeDevice {
+ public:
+  // Optional: mirror and drive an existing date. HA's set_value goes to the
+  // wrapped entity; its state changes are what get reported back.
+  void set_source(datetime::DateEntity *source) { this->source_ = source; }
+  const EntityBase *get_ws_bridge_source() const override { return this->source_; }
+  void setup() override;
+  void dump_config() override;
+  void ws_bridge_declare() override;
+  void ws_bridge_handle_command(const WsCommand &command) override;
+
+ protected:
+  void control(const datetime::DateCall &call) override;
+  datetime::DateEntity *source_{nullptr};
+};
+#endif
+
+#ifdef USE_DATETIME_TIME
+class WsBridgeTime : public datetime::TimeEntity, public Component, public WsBridgeDevice {
+ public:
+  void set_source(datetime::TimeEntity *source) { this->source_ = source; }
+  const EntityBase *get_ws_bridge_source() const override { return this->source_; }
+  void setup() override;
+  void dump_config() override;
+  void ws_bridge_declare() override;
+  void ws_bridge_handle_command(const WsCommand &command) override;
+
+ protected:
+  void control(const datetime::TimeCall &call) override;
+  datetime::TimeEntity *source_{nullptr};
+};
+#endif
+
+#ifdef USE_DATETIME_DATETIME
+class WsBridgeDateTime : public datetime::DateTimeEntity, public Component, public WsBridgeDevice {
+ public:
+  void set_source(datetime::DateTimeEntity *source) { this->source_ = source; }
+  const EntityBase *get_ws_bridge_source() const override { return this->source_; }
+  void setup() override;
+  void dump_config() override;
+  void ws_bridge_declare() override;
+  void ws_bridge_handle_command(const WsCommand &command) override;
+
+ protected:
+  void control(const datetime::DateTimeCall &call) override;
+  datetime::DateTimeEntity *source_{nullptr};
+};
+#endif
+
+}  // namespace ws_bridge
+}  // namespace esphome

--- a/components/ws_bridge/event/__init__.py
+++ b/components/ws_bridge/event/__init__.py
@@ -1,0 +1,48 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import event, ws_bridge
+from esphome.const import CONF_EVENT_TYPES
+
+from .. import ws_bridge_ns
+from ..const import CONF_EVENT_ID
+
+DEPENDENCIES = ["ws_bridge"]
+WsBridgeEvent = ws_bridge_ns.class_("WsBridgeEvent", event.Event, cg.Component, ws_bridge.WsBridgeDevice)
+
+# An empty Python list renders as a bare `{}`, which is ambiguous across
+# Event::set_event_types()'s initializer_list / FixedVector / vector overloads
+# (including the =delete'd std::string ones that exist to catch mistakes). Name
+# the type so the vector overload is an exact match. The wrapper's real list is
+# copied off the source in setup() — see WsBridgeEvent::setup().
+_NO_EVENT_TYPES = cg.RawExpression("std::vector<const char *>{}")
+
+
+def validate_event_types(config):
+    if CONF_EVENT_TYPES not in config and CONF_EVENT_ID not in config:
+        raise cv.Invalid("event_types is required unless event_id: is set")
+    return config
+
+
+CONFIG_SCHEMA = cv.All(
+    event.event_schema(WsBridgeEvent)
+    .extend(
+        {
+            cv.Optional(CONF_EVENT_TYPES): cv.All(cv.ensure_list(cv.string_strict), cv.Length(min=1)),
+            # Wrap an existing ESPHome event. Its triggers are what get
+            # reported, and its event_types are what get declared, so
+            # event_types: may be omitted here.
+            cv.Optional(CONF_EVENT_ID): cv.use_id(event.Event),
+        }
+    )
+    .extend(ws_bridge.WS_BRIDGE_DEVICE_SCHEMA)
+    .extend(cv.COMPONENT_SCHEMA),
+    validate_event_types,
+)
+
+
+async def to_code(config):
+    var = await event.new_event(config, event_types=config.get(CONF_EVENT_TYPES, _NO_EVENT_TYPES))
+    await cg.register_component(var, config)
+    await ws_bridge.register_ws_bridge_device(var, config)
+    if CONF_EVENT_ID in config:
+        cg.add(var.set_source(await cg.get_variable(config[CONF_EVENT_ID])))

--- a/components/ws_bridge/event/ws_bridge_event.cpp
+++ b/components/ws_bridge/event/ws_bridge_event.cpp
@@ -1,0 +1,36 @@
+#include "ws_bridge_event.h"
+#include "../ws_bridge_domains.h"
+
+namespace esphome {
+namespace ws_bridge {
+
+static const char *const TAG = "ws_bridge.event";
+
+void WsBridgeEvent::setup() {
+  if (this->source_ != nullptr) {
+    // `event_types:` is optional when wrapping, so this entity's own list may
+    // be empty. Adopt the source's — the declaration reads from the source
+    // either way, but leaving this entity with no types would make it invalid
+    // for everything else that lists ESPHome entities (API, web server).
+    this->set_event_types(this->source_->get_event_types());
+  }
+  ws_subscribe_event(this, this->source_ != nullptr ? this->source_ : this);
+}
+
+void WsBridgeEvent::dump_config() {
+  LOG_EVENT("", "WS Bridge Event", this);
+  if (this->source_ != nullptr)
+    ESP_LOGCONFIG(TAG, "  Wrapped: '%s'", this->source_->get_name().str().c_str());
+}
+
+// No state push here, unlike every other domain: events are one-shot and HA
+// restores no last state for them, so re-sending the last event_type on each
+// (re)declare would replay a doorbell press that already happened.
+void WsBridgeEvent::ws_bridge_declare() {
+  event::Event &src = this->source_ != nullptr ? *this->source_ : *this;
+  const std::string own_name = this->has_own_name() ? this->get_name().str() : "";
+  ws_declare_event(this, src, this, ws_ha_name(src, own_name, this->unique_id_));
+}
+
+}  // namespace ws_bridge
+}  // namespace esphome

--- a/components/ws_bridge/event/ws_bridge_event.h
+++ b/components/ws_bridge/event/ws_bridge_event.h
@@ -1,0 +1,26 @@
+#pragma once
+#include "esphome/components/event/event.h"
+#include "esphome/core/component.h"
+#include "../ws_bridge_device.h"
+
+namespace esphome {
+namespace ws_bridge {
+
+// Read-only: HA never sends commands to an event entity, so there is no
+// ws_bridge_handle_command() override here.
+class WsBridgeEvent : public event::Event, public Component, public WsBridgeDevice {
+ public:
+  // Optional: mirror an existing event. Its triggers are what get forwarded to
+  // HA, and its event_types are what get declared.
+  void set_source(event::Event *source) { this->source_ = source; }
+  const EntityBase *get_ws_bridge_source() const override { return this->source_; }
+  void setup() override;
+  void dump_config() override;
+  void ws_bridge_declare() override;
+
+ protected:
+  event::Event *source_{nullptr};
+};
+
+}  // namespace ws_bridge
+}  // namespace esphome

--- a/components/ws_bridge/lock/__init__.py
+++ b/components/ws_bridge/lock/__init__.py
@@ -1,0 +1,36 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import lock, ws_bridge
+
+from .. import ws_bridge_ns
+from ..const import CONF_CODE_FORMAT, CONF_LOCK_ID
+
+DEPENDENCIES = ["ws_bridge"]
+WsBridgeLock = ws_bridge_ns.class_("WsBridgeLock", lock.Lock, cg.Component, ws_bridge.WsBridgeDevice)
+
+CONFIG_SCHEMA = (
+    lock.lock_schema(WsBridgeLock)
+    .extend(ws_bridge.WS_BRIDGE_DEVICE_SCHEMA)
+    .extend(cv.COMPONENT_SCHEMA)
+    .extend(
+        {
+            # Regex HA validates the typed code against before sending the
+            # command. Declare-only: ESPHome's lock domain cannot receive a
+            # code, so this is a UI confirmation prompt, not authentication.
+            cv.Optional(CONF_CODE_FORMAT): cv.string_strict,
+            # Wrap and drive an existing ESPHome lock. HA commands are applied
+            # to it, and its state changes are what get reported back.
+            cv.Optional(CONF_LOCK_ID): cv.use_id(lock.Lock),
+        }
+    )
+)
+
+
+async def to_code(config):
+    var = await lock.new_lock(config)
+    await cg.register_component(var, config)
+    await ws_bridge.register_ws_bridge_device(var, config)
+    if CONF_CODE_FORMAT in config:
+        cg.add(var.set_code_format(config[CONF_CODE_FORMAT]))
+    if CONF_LOCK_ID in config:
+        cg.add(var.set_source(await cg.get_variable(config[CONF_LOCK_ID])))

--- a/components/ws_bridge/lock/ws_bridge_lock.cpp
+++ b/components/ws_bridge/lock/ws_bridge_lock.cpp
@@ -1,0 +1,54 @@
+#include "ws_bridge_lock.h"
+#include "../ws_bridge_domains.h"
+
+namespace esphome {
+namespace ws_bridge {
+
+static const char *const TAG = "ws_bridge.lock";
+
+void WsBridgeLock::setup() {
+  if (this->source_ == nullptr) {
+    // Standalone, so this entity's own traits are what get declared. Offer the
+    // full surface — same reasoning as WsBridgeCover::get_traits() advertising
+    // position and stop: there is no hardware here to constrain it, and open()
+    // refuses outright unless supports_open is set. LockCall::validate_() drops
+    // any state outside the supported mask, so OPEN has to be added for
+    // lambda-driven `lock.open` on this entity to survive.
+    this->traits.set_supports_open(true);
+    this->traits.add_supported_state(lock::LOCK_STATE_OPEN);
+  }
+  ws_subscribe_lock(this, this->source_ != nullptr ? this->source_ : this);
+}
+
+void WsBridgeLock::dump_config() {
+  LOG_LOCK("", "WS Bridge Lock", this);
+  if (!this->code_format_.empty())
+    ESP_LOGCONFIG(TAG, "  Code Format: '%s'", this->code_format_.c_str());
+  if (this->source_ != nullptr)
+    ESP_LOGCONFIG(TAG, "  Wrapped: '%s'", this->source_->get_name().str().c_str());
+}
+
+// Only reached when NOT wrapping — see WsBridgeSwitch::write_state().
+void WsBridgeLock::control(const lock::LockCall &call) {
+  if (call.get_state().has_value())
+    this->publish_state(*call.get_state());
+}
+
+// Lock::open() routes here instead of through control(). The base
+// implementation falls back to unlock(); report the unlatched state HA asked
+// for instead.
+void WsBridgeLock::open_latch() { this->publish_state(lock::LOCK_STATE_OPEN); }
+
+void WsBridgeLock::ws_bridge_handle_command(const WsCommand &command) {
+  ws_handle_command_lock(this->source_ != nullptr ? this->source_ : this, command);
+}
+
+void WsBridgeLock::ws_bridge_declare() {
+  lock::Lock &src = this->source_ != nullptr ? *this->source_ : *this;
+  const std::string own_name = this->has_own_name() ? this->get_name().str() : "";
+  ws_declare_lock(this, src, this, ws_ha_name(src, own_name, this->unique_id_), this->code_format_);
+  ws_push_state_lock(this, src);
+}
+
+}  // namespace ws_bridge
+}  // namespace esphome

--- a/components/ws_bridge/lock/ws_bridge_lock.h
+++ b/components/ws_bridge/lock/ws_bridge_lock.h
@@ -1,0 +1,31 @@
+#pragma once
+#include <string>
+#include "esphome/components/lock/lock.h"
+#include "esphome/core/component.h"
+#include "../ws_bridge_device.h"
+
+namespace esphome {
+namespace ws_bridge {
+
+class WsBridgeLock : public lock::Lock, public Component, public WsBridgeDevice {
+ public:
+  // Optional: mirror and drive an existing lock. HA commands go to the wrapped
+  // lock; its state changes are what get reported back.
+  void set_source(lock::Lock *source) { this->source_ = source; }
+  // Declare-only regex for HA's code prompt — see CONF_CODE_FORMAT in const.py.
+  void set_code_format(const std::string &code_format) { this->code_format_ = code_format; }
+  const EntityBase *get_ws_bridge_source() const override { return this->source_; }
+  void setup() override;
+  void dump_config() override;
+  void ws_bridge_declare() override;
+  void ws_bridge_handle_command(const WsCommand &command) override;
+
+ protected:
+  void control(const lock::LockCall &call) override;
+  void open_latch() override;
+  lock::Lock *source_{nullptr};
+  std::string code_format_;
+};
+
+}  // namespace ws_bridge
+}  // namespace esphome

--- a/components/ws_bridge/text/__init__.py
+++ b/components/ws_bridge/text/__init__.py
@@ -1,0 +1,45 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import text, ws_bridge
+from esphome.const import CONF_MAX_LENGTH, CONF_MIN_LENGTH, CONF_PATTERN
+
+from .. import ws_bridge_ns
+from ..const import CONF_TEXT_ID
+
+DEPENDENCIES = ["ws_bridge"]
+WsBridgeText = ws_bridge_ns.class_("WsBridgeText", text.Text, cg.Component, ws_bridge.WsBridgeDevice)
+
+CONFIG_SCHEMA = (
+    # mode: defaults to TEXT here — ESPHome's own text_schema() makes it
+    # required, which would be noise on a bridge entity.
+    text.text_schema(WsBridgeText, mode="TEXT")
+    .extend(ws_bridge.WS_BRIDGE_DEVICE_SCHEMA)
+    .extend(cv.COMPONENT_SCHEMA)
+    .extend(
+        {
+            # String *length* bounds, not a value range (unlike number's
+            # min_value/max_value). ESPHome's own defaults.
+            cv.Optional(CONF_MIN_LENGTH, default=0): cv.int_range(min=0, max=255),
+            cv.Optional(CONF_MAX_LENGTH, default=255): cv.int_range(min=0, max=255),
+            cv.Optional(CONF_PATTERN): cv.string,
+            # Wrap and drive an existing ESPHome text. HA commands are applied
+            # to it, and its state changes are what get reported back. Its
+            # length limits, pattern and mode are what get declared — see
+            # ws_declare_text in ws_bridge_domains.h.
+            cv.Optional(CONF_TEXT_ID): cv.use_id(text.Text),
+        }
+    )
+)
+
+
+async def to_code(config):
+    var = await text.new_text(
+        config,
+        min_length=config[CONF_MIN_LENGTH],
+        max_length=config[CONF_MAX_LENGTH],
+        pattern=config.get(CONF_PATTERN),
+    )
+    await cg.register_component(var, config)
+    await ws_bridge.register_ws_bridge_device(var, config)
+    if CONF_TEXT_ID in config:
+        cg.add(var.set_source(await cg.get_variable(config[CONF_TEXT_ID])))

--- a/components/ws_bridge/text/ws_bridge_text.cpp
+++ b/components/ws_bridge/text/ws_bridge_text.cpp
@@ -1,0 +1,32 @@
+#include "ws_bridge_text.h"
+#include "../ws_bridge_domains.h"
+
+namespace esphome {
+namespace ws_bridge {
+
+static const char *const TAG = "ws_bridge.text";
+
+void WsBridgeText::setup() { ws_subscribe_text(this, this->source_ != nullptr ? this->source_ : this); }
+
+void WsBridgeText::dump_config() {
+  LOG_TEXT("", "WS Bridge Text", this);
+  if (this->source_ != nullptr)
+    ESP_LOGCONFIG(TAG, "  Wrapped: '%s'", this->source_->get_name().str().c_str());
+}
+
+// Only reached when NOT wrapping — see WsBridgeSwitch::write_state().
+void WsBridgeText::control(const std::string &value) { this->publish_state(value); }
+
+void WsBridgeText::ws_bridge_handle_command(const WsCommand &command) {
+  ws_handle_command_text(this->source_ != nullptr ? this->source_ : this, command);
+}
+
+void WsBridgeText::ws_bridge_declare() {
+  text::Text &src = this->source_ != nullptr ? *this->source_ : *this;
+  const std::string own_name = this->has_own_name() ? this->get_name().str() : "";
+  ws_declare_text(this, src, this, ws_ha_name(src, own_name, this->unique_id_));
+  ws_push_state_text(this, src);
+}
+
+}  // namespace ws_bridge
+}  // namespace esphome

--- a/components/ws_bridge/text/ws_bridge_text.h
+++ b/components/ws_bridge/text/ws_bridge_text.h
@@ -1,0 +1,27 @@
+#pragma once
+#include "esphome/components/text/text.h"
+#include "esphome/core/component.h"
+#include "../ws_bridge_device.h"
+
+namespace esphome {
+namespace ws_bridge {
+
+class WsBridgeText : public text::Text, public Component, public WsBridgeDevice {
+ public:
+  // Optional: mirror and drive an existing text input. HA's set_value goes to
+  // the wrapped text; its state changes are what get reported back, and its
+  // length limits / pattern / mode are what get declared.
+  void set_source(text::Text *source) { this->source_ = source; }
+  const EntityBase *get_ws_bridge_source() const override { return this->source_; }
+  void setup() override;
+  void dump_config() override;
+  void ws_bridge_declare() override;
+  void ws_bridge_handle_command(const WsCommand &command) override;
+
+ protected:
+  void control(const std::string &value) override;
+  text::Text *source_{nullptr};
+};
+
+}  // namespace ws_bridge
+}  // namespace esphome

--- a/components/ws_bridge/valve/__init__.py
+++ b/components/ws_bridge/valve/__init__.py
@@ -1,0 +1,30 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import valve, ws_bridge
+
+from .. import ws_bridge_ns
+from ..const import CONF_VALVE_ID
+
+DEPENDENCIES = ["ws_bridge"]
+WsBridgeValve = ws_bridge_ns.class_("WsBridgeValve", valve.Valve, cg.Component, ws_bridge.WsBridgeDevice)
+
+CONFIG_SCHEMA = (
+    valve.valve_schema(WsBridgeValve)
+    .extend(ws_bridge.WS_BRIDGE_DEVICE_SCHEMA)
+    .extend(cv.COMPONENT_SCHEMA)
+    .extend(
+        {
+            # Wrap and drive an existing ESPHome valve. HA commands are applied
+            # to it, and its state changes are what get reported back.
+            cv.Optional(CONF_VALVE_ID): cv.use_id(valve.Valve),
+        }
+    )
+)
+
+
+async def to_code(config):
+    var = await valve.new_valve(config)
+    await cg.register_component(var, config)
+    await ws_bridge.register_ws_bridge_device(var, config)
+    if CONF_VALVE_ID in config:
+        cg.add(var.set_source(await cg.get_variable(config[CONF_VALVE_ID])))

--- a/components/ws_bridge/valve/ws_bridge_valve.cpp
+++ b/components/ws_bridge/valve/ws_bridge_valve.cpp
@@ -1,0 +1,49 @@
+#include "ws_bridge_valve.h"
+#include "../ws_bridge_domains.h"
+
+namespace esphome {
+namespace ws_bridge {
+
+static const char *const TAG = "ws_bridge.valve";
+
+void WsBridgeValve::setup() { ws_subscribe_valve(this, this->source_ != nullptr ? this->source_ : this); }
+
+void WsBridgeValve::dump_config() {
+  LOG_VALVE("", "WS Bridge Valve", this);
+  if (this->source_ != nullptr)
+    ESP_LOGCONFIG(TAG, "  Wrapped: '%s'", this->source_->get_name().str().c_str());
+}
+
+valve::ValveTraits WsBridgeValve::get_traits() {
+  if (this->source_ != nullptr)
+    return this->source_->get_traits();
+  valve::ValveTraits traits;
+  traits.set_supports_position(true);
+  traits.set_supports_stop(true);
+  return traits;
+}
+
+// Only reached when NOT wrapping — see WsBridgeSwitch::write_state().
+void WsBridgeValve::control(const valve::ValveCall &call) {
+  if (call.get_stop()) {
+    this->current_operation = valve::VALVE_OPERATION_IDLE;
+  } else if (call.get_position().has_value()) {
+    this->position = *call.get_position();
+    this->current_operation = valve::VALVE_OPERATION_IDLE;
+  }
+  this->publish_state();
+}
+
+void WsBridgeValve::ws_bridge_handle_command(const WsCommand &command) {
+  ws_handle_command_valve(this->source_ != nullptr ? this->source_ : this, command);
+}
+
+void WsBridgeValve::ws_bridge_declare() {
+  valve::Valve &src = this->source_ != nullptr ? *this->source_ : *this;
+  const std::string own_name = this->has_own_name() ? this->get_name().str() : "";
+  ws_declare_valve(this, src, this, ws_ha_name(src, own_name, this->unique_id_));
+  ws_push_state_valve(this, src);
+}
+
+}  // namespace ws_bridge
+}  // namespace esphome

--- a/components/ws_bridge/valve/ws_bridge_valve.h
+++ b/components/ws_bridge/valve/ws_bridge_valve.h
@@ -1,0 +1,27 @@
+#pragma once
+#include "esphome/components/valve/valve.h"
+#include "esphome/core/component.h"
+#include "../ws_bridge_device.h"
+
+namespace esphome {
+namespace ws_bridge {
+
+class WsBridgeValve : public valve::Valve, public Component, public WsBridgeDevice {
+ public:
+  // Optional: mirror and drive an existing valve. HA commands go to the wrapped
+  // valve; its state changes are what get reported back.
+  void set_source(valve::Valve *source) { this->source_ = source; }
+  const EntityBase *get_ws_bridge_source() const override { return this->source_; }
+  void setup() override;
+  void dump_config() override;
+  valve::ValveTraits get_traits() override;
+  void ws_bridge_declare() override;
+  void ws_bridge_handle_command(const WsCommand &command) override;
+
+ protected:
+  void control(const valve::ValveCall &call) override;
+  valve::Valve *source_{nullptr};
+};
+
+}  // namespace ws_bridge
+}  // namespace esphome

--- a/components/ws_bridge/ws_bridge_device.h
+++ b/components/ws_bridge/ws_bridge_device.h
@@ -10,10 +10,10 @@ namespace ws_bridge {
 
 class WsBridgeComponent;
 
-// Shared base for every ws_bridge platform entity (sensor/binary_sensor/switch/
-// number/select/button/update). Holds the protocol-facing identity fields and gives
-// the hub a uniform way to ask any registered entity to (re)send its
-// ws_bridge/entity declaration (used on first connect and on every reconnect).
+// Shared base for every ws_bridge platform entity. Holds the protocol-facing
+// identity fields and gives the hub a uniform way to ask any registered entity
+// to (re)send its ws_bridge/entity declaration (used on first connect and on
+// every reconnect).
 class WsBridgeDevice {
  public:
   void set_ws_bridge_parent(WsBridgeComponent *parent) { this->parent_ = parent; }
@@ -37,8 +37,8 @@ class WsBridgeDevice {
   virtual void ws_bridge_declare() = 0;
 
   // Called by the hub when a command arrives for this entity's unique_id.
-  // Read-only platforms (sensor/binary_sensor) never receive commands and
-  // keep the no-op default.
+  // Read-only platforms (sensor/binary_sensor/event/...) never receive commands
+  // and keep the no-op default.
   virtual void ws_bridge_handle_command(const WsCommand &command) {}
 
   // The ESPHome entity this device wraps, if any (`*_id:` / `entities:`

--- a/components/ws_bridge/ws_bridge_domains.h
+++ b/components/ws_bridge/ws_bridge_domains.h
@@ -41,6 +41,27 @@
 #ifdef USE_FAN
 #include "esphome/components/fan/fan.h"
 #endif
+#ifdef USE_TEXT
+#include "esphome/components/text/text.h"
+#endif
+#ifdef USE_LOCK
+#include "esphome/components/lock/lock.h"
+#endif
+#ifdef USE_VALVE
+#include "esphome/components/valve/valve.h"
+#endif
+#ifdef USE_EVENT
+#include "esphome/components/event/event.h"
+#endif
+#ifdef USE_DATETIME_DATE
+#include "esphome/components/datetime/date_entity.h"
+#endif
+#ifdef USE_DATETIME_TIME
+#include "esphome/components/datetime/time_entity.h"
+#endif
+#ifdef USE_DATETIME_DATETIME
+#include "esphome/components/datetime/datetime_entity.h"
+#endif
 
 namespace esphome {
 namespace ws_bridge {
@@ -809,6 +830,323 @@ inline void ws_handle_command_light(light::LightState *target, const WsCommand &
   call.perform();
 }
 #endif  // USE_LIGHT
+
+#ifdef USE_TEXT
+inline void ws_declare_text(WsBridgeDevice *dev, text::Text &src, text::Text *ovr, const std::string &name) {
+  dev->get_ws_bridge_parent()->send_entity_declare(
+      dev->get_ws_bridge_unique_id(), "text", name, dev->get_ws_bridge_device_id(), dev->get_ws_bridge_device_name(),
+      [&src, ovr](JsonObject root) {
+        add_common_entity_fields(root, src, ovr);
+        // min/max are *string lengths* here, not a value range like number's.
+        // Read from src only (like cover/fan/light traits, unlike number's
+        // per-field fallback): TextTraits has no "unset" sentinel — ESPHome's
+        // register_text() always writes both, defaulting to 0/255 — so a
+        // wrapper could not tell an inherited default from an explicit one.
+        // Wrapping therefore reports the wrapped text's length limits, pattern
+        // and mode as-is.
+        root["min"] = src.traits.get_min_length();
+        root["max"] = src.traits.get_max_length();
+        StringRef pattern = src.traits.get_pattern_ref();
+        if (!pattern.empty())
+          root["pattern"] = pattern;  // ArduinoJson has convertToJson(StringRef)
+        root["mode"] = src.traits.get_mode() == text::TEXT_MODE_PASSWORD ? "password" : "text";
+      });
+}
+
+inline void ws_push_state_text(WsBridgeDevice *dev, text::Text &src) {
+  if (src.has_state())
+    dev->get_ws_bridge_parent()->send_state_string(dev->get_ws_bridge_unique_id(), src.state);
+}
+
+inline void ws_subscribe_text(WsBridgeDevice *dev, text::Text *src) {
+  src->add_on_state_callback([dev](const std::string &state) {
+    dev->get_ws_bridge_parent()->send_state_string(dev->get_ws_bridge_unique_id(), state);
+  });
+}
+
+inline void ws_handle_command_text(text::Text *target, const WsCommand &command) {
+  if (command.action == "set_value" && command.has_value) {
+    target->make_call().set_value(command.value_string).perform();
+  }
+}
+#endif  // USE_TEXT
+
+#ifdef USE_LOCK
+// Null for LOCK_STATE_NONE — a lock that has never published. HA has no
+// equivalent "no state yet", so those are simply not sent.
+inline const char *ws_lock_state_to_ha_(lock::LockState state) {
+  switch (state) {
+    case lock::LOCK_STATE_LOCKED:
+      return "locked";
+    case lock::LOCK_STATE_UNLOCKED:
+      return "unlocked";
+    case lock::LOCK_STATE_JAMMED:
+      return "jammed";
+    case lock::LOCK_STATE_LOCKING:
+      return "locking";
+    case lock::LOCK_STATE_UNLOCKING:
+      return "unlocking";
+    case lock::LOCK_STATE_OPENING:
+      return "opening";
+    case lock::LOCK_STATE_OPEN:
+      return "open";
+    default:
+      return nullptr;
+  }
+}
+
+// `code_format` is a ws_bridge-only YAML option rather than something read off
+// the source: ESPHome's lock domain has LockTraits::requires_code but no way to
+// carry the code itself, so the regex HA validates against can only come from
+// here. Empty means "no code prompt in HA".
+inline void ws_declare_lock(WsBridgeDevice *dev, lock::Lock &src, lock::Lock *ovr, const std::string &name,
+                            const std::string &code_format) {
+  dev->get_ws_bridge_parent()->send_entity_declare(
+      dev->get_ws_bridge_unique_id(), "lock", name, dev->get_ws_bridge_device_id(), dev->get_ws_bridge_device_name(),
+      [&src, ovr, &code_format](JsonObject root) {
+        add_common_entity_fields(root, src, ovr);
+        // lock/unlock are always available, so "open" (unlatch) is the only
+        // feature flag the protocol defines for this domain.
+        if (src.traits.get_supports_open()) {
+          JsonArray features = root["features"].to<JsonArray>();
+          features.add("open");
+        }
+        if (!code_format.empty())
+          root["code_format"] = code_format;
+      });
+}
+
+inline void ws_push_state_lock(WsBridgeDevice *dev, lock::Lock &src) {
+  if (const char *state = ws_lock_state_to_ha_(src.state))
+    dev->get_ws_bridge_parent()->send_state_string(dev->get_ws_bridge_unique_id(), state);
+}
+
+inline void ws_subscribe_lock(WsBridgeDevice *dev, lock::Lock *src) {
+  src->add_on_state_callback([dev](lock::LockState state) {
+    if (const char *ha = ws_lock_state_to_ha_(state))
+      dev->get_ws_bridge_parent()->send_state_string(dev->get_ws_bridge_unique_id(), ha);
+  });
+}
+
+// HA may send params.code alongside lock/unlock/open when code_format is
+// declared. It is deliberately ignored: there is nothing in ESPHome's lock API
+// to hand it to. Treat code_format as a UI-side confirmation prompt only, never
+// as device-enforced authentication.
+inline void ws_handle_command_lock(lock::Lock *target, const WsCommand &command) {
+  if (command.action == "lock") {
+    target->lock();
+  } else if (command.action == "unlock") {
+    target->unlock();
+  } else if (command.action == "open") {
+    target->open();
+  }
+}
+#endif  // USE_LOCK
+
+#ifdef USE_VALVE
+inline void ws_fill_state_valve(valve::Valve &src, JsonObject value) {
+  switch (src.current_operation) {
+    case valve::VALVE_OPERATION_OPENING:
+      value["state"] = "opening";
+      break;
+    case valve::VALVE_OPERATION_CLOSING:
+      value["state"] = "closing";
+      break;
+    case valve::VALVE_OPERATION_IDLE:
+    default:
+      // Same rule as cover: only position==0 counts as closed (valve.cpp).
+      value["state"] = src.is_fully_closed() ? "closed" : "open";
+      break;
+  }
+  // A valve that declared reports_position: false must not report a position
+  // at all — the protocol keeps the two modes separate.
+  if (src.get_traits().get_supports_position())
+    value["position"] = static_cast<int>(roundf(src.position * 100.0f));
+}
+
+inline void ws_send_state_valve(WsBridgeDevice *dev, valve::Valve &src) {
+  dev->get_ws_bridge_parent()->send_state_object(dev->get_ws_bridge_unique_id(),
+                                                 [&src](JsonObject value) { ws_fill_state_valve(src, value); });
+}
+
+inline void ws_declare_valve(WsBridgeDevice *dev, valve::Valve &src, valve::Valve *ovr, const std::string &name) {
+  dev->get_ws_bridge_parent()->send_entity_declare(
+      dev->get_ws_bridge_unique_id(), "valve", name, dev->get_ws_bridge_device_id(), dev->get_ws_bridge_device_name(),
+      [&src, ovr](JsonObject root) {
+        add_common_entity_fields(root, src, ovr);
+        auto traits = src.get_traits();
+        root["reports_position"] = traits.get_supports_position();
+        JsonArray features = root["features"].to<JsonArray>();
+        features.add("open");
+        features.add("close");
+        if (traits.get_supports_stop())
+          features.add("stop");
+        if (traits.get_supports_position())
+          features.add("set_position");
+      });
+}
+
+inline void ws_push_state_valve(WsBridgeDevice *dev, valve::Valve &src) { ws_send_state_valve(dev, src); }
+
+inline void ws_subscribe_valve(WsBridgeDevice *dev, valve::Valve *src) {
+  src->add_on_state_callback([dev, src]() { ws_send_state_valve(dev, *src); });
+}
+
+inline void ws_handle_command_valve(valve::Valve *target, const WsCommand &command) {
+  if (command.action == "open_valve") {
+    target->make_call().set_command_open().perform();
+  } else if (command.action == "close_valve") {
+    target->make_call().set_command_close().perform();
+  } else if (command.action == "stop_valve") {
+    target->make_call().set_command_stop().perform();
+  } else if (command.action == "set_valve_position") {
+    float position;
+    if (command.param_float("position", position))
+      target->make_call().set_position(position / 100.0f).perform();
+  }
+}
+#endif  // USE_VALVE
+
+#ifdef USE_EVENT
+inline void ws_declare_event(WsBridgeDevice *dev, event::Event &src, event::Event *ovr, const std::string &name) {
+  dev->get_ws_bridge_parent()->send_entity_declare(
+      dev->get_ws_bridge_unique_id(), "event", name, dev->get_ws_bridge_device_id(), dev->get_ws_bridge_device_name(),
+      [&src, ovr](JsonObject root) {
+        add_common_entity_fields(root, src, ovr);
+        // Read from src, never from ovr: the state pushes come from src's
+        // trigger(), and HA drops any event_type that wasn't declared. A
+        // wrapper's own list could disagree with the source's and silently
+        // swallow events.
+        JsonArray types = root["event_types"].to<JsonArray>();
+        for (const char *type : src.get_event_types())
+          types.add(type);
+      });
+}
+
+// No ws_push_state_event(): events are fire-and-forget and HA restores no last
+// state for them, so re-pushing the last event_type on every (re)declare would
+// replay a doorbell press that already happened. There is no
+// ws_handle_command_event() either — the domain is read-only.
+inline void ws_subscribe_event(WsBridgeDevice *dev, event::Event *src) {
+  src->add_on_event_callback([dev](StringRef event_type) {
+    dev->get_ws_bridge_parent()->send_state_string(dev->get_ws_bridge_unique_id(), event_type.str());
+  });
+}
+#endif  // USE_EVENT
+
+#if defined(USE_DATETIME_DATE) || defined(USE_DATETIME_TIME) || defined(USE_DATETIME_DATETIME)
+// date/time/datetime share everything but the platform string and the state
+// format — none of the three has any declare-only field of its own.
+inline void ws_declare_datetime_(WsBridgeDevice *dev, datetime::DateTimeBase &src, datetime::DateTimeBase *ovr,
+                                 const std::string &name, const char *platform) {
+  dev->get_ws_bridge_parent()->send_entity_declare(
+      dev->get_ws_bridge_unique_id(), platform, name, dev->get_ws_bridge_device_id(),
+      dev->get_ws_bridge_device_name(), [&src, ovr](JsonObject root) { add_common_entity_fields(root, src, ovr); });
+}
+
+// Formats into a stack buffer (24 bytes covers the longest of these, the 19
+// character datetime). Each caller must pass a format naming only the fields
+// its entity actually owns: DateEntity::state_as_esptime() leaves
+// hour/minute/second untouched and TimeEntity leaves the date fields untouched.
+inline void ws_send_state_datetime_(WsBridgeDevice *dev, datetime::DateTimeBase &src, const char *format) {
+  ESPTime time = src.state_as_esptime();
+  char buf[24];
+  if (time.strftime(buf, sizeof(buf), format) == 0)
+    return;
+  dev->get_ws_bridge_parent()->send_state_string(dev->get_ws_bridge_unique_id(), buf);
+}
+
+// HA sends full ISO 8601 ("2026-08-13T21:30:00+09:00"); ESPTime::strptime()
+// accepts only "YYYY-MM-DD[ HH:MM[:SS]]" and "HH:MM[:SS]" — no 'T' separator,
+// no fractional seconds, no timezone. Values arriving in the device's own local
+// time is exactly what the tz-naive round trip assumes (HA re-attaches its
+// local zone to the tz-naive strings we send back).
+inline std::string ws_iso_to_esptime_string_(const std::string &iso) {
+  std::string out = iso;
+  size_t separator = out.find('T');
+  if (separator != std::string::npos)
+    out[separator] = ' ';
+
+  // Everything past the seconds field has to go. Scanning from the first ':'
+  // keeps the date's own '-' separators from being read as a negative UTC
+  // offset; a date-only value has no such suffix to strip in the first place.
+  size_t time_start = out.find(':');
+  if (time_start != std::string::npos) {
+    size_t cut = out.find_first_of(".Z+-", time_start);
+    if (cut != std::string::npos)
+      out.erase(cut);
+  }
+  while (!out.empty() && out.back() == ' ')
+    out.pop_back();
+  return out;
+}
+#endif  // any USE_DATETIME_*
+
+#ifdef USE_DATETIME_DATE
+inline void ws_declare_date(WsBridgeDevice *dev, datetime::DateEntity &src, datetime::DateEntity *ovr,
+                            const std::string &name) {
+  ws_declare_datetime_(dev, src, ovr, name, "date");
+}
+
+inline void ws_push_state_date(WsBridgeDevice *dev, datetime::DateEntity &src) {
+  if (src.has_state())
+    ws_send_state_datetime_(dev, src, "%Y-%m-%d");
+}
+
+inline void ws_subscribe_date(WsBridgeDevice *dev, datetime::DateEntity *src) {
+  src->add_on_state_callback([dev, src]() { ws_push_state_date(dev, *src); });
+}
+
+inline void ws_handle_command_date(datetime::DateEntity *target, const WsCommand &command) {
+  if (command.action == "set_value" && command.has_value) {
+    target->make_call().set_date(ws_iso_to_esptime_string_(command.value_string)).perform();
+  }
+}
+#endif  // USE_DATETIME_DATE
+
+#ifdef USE_DATETIME_TIME
+inline void ws_declare_time(WsBridgeDevice *dev, datetime::TimeEntity &src, datetime::TimeEntity *ovr,
+                            const std::string &name) {
+  ws_declare_datetime_(dev, src, ovr, name, "time");
+}
+
+inline void ws_push_state_time(WsBridgeDevice *dev, datetime::TimeEntity &src) {
+  if (src.has_state())
+    ws_send_state_datetime_(dev, src, "%H:%M:%S");
+}
+
+inline void ws_subscribe_time(WsBridgeDevice *dev, datetime::TimeEntity *src) {
+  src->add_on_state_callback([dev, src]() { ws_push_state_time(dev, *src); });
+}
+
+inline void ws_handle_command_time(datetime::TimeEntity *target, const WsCommand &command) {
+  if (command.action == "set_value" && command.has_value) {
+    target->make_call().set_time(ws_iso_to_esptime_string_(command.value_string)).perform();
+  }
+}
+#endif  // USE_DATETIME_TIME
+
+#ifdef USE_DATETIME_DATETIME
+inline void ws_declare_datetime(WsBridgeDevice *dev, datetime::DateTimeEntity &src, datetime::DateTimeEntity *ovr,
+                                const std::string &name) {
+  ws_declare_datetime_(dev, src, ovr, name, "datetime");
+}
+
+inline void ws_push_state_datetime(WsBridgeDevice *dev, datetime::DateTimeEntity &src) {
+  if (src.has_state())
+    ws_send_state_datetime_(dev, src, "%Y-%m-%dT%H:%M:%S");
+}
+
+inline void ws_subscribe_datetime(WsBridgeDevice *dev, datetime::DateTimeEntity *src) {
+  src->add_on_state_callback([dev, src]() { ws_push_state_datetime(dev, *src); });
+}
+
+inline void ws_handle_command_datetime(datetime::DateTimeEntity *target, const WsCommand &command) {
+  if (command.action == "set_value" && command.has_value) {
+    target->make_call().set_datetime(ws_iso_to_esptime_string_(command.value_string)).perform();
+  }
+}
+#endif  // USE_DATETIME_DATETIME
 
 }  // namespace ws_bridge
 }  // namespace esphome

--- a/components/ws_bridge/ws_bridge_entity_ref.cpp
+++ b/components/ws_bridge/ws_bridge_entity_ref.cpp
@@ -173,5 +173,118 @@ void WsBridgeFanRef::ws_bridge_handle_command(const WsCommand &command) {
 }
 #endif
 
+#ifdef USE_TEXT
+void WsBridgeTextRef::setup() { ws_subscribe_text(this, this->source_); }
+void WsBridgeTextRef::dump_config() {
+  ESP_LOGCONFIG(TAG, "WS Bridge Entity Ref '%s' -> text '%s'", this->get_ws_bridge_unique_id().c_str(),
+                this->source_->get_name().str().c_str());
+}
+void WsBridgeTextRef::ws_bridge_declare() {
+  ws_declare_text(this, *this->source_, nullptr,
+                  ws_ha_name(*this->source_, this->name_override_, this->get_ws_bridge_unique_id()));
+  ws_push_state_text(this, *this->source_);
+}
+void WsBridgeTextRef::ws_bridge_handle_command(const WsCommand &command) {
+  ws_handle_command_text(this->source_, command);
+}
+#endif
+
+#ifdef USE_LOCK
+void WsBridgeLockRef::setup() { ws_subscribe_lock(this, this->source_); }
+void WsBridgeLockRef::dump_config() {
+  ESP_LOGCONFIG(TAG, "WS Bridge Entity Ref '%s' -> lock '%s'", this->get_ws_bridge_unique_id().c_str(),
+                this->source_->get_name().str().c_str());
+}
+void WsBridgeLockRef::ws_bridge_declare() {
+  // entities: has no per-field overrides at all, and code_format has no ESPHome
+  // counterpart to inherit from — use `platform: ws_bridge` with `lock_id:` to
+  // set one.
+  const std::string no_code_format;
+  ws_declare_lock(this, *this->source_, nullptr,
+                  ws_ha_name(*this->source_, this->name_override_, this->get_ws_bridge_unique_id()), no_code_format);
+  ws_push_state_lock(this, *this->source_);
+}
+void WsBridgeLockRef::ws_bridge_handle_command(const WsCommand &command) {
+  ws_handle_command_lock(this->source_, command);
+}
+#endif
+
+#ifdef USE_VALVE
+void WsBridgeValveRef::setup() { ws_subscribe_valve(this, this->source_); }
+void WsBridgeValveRef::dump_config() {
+  ESP_LOGCONFIG(TAG, "WS Bridge Entity Ref '%s' -> valve '%s'", this->get_ws_bridge_unique_id().c_str(),
+                this->source_->get_name().str().c_str());
+}
+void WsBridgeValveRef::ws_bridge_declare() {
+  ws_declare_valve(this, *this->source_, nullptr,
+                   ws_ha_name(*this->source_, this->name_override_, this->get_ws_bridge_unique_id()));
+  ws_push_state_valve(this, *this->source_);
+}
+void WsBridgeValveRef::ws_bridge_handle_command(const WsCommand &command) {
+  ws_handle_command_valve(this->source_, command);
+}
+#endif
+
+#ifdef USE_EVENT
+void WsBridgeEventRef::setup() { ws_subscribe_event(this, this->source_); }
+void WsBridgeEventRef::dump_config() {
+  ESP_LOGCONFIG(TAG, "WS Bridge Entity Ref '%s' -> event '%s'", this->get_ws_bridge_unique_id().c_str(),
+                this->source_->get_name().str().c_str());
+}
+// No state push on declare — see ws_subscribe_event()'s comment.
+void WsBridgeEventRef::ws_bridge_declare() {
+  ws_declare_event(this, *this->source_, nullptr,
+                   ws_ha_name(*this->source_, this->name_override_, this->get_ws_bridge_unique_id()));
+}
+#endif
+
+#ifdef USE_DATETIME_DATE
+void WsBridgeDateRef::setup() { ws_subscribe_date(this, this->source_); }
+void WsBridgeDateRef::dump_config() {
+  ESP_LOGCONFIG(TAG, "WS Bridge Entity Ref '%s' -> date '%s'", this->get_ws_bridge_unique_id().c_str(),
+                this->source_->get_name().str().c_str());
+}
+void WsBridgeDateRef::ws_bridge_declare() {
+  ws_declare_date(this, *this->source_, nullptr,
+                  ws_ha_name(*this->source_, this->name_override_, this->get_ws_bridge_unique_id()));
+  ws_push_state_date(this, *this->source_);
+}
+void WsBridgeDateRef::ws_bridge_handle_command(const WsCommand &command) {
+  ws_handle_command_date(this->source_, command);
+}
+#endif
+
+#ifdef USE_DATETIME_TIME
+void WsBridgeTimeRef::setup() { ws_subscribe_time(this, this->source_); }
+void WsBridgeTimeRef::dump_config() {
+  ESP_LOGCONFIG(TAG, "WS Bridge Entity Ref '%s' -> time '%s'", this->get_ws_bridge_unique_id().c_str(),
+                this->source_->get_name().str().c_str());
+}
+void WsBridgeTimeRef::ws_bridge_declare() {
+  ws_declare_time(this, *this->source_, nullptr,
+                  ws_ha_name(*this->source_, this->name_override_, this->get_ws_bridge_unique_id()));
+  ws_push_state_time(this, *this->source_);
+}
+void WsBridgeTimeRef::ws_bridge_handle_command(const WsCommand &command) {
+  ws_handle_command_time(this->source_, command);
+}
+#endif
+
+#ifdef USE_DATETIME_DATETIME
+void WsBridgeDateTimeRef::setup() { ws_subscribe_datetime(this, this->source_); }
+void WsBridgeDateTimeRef::dump_config() {
+  ESP_LOGCONFIG(TAG, "WS Bridge Entity Ref '%s' -> datetime '%s'", this->get_ws_bridge_unique_id().c_str(),
+                this->source_->get_name().str().c_str());
+}
+void WsBridgeDateTimeRef::ws_bridge_declare() {
+  ws_declare_datetime(this, *this->source_, nullptr,
+                      ws_ha_name(*this->source_, this->name_override_, this->get_ws_bridge_unique_id()));
+  ws_push_state_datetime(this, *this->source_);
+}
+void WsBridgeDateTimeRef::ws_bridge_handle_command(const WsCommand &command) {
+  ws_handle_command_datetime(this->source_, command);
+}
+#endif
+
 }  // namespace ws_bridge
 }  // namespace esphome

--- a/components/ws_bridge/ws_bridge_entity_ref.h
+++ b/components/ws_bridge/ws_bridge_entity_ref.h
@@ -37,6 +37,27 @@
 #ifdef USE_FAN
 #include "esphome/components/fan/fan.h"
 #endif
+#ifdef USE_TEXT
+#include "esphome/components/text/text.h"
+#endif
+#ifdef USE_LOCK
+#include "esphome/components/lock/lock.h"
+#endif
+#ifdef USE_VALVE
+#include "esphome/components/valve/valve.h"
+#endif
+#ifdef USE_EVENT
+#include "esphome/components/event/event.h"
+#endif
+#ifdef USE_DATETIME_DATE
+#include "esphome/components/datetime/date_entity.h"
+#endif
+#ifdef USE_DATETIME_TIME
+#include "esphome/components/datetime/time_entity.h"
+#endif
+#ifdef USE_DATETIME_DATETIME
+#include "esphome/components/datetime/datetime_entity.h"
+#endif
 
 namespace esphome {
 namespace ws_bridge {
@@ -222,6 +243,111 @@ class WsBridgeFanRef : public WsBridgeEntityRefBase {
 
  protected:
   fan::Fan *source_{nullptr};
+};
+#endif
+
+#ifdef USE_TEXT
+class WsBridgeTextRef : public WsBridgeEntityRefBase {
+ public:
+  void set_source(text::Text *source) { this->source_ = source; }
+  const EntityBase *get_ws_bridge_source() const override { return this->source_; }
+  void setup() override;
+  void dump_config() override;
+  void ws_bridge_declare() override;
+  void ws_bridge_handle_command(const WsCommand &command) override;
+
+ protected:
+  text::Text *source_{nullptr};
+};
+#endif
+
+#ifdef USE_LOCK
+class WsBridgeLockRef : public WsBridgeEntityRefBase {
+ public:
+  void set_source(lock::Lock *source) { this->source_ = source; }
+  const EntityBase *get_ws_bridge_source() const override { return this->source_; }
+  void setup() override;
+  void dump_config() override;
+  void ws_bridge_declare() override;
+  void ws_bridge_handle_command(const WsCommand &command) override;
+
+ protected:
+  lock::Lock *source_{nullptr};
+};
+#endif
+
+#ifdef USE_VALVE
+class WsBridgeValveRef : public WsBridgeEntityRefBase {
+ public:
+  void set_source(valve::Valve *source) { this->source_ = source; }
+  const EntityBase *get_ws_bridge_source() const override { return this->source_; }
+  void setup() override;
+  void dump_config() override;
+  void ws_bridge_declare() override;
+  void ws_bridge_handle_command(const WsCommand &command) override;
+
+ protected:
+  valve::Valve *source_{nullptr};
+};
+#endif
+
+#ifdef USE_EVENT
+// Read-only, like the sensor refs — no ws_bridge_handle_command().
+class WsBridgeEventRef : public WsBridgeEntityRefBase {
+ public:
+  void set_source(event::Event *source) { this->source_ = source; }
+  const EntityBase *get_ws_bridge_source() const override { return this->source_; }
+  void setup() override;
+  void dump_config() override;
+  void ws_bridge_declare() override;
+
+ protected:
+  event::Event *source_{nullptr};
+};
+#endif
+
+#ifdef USE_DATETIME_DATE
+class WsBridgeDateRef : public WsBridgeEntityRefBase {
+ public:
+  void set_source(datetime::DateEntity *source) { this->source_ = source; }
+  const EntityBase *get_ws_bridge_source() const override { return this->source_; }
+  void setup() override;
+  void dump_config() override;
+  void ws_bridge_declare() override;
+  void ws_bridge_handle_command(const WsCommand &command) override;
+
+ protected:
+  datetime::DateEntity *source_{nullptr};
+};
+#endif
+
+#ifdef USE_DATETIME_TIME
+class WsBridgeTimeRef : public WsBridgeEntityRefBase {
+ public:
+  void set_source(datetime::TimeEntity *source) { this->source_ = source; }
+  const EntityBase *get_ws_bridge_source() const override { return this->source_; }
+  void setup() override;
+  void dump_config() override;
+  void ws_bridge_declare() override;
+  void ws_bridge_handle_command(const WsCommand &command) override;
+
+ protected:
+  datetime::TimeEntity *source_{nullptr};
+};
+#endif
+
+#ifdef USE_DATETIME_DATETIME
+class WsBridgeDateTimeRef : public WsBridgeEntityRefBase {
+ public:
+  void set_source(datetime::DateTimeEntity *source) { this->source_ = source; }
+  const EntityBase *get_ws_bridge_source() const override { return this->source_; }
+  void setup() override;
+  void dump_config() override;
+  void ws_bridge_declare() override;
+  void ws_bridge_handle_command(const WsCommand &command) override;
+
+ protected:
+  datetime::DateTimeEntity *source_{nullptr};
 };
 #endif
 

--- a/tests/components/ws_bridge/test.esp32-idf.yaml
+++ b/tests/components/ws_bridge/test.esp32-idf.yaml
@@ -67,6 +67,13 @@ ws_bridge:
     - source_id: local_light
     - source_id: local_cover
     - source_id: local_fan
+    - source_id: local_text
+    - source_id: local_lock
+    - source_id: local_valve
+    - source_id: local_event
+    - source_id: local_date
+    - source_id: local_time
+    - source_id: local_datetime
 
 sensor:
   - platform: ws_bridge
@@ -259,3 +266,121 @@ fan:
     unique_id: fan_bridged
     name: "Fan (bridged)"
     fan_id: local_fan
+
+# text is HA's writable text domain — unrelated to text_sensor above.
+# min_length/max_length are string lengths, not a value range.
+text:
+  - platform: ws_bridge
+    unique_id: note1
+    name: "Note"
+    min_length: 0
+    max_length: 64
+    pattern: "[A-Za-z0-9 ]*"
+  - platform: ws_bridge
+    unique_id: secret1
+    name: "Secret"
+    mode: password
+  - platform: template
+    id: local_text
+    name: "Local Text"
+    mode: text
+    optimistic: true
+  # min_length/max_length/pattern/mode omitted on purpose — wrapping reports
+  # the wrapped text's own limits.
+  - platform: ws_bridge
+    unique_id: text_bridged
+    name: "Text (bridged)"
+    text_id: local_text
+
+lock:
+  - platform: ws_bridge
+    unique_id: lock1
+    name: "Front Door"
+    code_format: '^\d{4}$'
+  - platform: template
+    id: local_lock
+    name: "Local Lock"
+    optimistic: true
+  - platform: ws_bridge
+    unique_id: lock_bridged
+    name: "Lock (bridged)"
+    lock_id: local_lock
+
+valve:
+  - platform: ws_bridge
+    unique_id: valve1
+    name: "Main Valve"
+  - platform: template
+    id: local_valve
+    name: "Local Valve"
+    optimistic: true
+    has_position: true
+  - platform: ws_bridge
+    unique_id: valve_bridged
+    name: "Valve (bridged)"
+    valve_id: local_valve
+
+event:
+  - platform: ws_bridge
+    unique_id: doorbell1
+    name: "Doorbell"
+    device_class: doorbell
+    event_types:
+      - "single"
+      - "double"
+  - platform: template
+    id: local_event
+    name: "Local Event"
+    event_types:
+      - "ping"
+  # event_types omitted on purpose — wrapping declares the wrapped event's list.
+  - platform: ws_bridge
+    unique_id: event_bridged
+    name: "Event (bridged)"
+    event_id: local_event
+
+# date / time / datetime all live in ESPHome's single datetime: domain, chosen
+# by type:. There is no time: entity domain — that name is the clock source.
+datetime:
+  - platform: ws_bridge
+    type: date
+    unique_id: date1
+    name: "Date"
+  - platform: ws_bridge
+    type: time
+    unique_id: time1
+    name: "Time"
+  - platform: ws_bridge
+    type: datetime
+    unique_id: datetime1
+    name: "DateTime"
+  - platform: template
+    id: local_date
+    type: date
+    name: "Local Date"
+    optimistic: true
+  - platform: template
+    id: local_time
+    type: time
+    name: "Local Time"
+    optimistic: true
+  - platform: template
+    id: local_datetime
+    type: datetime
+    name: "Local DateTime"
+    optimistic: true
+  - platform: ws_bridge
+    type: date
+    unique_id: date_bridged
+    name: "Date (bridged)"
+    datetime_id: local_date
+  - platform: ws_bridge
+    type: time
+    unique_id: time_bridged
+    name: "Time (bridged)"
+    datetime_id: local_time
+  - platform: ws_bridge
+    type: datetime
+    unique_id: datetime_bridged
+    name: "DateTime (bridged)"
+    datetime_id: local_datetime


### PR DESCRIPTION
## Summary
- Phase **C3**: `text`, `lock`, `valve`, `event`, and `datetime` (`type: date|time|datetime` — no `time/` dir).
- Optional `*_id:` wrapping + hub `entities:` refs; valve object state; event is declare/subscribe only (no initial push).
- Lock `code_format` is declare-only (ESPHome has no code API); datetime normalizes HA ISO (`T`/tz) before `strptime`.

## Test plan
- [x] `esphome compile tests/components/ws_bridge/test.esp32-idf.yaml` (ESPHome 2026.7.4)
- [ ] Device: declare each platform → HA entities appear
- [ ] Commands: text `set_value`; lock lock/unlock/open; valve position; datetime `set_value`
- [ ] Fire event → HA receives once; reconnect does not re-fire last event
- [ ] Existing platforms regression

Next: **C4** (`climate`).


Made with [Cursor](https://cursor.com)