### PR TITLE
fix(ws_bridge): value type flags + paced declare/TX queue

### DIFF
--- a/components/ws_bridge/IMPLEMENTATION_PLAN_ko.md
+++ b/components/ws_bridge/IMPLEMENTATION_PLAN_ko.md
@@ -5,7 +5,7 @@
 > **서버 기준**: `hass-ws-bridge` main (Phase 4 + 공통 계층 정리 완료, 플랫폼 27종)
 > **클라이언트 현재**: 플랫폼 19종(+ tracker) — C0 `params`/`features`·C1 `update`·C2 `light`/`cover`/`fan`·C3 `text`/`lock`/`valve`/`event`/`date`/`time`/`datetime`·C4 `climate` 반영. 남은 Tier A는 C5.
 > **작성일**: 2026-08-13
-> **갱신**: 2026-08-13 — C0~C4 구현
+> **갱신**: 2026-08-13 — C0~C4 구현; 후속: `value` 타입 플래그 + paced declare/TX 큐
 
 ---
 
@@ -189,9 +189,9 @@ this->parent_->send_state_object(this->unique_id_, [this](JsonObject v) {
 
 **새 빌더를 만들지 말 것.**
 
-### 3.4 (선택) 상태 배치 전송
+### 3.4 전송 스케줄링 (후속)
 
-`build_state_*`가 매번 프레임 1개에 항목 1개만 담는다. 복합 플랫폼이 늘면 프레임 수가 늘어난다. 여유가 있으면 `send_state_batch()`를 추가하되, **C0 범위 밖이다.** 먼저 동작을 맞추고 나중에 최적화한다.
+연결/재공지 때 엔티티마다 declare+state를 한 loop에서 블로킹 `send_text`(timeout 1s)로 몰아 보내면 대형 게이트웨이에서 메인 루프가 수십 초 멈출 수 있고, 실패해도 `declared_ids_`에 들어가 sync가 거짓 양성으로 보고된다. **paced declare**(루프당 소수 엔티티) + **비블로킹 TX 큐**(성공 시에만 sync 목록 반영)로 고친다. `send_state_batch()`는 여전히 선택 최적화다.
 
 ### 3.5 Phase C0 완료 조건
 

--- a/components/ws_bridge/ws_bridge.cpp
+++ b/components/ws_bridge/ws_bridge.cpp
@@ -342,11 +342,6 @@ void WsBridgeComponent::start_declare_pass_(bool run_connected_and_sync) {
   }
 }
 
-void WsBridgeComponent::declare_all_entities_() {
-  // Kept for call sites that want a full redeclare without connect/sync.
-  this->start_declare_pass_(/*run_connected_and_sync=*/false);
-}
-
 void WsBridgeComponent::progress_declare_() {
   if (this->declare_in_progress_) {
     size_t n = 0;
@@ -402,7 +397,8 @@ void WsBridgeComponent::drain_tx_queue_() {
   size_t sent = 0;
   while (!this->tx_queue_.empty() && sent < TX_PER_LOOP) {
     TxItem &item = this->tx_queue_.front();
-    int r = esp_websocket_client_send_text(this->client_, item.msg.c_str(), item.msg.size(), 0);
+    int r = esp_websocket_client_send_text(this->client_, item.msg.c_str(), item.msg.size(),
+                                           pdMS_TO_TICKS(TX_SEND_TIMEOUT_MS));
     if (r < 0)
       break;
     if (this->collecting_declared_ids_ && !item.sync_declare_uid.empty())
@@ -415,12 +411,17 @@ void WsBridgeComponent::drain_tx_queue_() {
 bool WsBridgeComponent::send_raw_(const std::string &msg, const std::string &sync_declare_uid) {
   if (this->client_ == nullptr || !esp_websocket_client_is_connected(this->client_))
     return false;
-  // Non-blocking attempt first — a stalled peer must not freeze loop().
-  int r = esp_websocket_client_send_text(this->client_, msg.c_str(), msg.size(), 0);
-  if (r >= 0) {
-    if (this->collecting_declared_ids_ && !sync_declare_uid.empty())
-      this->declared_ids_.push_back(sync_declare_uid);
-    return true;
+  // Keep FIFO: a queued v1 must leave before a later v2. Bypass the queue only
+  // when it is empty. Timeout is short (not 0) so a full TCP window waits
+  // instead of aborting the connection.
+  if (this->tx_queue_.empty()) {
+    int r = esp_websocket_client_send_text(this->client_, msg.c_str(), msg.size(),
+                                           pdMS_TO_TICKS(TX_SEND_TIMEOUT_MS));
+    if (r >= 0) {
+      if (this->collecting_declared_ids_ && !sync_declare_uid.empty())
+        this->declared_ids_.push_back(sync_declare_uid);
+      return true;
+    }
   }
   if (this->tx_queue_.size() >= TX_QUEUE_MAX) {
     ESP_LOGW(TAG, "TX queue full (%u) — dropping outbound message", (unsigned) TX_QUEUE_MAX);

--- a/components/ws_bridge/ws_bridge.cpp
+++ b/components/ws_bridge/ws_bridge.cpp
@@ -52,6 +52,12 @@ void WsBridgeComponent::loop() {
     this->event_pool_.release(event);
   }
 
+  this->drain_tx_queue_();
+  this->progress_declare_();
+  // Drain again so frames enqueued by this declare slice can leave before
+  // sync is considered, and so a stalled peer is retried every loop.
+  this->drain_tx_queue_();
+  this->maybe_flush_sync_();
   this->check_liveness_();
 }
 
@@ -67,6 +73,10 @@ void WsBridgeComponent::loop() {
 void WsBridgeComponent::force_reconnect_() {
   this->last_reconnect_attempt_ms_ = millis();
   this->set_state_(WS_BRIDGE_DISCONNECTED);
+  this->clear_tx_queue_();
+  this->declare_in_progress_ = false;
+  this->sync_flush_pending_ = false;
+  this->collecting_declared_ids_ = false;
   esp_websocket_client_stop(this->client_);
   esp_websocket_client_start(this->client_);
 }
@@ -124,7 +134,9 @@ void WsBridgeComponent::check_liveness_() {
     this->last_connect_msg_id_ = connect_id;
     this->awaiting_connect_result_ = true;
     this->connect_sent_ms_ = now;
-    this->declare_all_entities_();
+    // Re-announce only re-declares — no on_connected: and no sync (stale
+    // entities are not urgent enough to scan HA's registry every interval).
+    this->start_declare_pass_(/*run_connected_and_sync=*/false);
     this->last_reannounce_ms_ = now;
   }
   if (now - this->last_ping_sent_ms_ > this->ping_interval_ms_) {
@@ -257,6 +269,10 @@ void WsBridgeComponent::handle_event_(const WsEvent &event) {
         // comment on reconnect_backoff_ms_ in ws_bridge.h.
         this->last_reconnect_attempt_ms_ = millis();
         this->reconnect_backoff_ms_ = RECONNECT_BACKOFF_BASE_MS;
+        this->clear_tx_queue_();
+        this->declare_in_progress_ = false;
+        this->sync_flush_pending_ = false;
+        this->collecting_declared_ids_ = false;
         this->disconnected_cb_.call();
       }
       break;
@@ -282,13 +298,9 @@ void WsBridgeComponent::handle_message_(const std::string &raw) {
     this->reconnect_backoff_ms_ = RECONNECT_BACKOFF_BASE_MS;
     this->last_ping_sent_ms_ = millis();
     this->last_reannounce_ms_ = this->last_ping_sent_ms_;
-    // Collect across both the declare pass and on_connected:, so a lambda that
-    // declares from either trigger is counted before the list is sent.
-    this->collecting_declared_ids_ = this->sync_entities_;
-    this->declared_ids_.clear();
-    this->declare_all_entities_();
-    this->connected_cb_.call();
-    this->flush_sync_();
+    // Platform declares + on_declare:/on_connected: + sync are paced across
+    // loop() iterations — see start_declare_pass_().
+    this->start_declare_pass_(/*run_connected_and_sync=*/true);
   } else if (msg.type == "auth_invalid") {
     ESP_LOGE(TAG, "Home Assistant rejected the access token");
   } else if (msg.type == "pong") {
@@ -314,17 +326,62 @@ void WsBridgeComponent::route_command_(const WsCommand &command) {
   ESP_LOGW(TAG, "Command for unknown unique_id '%s'", command.unique_id.c_str());
 }
 
+void WsBridgeComponent::start_declare_pass_(bool run_connected_and_sync) {
+  this->declare_in_progress_ = true;
+  this->declare_device_index_ = 0;
+  this->declare_run_connected_ = run_connected_and_sync;
+  if (run_connected_and_sync) {
+    // Collect across the paced declare pass and on_connected:, so a lambda
+    // that declares from either trigger is counted before sync is sent.
+    this->collecting_declared_ids_ = this->sync_entities_;
+    this->declared_ids_.clear();
+    this->sync_flush_pending_ = this->sync_entities_;
+  } else {
+    this->collecting_declared_ids_ = false;
+    this->sync_flush_pending_ = false;
+  }
+}
+
 void WsBridgeComponent::declare_all_entities_() {
-  for (auto *device : this->devices_) device->ws_bridge_declare();
-  // Manual (lambda-built) declarations piggyback here rather than on
-  // on_connected, so they're re-sent by the periodic re-announce too — see
-  // add_on_declare_callback().
-  this->declare_cb_.call();
+  // Kept for call sites that want a full redeclare without connect/sync.
+  this->start_declare_pass_(/*run_connected_and_sync=*/false);
+}
+
+void WsBridgeComponent::progress_declare_() {
+  if (this->declare_in_progress_) {
+    size_t n = 0;
+    while (this->declare_device_index_ < this->devices_.size() && n < DECLARE_DEVICES_PER_LOOP) {
+      this->devices_[this->declare_device_index_++]->ws_bridge_declare();
+      n++;
+    }
+    if (this->declare_device_index_ < this->devices_.size())
+      return;
+
+    // Manual (lambda-built) declarations piggyback here rather than on
+    // on_connected alone, so they're re-sent by the periodic re-announce too.
+    this->declare_cb_.call();
+    if (this->declare_run_connected_) {
+      this->connected_cb_.call();
+      this->declare_run_connected_ = false;
+    }
+    this->declare_in_progress_ = false;
+  }
+  this->maybe_flush_sync_();
+}
+
+void WsBridgeComponent::maybe_flush_sync_() {
+  if (!this->sync_flush_pending_)
+    return;
+  if (this->declare_in_progress_ || !this->tx_queue_.empty())
+    return;
+  this->flush_sync_();
+  this->sync_flush_pending_ = false;
 }
 
 void WsBridgeComponent::flush_sync_() {
   this->collecting_declared_ids_ = false;
-  if (!this->sync_entities_) return;
+  if (!this->sync_entities_)
+    return;
   // HA rejects an empty list (it would mean "delete everything"), and a
   // gateway that declared nothing has nothing to reconcile against anyway.
   if (this->declared_ids_.empty()) {
@@ -337,41 +394,79 @@ void WsBridgeComponent::flush_sync_() {
   this->declared_ids_.shrink_to_fit();
 }
 
-void WsBridgeComponent::send_raw_(const std::string &msg) {
-  if (this->client_ == nullptr || !esp_websocket_client_is_connected(this->client_)) return;
-  esp_websocket_client_send_text(this->client_, msg.c_str(), msg.size(), pdMS_TO_TICKS(1000));
+void WsBridgeComponent::clear_tx_queue_() { this->tx_queue_.clear(); }
+
+void WsBridgeComponent::drain_tx_queue_() {
+  if (this->client_ == nullptr || !esp_websocket_client_is_connected(this->client_))
+    return;
+  size_t sent = 0;
+  while (!this->tx_queue_.empty() && sent < TX_PER_LOOP) {
+    TxItem &item = this->tx_queue_.front();
+    int r = esp_websocket_client_send_text(this->client_, item.msg.c_str(), item.msg.size(), 0);
+    if (r < 0)
+      break;
+    if (this->collecting_declared_ids_ && !item.sync_declare_uid.empty())
+      this->declared_ids_.push_back(item.sync_declare_uid);
+    this->tx_queue_.pop_front();
+    sent++;
+  }
+}
+
+bool WsBridgeComponent::send_raw_(const std::string &msg, const std::string &sync_declare_uid) {
+  if (this->client_ == nullptr || !esp_websocket_client_is_connected(this->client_))
+    return false;
+  // Non-blocking attempt first — a stalled peer must not freeze loop().
+  int r = esp_websocket_client_send_text(this->client_, msg.c_str(), msg.size(), 0);
+  if (r >= 0) {
+    if (this->collecting_declared_ids_ && !sync_declare_uid.empty())
+      this->declared_ids_.push_back(sync_declare_uid);
+    return true;
+  }
+  if (this->tx_queue_.size() >= TX_QUEUE_MAX) {
+    ESP_LOGW(TAG, "TX queue full (%u) — dropping outbound message", (unsigned) TX_QUEUE_MAX);
+    return false;
+  }
+  this->tx_queue_.push_back(TxItem{msg, sync_declare_uid});
+  return true;
 }
 
 void WsBridgeComponent::send_entity_declare(const std::string &unique_id, const std::string &platform,
                                             const std::string &name, const std::string &device_id,
                                             const std::string &device_name,
                                             const std::function<void(JsonObject)> &extra) {
-  if (!this->is_connected()) return;
+  if (!this->is_connected())
+    return;
   // Every declaration funnels through here — registered platform entities and
   // hand-built lambda ones alike — so this is the one place that sees the full
-  // set for ws_bridge/sync. See sync_entities_.
-  if (this->collecting_declared_ids_) this->declared_ids_.push_back(unique_id);
-  this->send_raw_(build_entity_declare(this->next_id_(), unique_id, platform, name, device_id, device_name, extra));
+  // set for ws_bridge/sync. unique_id is only recorded after the frame is
+  // actually written (or when a queued frame is later drained).
+  const std::string sync_uid = this->collecting_declared_ids_ ? unique_id : "";
+  this->send_raw_(build_entity_declare(this->next_id_(), unique_id, platform, name, device_id, device_name, extra),
+                  sync_uid);
 }
 
 void WsBridgeComponent::send_state_float(const std::string &unique_id, float value) {
-  if (!this->is_connected()) return;
+  if (!this->is_connected())
+    return;
   this->send_raw_(build_state_float(this->next_id_(), unique_id, value));
 }
 
 void WsBridgeComponent::send_state_bool(const std::string &unique_id, bool value) {
-  if (!this->is_connected()) return;
+  if (!this->is_connected())
+    return;
   this->send_raw_(build_state_bool(this->next_id_(), unique_id, value));
 }
 
 void WsBridgeComponent::send_state_string(const std::string &unique_id, const std::string &value) {
-  if (!this->is_connected()) return;
+  if (!this->is_connected())
+    return;
   this->send_raw_(build_state_string(this->next_id_(), unique_id, value));
 }
 
 void WsBridgeComponent::send_state_object(const std::string &unique_id,
                                           const std::function<void(JsonObject)> &value_fn) {
-  if (!this->is_connected()) return;
+  if (!this->is_connected())
+    return;
   this->send_raw_(build_state_object(this->next_id_(), unique_id, value_fn));
 }
 

--- a/components/ws_bridge/ws_bridge.h
+++ b/components/ws_bridge/ws_bridge.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <atomic>
+#include <deque>
 #include <functional>
 #include <string>
 #include <vector>
@@ -100,12 +101,27 @@ class WsBridgeComponent : public Component {
   void handle_message_(const std::string &raw);
   void route_command_(const WsCommand &command);
   void declare_all_entities_();
+  void start_declare_pass_(bool run_connected_and_sync);
+  void progress_declare_();
+  void maybe_flush_sync_();
   void flush_sync_();
-  void send_raw_(const std::string &msg);
+  // Non-blocking send with a drainable queue. Returns false only when the
+  // message could not be accepted (not connected, or queue full).
+  bool send_raw_(const std::string &msg, const std::string &sync_declare_uid = "");
+  void drain_tx_queue_();
+  void clear_tx_queue_();
   uint32_t next_id_() { return ++this->msg_id_; }
   void set_state_(WsBridgeState s);
   void check_liveness_();
   void force_reconnect_();
+
+  // One outbound WS text frame. `sync_declare_uid` is set for entity declares
+  // collected during a sync pass — only appended to declared_ids_ after the
+  // frame is actually written to the socket (not when merely queued).
+  struct TxItem {
+    std::string msg;
+    std::string sync_declare_uid;
+  };
 
   esp_websocket_client_handle_t client_{nullptr};
   bool started_{false};
@@ -134,6 +150,22 @@ class WsBridgeComponent : public Component {
   bool sync_entities_{false};
   bool collecting_declared_ids_{false};
   std::vector<std::string> declared_ids_{};
+
+  // Paced (re)declare: platform entities are declared a few per loop() so a
+  // large gateway cannot block the main loop for tens of seconds on a slow
+  // link (each send_text used to wait up to 1000 ms). on_declare: /
+  // on_connected: run after the device list is finished; ws_bridge/sync waits
+  // until the TX queue has drained so declared_ids_ only contains frames that
+  // actually left the socket.
+  bool declare_in_progress_{false};
+  size_t declare_device_index_{0};
+  bool declare_run_connected_{false};
+  bool sync_flush_pending_{false};
+  static constexpr size_t DECLARE_DEVICES_PER_LOOP = 2;
+
+  std::deque<TxItem> tx_queue_{};
+  static constexpr size_t TX_QUEUE_MAX = 64;
+  static constexpr size_t TX_PER_LOOP = 4;
 
   std::atomic<WsBridgeState> state_{WS_BRIDGE_DISCONNECTED};
   uint32_t msg_id_{0};

--- a/components/ws_bridge/ws_bridge.h
+++ b/components/ws_bridge/ws_bridge.h
@@ -100,7 +100,6 @@ class WsBridgeComponent : public Component {
   void handle_event_(const WsEvent &event);
   void handle_message_(const std::string &raw);
   void route_command_(const WsCommand &command);
-  void declare_all_entities_();
   void start_declare_pass_(bool run_connected_and_sync);
   void progress_declare_();
   void maybe_flush_sync_();
@@ -153,10 +152,11 @@ class WsBridgeComponent : public Component {
 
   // Paced (re)declare: platform entities are declared a few per loop() so a
   // large gateway cannot block the main loop for tens of seconds on a slow
-  // link (each send_text used to wait up to 1000 ms). on_declare: /
-  // on_connected: run after the device list is finished; ws_bridge/sync waits
-  // until the TX queue has drained so declared_ids_ only contains frames that
-  // actually left the socket.
+  // link. send_text waits TX_SEND_TIMEOUT_MS (not 0 — a 0 timeout aborts the
+  // connection when the TCP window is full). on_declare: / on_connected: run
+  // after the device list is finished; ws_bridge/sync waits until the TX queue
+  // has drained so declared_ids_ only contains frames that actually left the
+  // socket.
   bool declare_in_progress_{false};
   size_t declare_device_index_{0};
   bool declare_run_connected_{false};
@@ -166,6 +166,9 @@ class WsBridgeComponent : public Component {
   std::deque<TxItem> tx_queue_{};
   static constexpr size_t TX_QUEUE_MAX = 64;
   static constexpr size_t TX_PER_LOOP = 4;
+  // Small enough that 4 sends stay under the loop budget (~200 ms), long
+  // enough for a momentarily full TCP window to drain instead of aborting.
+  static constexpr uint32_t TX_SEND_TIMEOUT_MS = 50;
 
   std::atomic<WsBridgeState> state_{WS_BRIDGE_DISCONNECTED};
   uint32_t msg_id_{0};

--- a/components/ws_bridge/ws_bridge_domains.h
+++ b/components/ws_bridge/ws_bridge_domains.h
@@ -251,7 +251,7 @@ inline void ws_subscribe_number(WsBridgeDevice *dev, number::Number *src) {
 }
 
 inline void ws_handle_command_number(number::Number *target, const WsCommand &command) {
-  if (command.action == "set_value" && command.has_value) {
+  if (command.action == "set_value" && command.value_is_number) {
     target->make_call().set_value(command.value_float).perform();
   }
 }
@@ -287,7 +287,7 @@ inline void ws_subscribe_select(WsBridgeDevice *dev, select::Select *src) {
 }
 
 inline void ws_handle_command_select(select::Select *target, const WsCommand &command) {
-  if (command.action == "select_option" && command.has_value) {
+  if (command.action == "select_option" && command.value_is_string) {
     target->make_call().set_option(command.value_string).perform();
   }
 }
@@ -868,7 +868,7 @@ inline void ws_subscribe_text(WsBridgeDevice *dev, text::Text *src) {
 }
 
 inline void ws_handle_command_text(text::Text *target, const WsCommand &command) {
-  if (command.action == "set_value" && command.has_value) {
+  if (command.action == "set_value" && command.value_is_string) {
     target->make_call().set_value(command.value_string).perform();
   }
 }
@@ -1061,9 +1061,10 @@ inline void ws_send_state_datetime_(WsBridgeDevice *dev, datetime::DateTimeBase 
 
 // HA sends full ISO 8601 ("2026-08-13T21:30:00+09:00"); ESPTime::strptime()
 // accepts only "YYYY-MM-DD[ HH:MM[:SS]]" and "HH:MM[:SS]" — no 'T' separator,
-// no fractional seconds, no timezone. Values arriving in the device's own local
-// time is exactly what the tz-naive round trip assumes (HA re-attaches its
-// local zone to the tz-naive strings we send back).
+// no fractional seconds, no timezone. We keep the wall-clock digits and drop
+// any offset/Z — the round trip assumes HA sends **local** wall time (see
+// hass-ws-bridge datetime.async_set_value), matching the tz-naive strings we
+// publish back (HA re-attaches its local zone on receive).
 inline std::string ws_iso_to_esptime_string_(const std::string &iso) {
   std::string out = iso;
   size_t separator = out.find('T');
@@ -1101,7 +1102,7 @@ inline void ws_subscribe_date(WsBridgeDevice *dev, datetime::DateEntity *src) {
 }
 
 inline void ws_handle_command_date(datetime::DateEntity *target, const WsCommand &command) {
-  if (command.action == "set_value" && command.has_value) {
+  if (command.action == "set_value" && command.value_is_string) {
     target->make_call().set_date(ws_iso_to_esptime_string_(command.value_string)).perform();
   }
 }
@@ -1123,7 +1124,7 @@ inline void ws_subscribe_time(WsBridgeDevice *dev, datetime::TimeEntity *src) {
 }
 
 inline void ws_handle_command_time(datetime::TimeEntity *target, const WsCommand &command) {
-  if (command.action == "set_value" && command.has_value) {
+  if (command.action == "set_value" && command.value_is_string) {
     target->make_call().set_time(ws_iso_to_esptime_string_(command.value_string)).perform();
   }
 }
@@ -1145,7 +1146,7 @@ inline void ws_subscribe_datetime(WsBridgeDevice *dev, datetime::DateTimeEntity 
 }
 
 inline void ws_handle_command_datetime(datetime::DateTimeEntity *target, const WsCommand &command) {
-  if (command.action == "set_value" && command.has_value) {
+  if (command.action == "set_value" && command.value_is_string) {
     target->make_call().set_datetime(ws_iso_to_esptime_string_(command.value_string)).perform();
   }
 }

--- a/components/ws_bridge/ws_bridge_domains.h
+++ b/components/ws_bridge/ws_bridge_domains.h
@@ -1059,30 +1059,93 @@ inline void ws_send_state_datetime_(WsBridgeDevice *dev, datetime::DateTimeBase 
   dev->get_ws_bridge_parent()->send_state_string(dev->get_ws_bridge_unique_id(), buf);
 }
 
-// HA sends full ISO 8601 ("2026-08-13T21:30:00+09:00"); ESPTime::strptime()
-// accepts only "YYYY-MM-DD[ HH:MM[:SS]]" and "HH:MM[:SS]" — no 'T' separator,
-// no fractional seconds, no timezone. We keep the wall-clock digits and drop
-// any offset/Z — the round trip assumes HA sends **local** wall time (see
-// hass-ws-bridge datetime.async_set_value), matching the tz-naive strings we
-// publish back (HA re-attaches its local zone on receive).
+// HA may send full ISO 8601 ("2026-08-13T21:30:00+09:00", "...Z").
+// ESPTime::strptime() accepts only "YYYY-MM-DD[ HH:MM[:SS]]" and "HH:MM[:SS]".
+// When a numeric offset / Z is present on a full datetime, convert to the
+// device's local wall clock (USE_TIME_TIMEZONE) instead of stripping digits —
+// otherwise a UTC payload like "...T12:30:00+00:00" lands 9h wrong on KST.
+// Offset-less values are already local wall clock (see hass-ws-bridge
+// datetime.async_set_value) and are only normalized (T→space, trim).
+inline bool ws_parse_iso_tz_offset_(const char *s, size_t len, int32_t &offset_sec) {
+  if (len == 0)
+    return false;
+  if (s[0] == 'Z' || s[0] == 'z') {
+    offset_sec = 0;
+    return true;
+  }
+  if ((s[0] != '+' && s[0] != '-') || len < 3)
+    return false;
+  const int sign = (s[0] == '-') ? -1 : 1;
+  auto digit = [](char c) -> int { return (c >= '0' && c <= '9') ? (c - '0') : -1; };
+  int hour = digit(s[1]) * 10 + digit(s[2]);
+  if (hour < 0 || hour > 23)
+    return false;
+  int minute = 0;
+  if (len >= 6 && s[3] == ':') {
+    minute = digit(s[4]) * 10 + digit(s[5]);
+  } else if (len >= 5 && digit(s[3]) >= 0) {
+    minute = digit(s[3]) * 10 + digit(s[4]);
+  } else if (len != 3) {
+    return false;
+  }
+  if (minute < 0 || minute > 59)
+    return false;
+  offset_sec = sign * (hour * 3600 + minute * 60);
+  return true;
+}
+
 inline std::string ws_iso_to_esptime_string_(const std::string &iso) {
   std::string out = iso;
   size_t separator = out.find('T');
   if (separator != std::string::npos)
     out[separator] = ' ';
 
+  int32_t offset_sec = 0;
+  bool has_offset = false;
   // Everything past the seconds field has to go. Scanning from the first ':'
   // keeps the date's own '-' separators from being read as a negative UTC
   // offset; a date-only value has no such suffix to strip in the first place.
   size_t time_start = out.find(':');
   if (time_start != std::string::npos) {
     size_t cut = out.find_first_of(".Z+-", time_start);
-    if (cut != std::string::npos)
+    if (cut != std::string::npos) {
+      if (out[cut] == '.') {
+        size_t tz = out.find_first_of("Z+-", cut + 1);
+        if (tz != std::string::npos)
+          has_offset = ws_parse_iso_tz_offset_(out.c_str() + tz, out.size() - tz, offset_sec);
+      } else {
+        has_offset = ws_parse_iso_tz_offset_(out.c_str() + cut, out.size() - cut, offset_sec);
+      }
       out.erase(cut);
+    }
   }
   while (!out.empty() && out.back() == ' ')
     out.pop_back();
-  return out;
+
+  if (!has_offset)
+    return out;
+
+  // Full datetime only — date-only / time-only keep wall-clock digits (HA date
+  // and time platforms are timezone-naive calendar values).
+  const bool has_date = out.size() >= 10 && out[4] == '-';
+  const bool has_time = out.find(':') != std::string::npos;
+  if (!has_date || !has_time)
+    return out;
+
+  ESPTime wall{};
+  if (!ESPTime::strptime(out, wall))
+    return out;
+  wall.recalc_timestamp_utc(false);
+  if (wall.timestamp < 0)
+    return out;
+
+  // ISO offset is east of UTC: utc = wall_as_utc_fields - offset.
+  const time_t utc_epoch = static_cast<time_t>(wall.timestamp - offset_sec);
+  ESPTime local = ESPTime::from_epoch_local(utc_epoch);
+  char buf[24];
+  if (local.strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S") == 0)
+    return out;
+  return std::string(buf);
 }
 #endif  // any USE_DATETIME_*
 

--- a/components/ws_bridge/ws_protocol.cpp
+++ b/components/ws_bridge/ws_protocol.cpp
@@ -57,11 +57,19 @@ ParsedMessage parse_message(const std::string &raw) {
         if (event["unique_id"].is<const char *>()) msg.command.unique_id = event["unique_id"].as<std::string>();
         if (event["action"].is<const char *>()) msg.command.action = event["action"].as<std::string>();
         if (!event["value"].isNull()) {
-          msg.command.has_value = true;
-          if (event["value"].is<const char *>()) {
-            msg.command.value_string = event["value"].as<std::string>();
-          } else {
-            msg.command.value_float = event["value"].as<float>();
+          JsonVariant v = event["value"];
+          // Mirror WsParam typing: never treat null/object/bool as float 0, and
+          // never leave has_value set without a matching type flag.
+          if (v.is<const char *>()) {
+            msg.command.has_value = true;
+            msg.command.value_is_string = true;
+            msg.command.value_string = v.as<std::string>();
+          } else if (v.is<bool>()) {
+            // No scalar command uses a JSON bool `value` today.
+          } else if (v.is<float>()) {
+            msg.command.has_value = true;
+            msg.command.value_is_number = true;
+            msg.command.value_float = v.as<float>();
           }
         }
         // Copy params out of the JsonDocument — it is destroyed when this

--- a/components/ws_bridge/ws_protocol.h
+++ b/components/ws_bridge/ws_protocol.h
@@ -31,9 +31,14 @@ struct WsParam {
 struct WsCommand {
   std::string unique_id;
   std::string action;  // "turn_on" | "turn_off" | "set_value" | "select_option" | "press" | "install" | "check"
+  // Same discipline as WsParam: has_value alone is not enough — a string "23.5"
+  // must not become float 0 for number, and a JSON number must not become "" for
+  // text/select/datetime. Type flags stay false for null / object / bool.
   bool has_value{false};
-  float value_float{0};
-  std::string value_string;
+  bool value_is_number{false};
+  float value_float{0};  // value_is_number == true
+  bool value_is_string{false};
+  std::string value_string;  // value_is_string == true
   std::vector<WsParam> params;
 
   const WsParam *param(const char *key) const;


### PR DESCRIPTION
## Summary
- Add `value_is_number` / `value_is_string` on `WsCommand` (same discipline as `WsParam`) and gate number / text / select / date / time / datetime handlers on the matching flag — stops `"23.5"` → `set_value(0)` and numeric JSON → empty string.
- Pace connect/re-announce declares across `loop()` (2 devices/iteration) and send with a drainable TX queue; only record `unique_id` in `declared_ids_` after a frame is actually written, then flush `ws_bridge/sync` once the queue is empty.
- **Datetime ISO offsets**: when `Z` / `±HH:MM` is present on a full datetime, convert to device local wall clock (`ESPTime::from_epoch_local`) instead of digit-stripping. Offset-less values stay normalized local wall clock. Pairs with [hass-ws-bridge#40](https://github.com/eigger/hass-ws-bridge/pull/40).
- **TX review follow-up:** `send_text` uses a 50 ms timeout (not 0 — a 0-tick wait aborts the connection on a full TCP window); never bypass a non-empty queue (FIFO); drop unused `declare_all_entities_()`.

## Test plan
- [ ] `esphome compile tests/components/ws_bridge/test.esp32-idf.yaml` (2026.7.4+)
- [ ] Send a string `value` to a number entity — must be ignored (not become 0)
- [ ] Send a numeric `value` to text/select/datetime — must be ignored
- [ ] Connect with `sync_entities: true` and many entities — no long main-loop stall; sync list matches successfully sent declares
- [ ] With device TZ set (e.g. Asia/Seoul), command `2026-08-13T12:30:00Z` → local `21:30:00`; `...T21:30:00+09:00` → `21:30:00`
- [ ] Slow/lossy link: declare burst should queue/retry, not drop the WebSocket