### PR TITLE
feat(ws_bridge): send app_version on connect

### DIFF
--- a/components/ws_bridge/README.md
+++ b/components/ws_bridge/README.md
@@ -45,6 +45,7 @@ ws_bridge:
   token: !secret ha_token    # Home Assistant long-lived access token
   gateway_id: my_esp         # (default: this device's name)
   name: "My ESP"             # (default: this device's friendly_name)
+  # app_version: "1.2.3"     # optional; default is ESPHome version + compile time
   keep_last_state_on_disconnect: false
   sync_entities: false      # true = remove HA entities this device no longer declares
   ping_interval: 60s
@@ -127,6 +128,7 @@ update:
 | `token` | ✓ | - | Home Assistant long-lived access token |
 | `gateway_id` | | device name | Unique client identifier (becomes the HA gateway device) |
 | `name` | | device friendly name | Display name for the gateway device |
+| `app_version` | | ESPHome version + compile time | Firmware/app version sent on `ws_bridge/connect` (HA gateway device `sw_version`). Default looks like `2025.8.0 (Aug 14 2026, 07:31:00)`. Set this to send a custom version instead |
 | `keep_last_state_on_disconnect` | | `false` | If `true`, this gateway's entities keep their last state in HA instead of going `unavailable` when the connection drops (including an ungraceful disconnect) |
 | `sync_entities` | | `false` | If `true`, sends `ws_bridge/sync` with every declared `unique_id` right after connecting, so HA removes entities this gateway no longer provides. Entities still declared keep their `entity_id`, history and long-term statistics — nothing is wiped and recreated. See [Removing stale entities](#removing-stale-entities) |
 | `ping_interval` | | `60s` | How often to send an app-level `ping` once connected, to detect a peer that dropped without a clean WebSocket close |

--- a/components/ws_bridge/__init__.py
+++ b/components/ws_bridge/__init__.py
@@ -29,6 +29,7 @@ from .const import (
     CONF_SSL,
     CONF_TOKEN,
     CONF_GATEWAY_ID,
+    CONF_APP_VERSION,
     CONF_KEEP_LAST_STATE_ON_DISCONNECT,
     CONF_SYNC_ENTITIES,
     CONF_UNIQUE_ID,
@@ -165,6 +166,9 @@ CONFIG_SCHEMA = cv.All(
             cv.Required(CONF_TOKEN): cv.string_strict,
             cv.Optional(CONF_GATEWAY_ID, default=lambda: CORE.name): cv.string_strict,
             cv.Optional(CONF_NAME, default=lambda: CORE.friendly_name or CORE.name): cv.string_strict,
+            # Sent as ws_bridge/connect app_version (HA gateway sw_version).
+            # Omitted: ESPHome version + compilation time, e.g. "2025.8.0 (Aug 14 2026, 07:31:00)".
+            cv.Optional(CONF_APP_VERSION): cv.string,
             cv.Optional(CONF_KEEP_LAST_STATE_ON_DISCONNECT, default=False): cv.boolean,
             # After declaring everything on connect, send ws_bridge/sync with the
             # full set of unique_ids so HA drops entities this gateway no longer
@@ -260,6 +264,8 @@ async def to_code(config):
     cg.add(var.set_token(config[CONF_TOKEN]))
     cg.add(var.set_gateway_id(config[CONF_GATEWAY_ID]))
     cg.add(var.set_gateway_name(config[CONF_NAME]))
+    if CONF_APP_VERSION in config:
+        cg.add(var.set_app_version(config[CONF_APP_VERSION]))
     cg.add(var.set_keep_last_state_on_disconnect(config[CONF_KEEP_LAST_STATE_ON_DISCONNECT]))
     cg.add(var.set_sync_entities(config[CONF_SYNC_ENTITIES]))
     cg.add(var.set_ping_interval(config[CONF_PING_INTERVAL].total_milliseconds))

--- a/components/ws_bridge/const.py
+++ b/components/ws_bridge/const.py
@@ -4,6 +4,7 @@ CONF_HOST = "host"
 CONF_SSL = "ssl"
 CONF_TOKEN = "token"
 CONF_GATEWAY_ID = "gateway_id"
+CONF_APP_VERSION = "app_version"
 CONF_KEEP_LAST_STATE_ON_DISCONNECT = "keep_last_state_on_disconnect"
 CONF_SYNC_ENTITIES = "sync_entities"
 

--- a/components/ws_bridge/ws_bridge.cpp
+++ b/components/ws_bridge/ws_bridge.cpp
@@ -3,9 +3,11 @@
 #include "esp_crt_bundle.h"
 #include "esp_transport_ws.h"
 #include "esphome/components/network/util.h"
+#include "esphome/core/application.h"
 #include "esphome/core/entity_base.h"
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
+#include "esphome/core/version.h"
 
 namespace esphome {
 namespace ws_bridge {
@@ -71,6 +73,17 @@ void WsBridgeComponent::force_reconnect_() {
   esp_websocket_client_start(this->client_);
 }
 
+std::string WsBridgeComponent::effective_app_version_() {
+  if (!this->app_version_.empty()) return this->app_version_;
+#if ESPHOME_VERSION_CODE >= VERSION_CODE(2026, 1, 0)
+  char build_time[Application::BUILD_TIME_STR_SIZE];
+  App.get_build_time_string(build_time);
+  return std::string(ESPHOME_VERSION) + " (" + build_time + ")";
+#else
+  return std::string(ESPHOME_VERSION) + " (" + App.get_compilation_time() + ")";
+#endif
+}
+
 // Actively probes the connection with HA's standard "ping"/"pong" websocket_api
 // commands. Needed because a dead peer (e.g. HA killed without a clean WS
 // close — no FIN/RST ever reaches the socket) can otherwise leave the
@@ -120,7 +133,7 @@ void WsBridgeComponent::check_liveness_() {
     ESP_LOGD(TAG, "Periodic re-announce: resending connect + entity declarations");
     uint32_t connect_id = this->next_id_();
     this->send_raw_(build_connect(connect_id, this->gateway_id_, this->gateway_name_,
-                                  this->keep_last_state_on_disconnect_));
+                                  this->keep_last_state_on_disconnect_, this->effective_app_version_()));
     this->last_connect_msg_id_ = connect_id;
     this->awaiting_connect_result_ = true;
     this->connect_sent_ms_ = now;
@@ -139,6 +152,7 @@ void WsBridgeComponent::dump_config() {
   ESP_LOGCONFIG(TAG, "  Server: %s://%s:%u/api/websocket", this->ssl_ ? "wss" : "ws", this->host_.c_str(),
                 this->port_);
   ESP_LOGCONFIG(TAG, "  Gateway ID: %s", this->gateway_id_.c_str());
+  ESP_LOGCONFIG(TAG, "  App version: %s", this->effective_app_version_().c_str());
   ESP_LOGCONFIG(TAG, "  Keep last state on disconnect: %s", YESNO(this->keep_last_state_on_disconnect_));
   ESP_LOGCONFIG(TAG, "  Ping interval: %u ms", static_cast<unsigned>(this->ping_interval_ms_));
   ESP_LOGCONFIG(TAG, "  Pong timeout: %u ms", static_cast<unsigned>(this->pong_timeout_ms_));
@@ -276,7 +290,8 @@ void WsBridgeComponent::handle_message_(const std::string &raw) {
     this->set_state_(WS_BRIDGE_WAIT_AUTH_OK);
   } else if (msg.type == "auth_ok") {
     this->send_raw_(
-        build_connect(this->next_id_(), this->gateway_id_, this->gateway_name_, this->keep_last_state_on_disconnect_));
+        build_connect(this->next_id_(), this->gateway_id_, this->gateway_name_, this->keep_last_state_on_disconnect_,
+                      this->effective_app_version_()));
     this->set_state_(WS_BRIDGE_CONNECTED);
     this->ping_outstanding_ = false;
     this->reconnect_backoff_ms_ = RECONNECT_BACKOFF_BASE_MS;

--- a/components/ws_bridge/ws_bridge.h
+++ b/components/ws_bridge/ws_bridge.h
@@ -50,6 +50,9 @@ class WsBridgeComponent : public Component {
   void set_token(const std::string &token) { this->token_ = token; }
   void set_gateway_id(const std::string &id) { this->gateway_id_ = id; }
   void set_gateway_name(const std::string &name) { this->gateway_name_ = name; }
+  // Empty = default: ESPHome version + compilation time. A non-empty value is
+  // sent as-is on ws_bridge/connect (HA gateway device sw_version).
+  void set_app_version(const std::string &v) { this->app_version_ = v; }
   void set_keep_last_state_on_disconnect(bool v) { this->keep_last_state_on_disconnect_ = v; }
   void set_sync_entities(bool v) { this->sync_entities_ = v; }
   // See check_liveness_() for what these govern.
@@ -106,6 +109,7 @@ class WsBridgeComponent : public Component {
   void set_state_(WsBridgeState s);
   void check_liveness_();
   void force_reconnect_();
+  std::string effective_app_version_();
 
   esp_websocket_client_handle_t client_{nullptr};
   bool started_{false};
@@ -116,6 +120,7 @@ class WsBridgeComponent : public Component {
   std::string token_;
   std::string gateway_id_;
   std::string gateway_name_;
+  std::string app_version_;
   bool keep_last_state_on_disconnect_{false};
 
   // Opt-in (sync_entities:). After declaring everything on connect, tell HA the

--- a/components/ws_bridge/ws_protocol.cpp
+++ b/components/ws_bridge/ws_protocol.cpp
@@ -46,13 +46,14 @@ std::string build_auth(const std::string &access_token) {
 }
 
 std::string build_connect(uint32_t id, const std::string &gateway_id, const std::string &name,
-                          bool keep_last_state_on_disconnect) {
+                          bool keep_last_state_on_disconnect, const std::string &app_version) {
   return json::build_json([&](JsonObject root) {
     root["id"] = id;
     root["type"] = "ws_bridge/connect";
     root["gateway_id"] = gateway_id;
     if (!name.empty()) root["name"] = name;
     root["keep_last_state_on_disconnect"] = keep_last_state_on_disconnect;
+    if (!app_version.empty()) root["app_version"] = app_version;
   });
 }
 

--- a/components/ws_bridge/ws_protocol.h
+++ b/components/ws_bridge/ws_protocol.h
@@ -35,7 +35,7 @@ ParsedMessage parse_message(const std::string &raw);
 // ws_bridge/* command does).
 std::string build_auth(const std::string &access_token);
 std::string build_connect(uint32_t id, const std::string &gateway_id, const std::string &name,
-                          bool keep_last_state_on_disconnect);
+                          bool keep_last_state_on_disconnect, const std::string &app_version);
 
 // Application-level keepalive (HA's standard websocket_api "ping"/"pong"
 // commands) — used to actively detect a dead connection that the transport

--- a/tests/components/ws_bridge/test.esp32-idf.yaml
+++ b/tests/components/ws_bridge/test.esp32-idf.yaml
@@ -24,6 +24,7 @@ ws_bridge:
   token: "test_token"
   gateway_id: my_esp
   name: "My ESP"
+  app_version: "1.0.0-test"
   keep_last_state_on_disconnect: true
   sync_entities: true
   on_connected:


### PR DESCRIPTION
## Summary
- Send `app_version` on `ws_bridge/connect` so Home Assistant can set the gateway device `sw_version`.
- Default is ESPHome version plus compile time when YAML `app_version` is omitted; a defined `app_version` overrides that string.

## Test plan
- [ ] Compile `tests/components/ws_bridge/test.esp32-idf.yaml`
- [ ] Connect without `app_version` and confirm HA gateway `sw_version` is ESPHome version + build time
- [ ] Connect with `app_version: 1.2.3` and confirm HA shows `1.2.3`

Made with [Cursor](https://cursor.com)