### PR TITLE
fix(ws_bridge): avoid websocket abort on short TX timeouts

### DIFF
--- a/components/ws_bridge/ws_bridge.cpp
+++ b/components/ws_bridge/ws_bridge.cpp
@@ -126,7 +126,11 @@ void WsBridgeComponent::check_liveness_() {
   // detected failure, it just periodically re-establishes our registration
   // in case the HA-side integration silently lost track of us while the
   // transport itself (and ping/pong) stayed healthy.
-  if (now - this->last_reannounce_ms_ > this->reannounce_interval_ms_) {
+  // Skip while a declare pass or TX backlog is still draining — stacking
+  // another full redeclare on a congested socket aborts the connection
+  // (esp_websocket_client treats timed-out 0-byte writes as fatal).
+  if (!this->declare_in_progress_ && this->tx_queue_.empty() &&
+      now - this->last_reannounce_ms_ > this->reannounce_interval_ms_) {
     ESP_LOGD(TAG, "Periodic re-announce: resending connect + entity declarations");
     uint32_t connect_id = this->next_id_();
     this->send_raw_(build_connect(connect_id, this->gateway_id_, this->gateway_name_,
@@ -399,8 +403,12 @@ void WsBridgeComponent::drain_tx_queue_() {
     TxItem &item = this->tx_queue_.front();
     int r = esp_websocket_client_send_text(this->client_, item.msg.c_str(), item.msg.size(),
                                            pdMS_TO_TICKS(TX_SEND_TIMEOUT_MS));
-    if (r < 0)
+    if (r < 0) {
+      // Library already aborted the socket on a 0-byte/failed write — drop the
+      // backlog rather than retrying into a dead connection.
+      this->clear_tx_queue_();
       break;
+    }
     if (this->collecting_declared_ids_ && !item.sync_declare_uid.empty())
       this->declared_ids_.push_back(item.sync_declare_uid);
     this->tx_queue_.pop_front();
@@ -412,8 +420,8 @@ bool WsBridgeComponent::send_raw_(const std::string &msg, const std::string &syn
   if (this->client_ == nullptr || !esp_websocket_client_is_connected(this->client_))
     return false;
   // Keep FIFO: a queued v1 must leave before a later v2. Bypass the queue only
-  // when it is empty. Timeout is short (not 0) so a full TCP window waits
-  // instead of aborting the connection.
+  // when it is empty. Timeout must be long enough that a full TCP window can
+  // drain — a short/0 wait makes esp_websocket_client abort the connection.
   if (this->tx_queue_.empty()) {
     int r = esp_websocket_client_send_text(this->client_, msg.c_str(), msg.size(),
                                            pdMS_TO_TICKS(TX_SEND_TIMEOUT_MS));
@@ -422,6 +430,8 @@ bool WsBridgeComponent::send_raw_(const std::string &msg, const std::string &syn
         this->declared_ids_.push_back(sync_declare_uid);
       return true;
     }
+    // Send aborted the socket; do not queue onto a dead link.
+    return false;
   }
   if (this->tx_queue_.size() >= TX_QUEUE_MAX) {
     ESP_LOGW(TAG, "TX queue full (%u) — dropping outbound message", (unsigned) TX_QUEUE_MAX);

--- a/components/ws_bridge/ws_bridge.h
+++ b/components/ws_bridge/ws_bridge.h
@@ -152,23 +152,24 @@ class WsBridgeComponent : public Component {
 
   // Paced (re)declare: platform entities are declared a few per loop() so a
   // large gateway cannot block the main loop for tens of seconds on a slow
-  // link. send_text waits TX_SEND_TIMEOUT_MS (not 0 — a 0 timeout aborts the
-  // connection when the TCP window is full). on_declare: / on_connected: run
-  // after the device list is finished; ws_bridge/sync waits until the TX queue
-  // has drained so declared_ids_ only contains frames that actually left the
-  // socket.
+  // link. on_declare: / on_connected: run after the device list is finished;
+  // ws_bridge/sync waits until the TX queue has drained so declared_ids_ only
+  // contains frames that actually left the socket.
+  //
+  // send_text timeout must NOT be 0 (or tiny): esp_websocket_client 1.7.0
+  // treats a 0-byte write (tcp window full past the wait) as fatal and calls
+  // abort_connection(). That turns declare bursts into reconnect storms.
+  // Keep one/few sends per loop with a generous wait instead.
   bool declare_in_progress_{false};
   size_t declare_device_index_{0};
   bool declare_run_connected_{false};
   bool sync_flush_pending_{false};
-  static constexpr size_t DECLARE_DEVICES_PER_LOOP = 2;
+  static constexpr size_t DECLARE_DEVICES_PER_LOOP = 1;
 
   std::deque<TxItem> tx_queue_{};
   static constexpr size_t TX_QUEUE_MAX = 64;
-  static constexpr size_t TX_PER_LOOP = 4;
-  // Small enough that 4 sends stay under the loop budget (~200 ms), long
-  // enough for a momentarily full TCP window to drain instead of aborting.
-  static constexpr uint32_t TX_SEND_TIMEOUT_MS = 50;
+  static constexpr size_t TX_PER_LOOP = 1;
+  static constexpr uint32_t TX_SEND_TIMEOUT_MS = 1000;
 
   std::atomic<WsBridgeState> state_{WS_BRIDGE_DISCONNECTED};
   uint32_t msg_id_{0};


### PR DESCRIPTION
## Summary
- `#304` used a 50 ms `send_text` timeout to keep the main loop responsive, but `esp_websocket_client` 1.7.0 **aborts the connection** when a write returns 0 bytes after the wait (full TCP window). Declare/reannounce bursts then become reconnect storms and can look like a crash/reboot after a few minutes.
- Use **1 s** send timeout, **1** frame per loop, skip periodic reannounce while a declare pass or TX queue is still draining, and clear the TX queue after a failed send instead of retrying on a dead socket.

## Test plan
- [x] `esphome compile tests/components/ws_bridge/test.esp32-idf.yaml` (2026.7.4)
- [ ] Flash the build and leave connected 10+ minutes — no unexpected reboot
- [ ] Confirm entities still declare after connect / reannounce

Made with [Cursor](https://cursor.com)