### PR TITLE
fix(ws_bridge): charge the TX budget by time actually blocked, not wall clock

### DIFF
--- a/components/ws_bridge/ws_bridge.cpp
+++ b/components/ws_bridge/ws_bridge.cpp
@@ -67,11 +67,6 @@ void WsBridgeComponent::loop() {
     this->reconnect_backoff_ms_ = this->reconnect_backoff_base_();
   }
 
-  // The whole loop (including sends triggered while draining command events)
-  // shares one TX budget. Capturing this after the drain would issue a second
-  // budget and let one loop() block for up to ~4s.
-  this->tx_loop_start_ms_ = millis();
-
   WsEvent *event;
   while ((event = this->event_queue_.pop()) != nullptr) {
     this->handle_event_(*event);
@@ -150,8 +145,26 @@ uint32_t WsBridgeComponent::reconnect_backoff_base_() const {
   return std::min(RECONNECT_BACKOFF_BASE_MS, this->reconnect_retry_ms_);
 }
 
-bool WsBridgeComponent::tx_budget_exhausted_() const {
-  return millis() - this->tx_loop_start_ms_ > TX_LOOP_BUDGET_MS;
+bool WsBridgeComponent::tx_budget_exhausted_() {
+  // A gap this long since the last real send means whatever burst charged
+  // tx_budget_used_ms_ is over (or nothing has sent yet) — start the next
+  // one with a clean budget rather than inheriting a stale total.
+  if (millis() - this->tx_budget_last_send_ms_ > TX_BUDGET_IDLE_RESET_MS)
+    this->tx_budget_used_ms_ = 0;
+  return this->tx_budget_used_ms_ > TX_LOOP_BUDGET_MS;
+}
+
+// Wraps esp_websocket_client_send_text and charges the wall-clock time it
+// actually blocked for against tx_budget_used_ms_ — see the member
+// declaration in ws_bridge.h for why the budget must be time-spent rather
+// than time-elapsed.
+int WsBridgeComponent::send_text_(const std::string &msg) {
+  uint32_t start = millis();
+  int r = esp_websocket_client_send_text(this->client_, msg.c_str(), msg.size(), pdMS_TO_TICKS(TX_SEND_TIMEOUT_MS));
+  uint32_t done = millis();
+  this->tx_budget_used_ms_ += done - start;
+  this->tx_budget_last_send_ms_ = done;
+  return r;
 }
 
 std::string WsBridgeComponent::effective_sw_version_() {
@@ -590,8 +603,7 @@ void WsBridgeComponent::drain_tx_queue_() {
     if (this->tx_budget_exhausted_())
       break;
     TxItem &item = this->tx_queue_.front();
-    int r = esp_websocket_client_send_text(this->client_, item.msg.c_str(), item.msg.size(),
-                                           pdMS_TO_TICKS(TX_SEND_TIMEOUT_MS));
+    int r = this->send_text_(item.msg);
     if (r < 0) {
       // Failure is either (a) the library aborted the socket, or (b) a
       // client->lock timeout — the connection is still up in (b). Only drop
@@ -625,8 +637,7 @@ bool WsBridgeComponent::send_raw_(const std::string &msg, const std::string &syn
   // when it is empty. If this loop's send budget is already spent, enqueue
   // instead of blocking the main loop again.
   if (this->tx_queue_.empty() && !this->tx_budget_exhausted_()) {
-    int r = esp_websocket_client_send_text(this->client_, msg.c_str(), msg.size(),
-                                           pdMS_TO_TICKS(TX_SEND_TIMEOUT_MS));
+    int r = this->send_text_(msg);
     if (r >= 0) {
       if (this->collecting_declared_ids_ && !sync_declare_uid.empty())
         this->declared_ids_.push_back(sync_declare_uid);

--- a/components/ws_bridge/ws_bridge.h
+++ b/components/ws_bridge/ws_bridge.h
@@ -123,7 +123,12 @@ class WsBridgeComponent : public Component {
   std::string effective_sw_version_();
   bool send_connect_(uint32_t id);
   uint32_t reconnect_backoff_base_() const;
-  bool tx_budget_exhausted_() const;
+  // Blocking send_text wrapper that charges the time actually spent against
+  // tx_budget_used_ms_ — see the member declaration for why.
+  int send_text_(const std::string &msg);
+  // Mutates tx_budget_used_ms_ on an idle-gap reset — see the member
+  // declaration for why this can't just be a wall-clock comparison.
+  bool tx_budget_exhausted_();
   void mark_sync_declare_dropped_(const std::string &sync_declare_uid);
 
   // One outbound WS text frame. `sync_declare_uid` is set for entity declares
@@ -192,8 +197,23 @@ class WsBridgeComponent : public Component {
   // abort the connection (see #305). The WDT is guarded by TX_LOOP_BUDGET_MS
   // (cumulative), not by shortening individual sends.
   static constexpr uint32_t TX_SEND_TIMEOUT_MS = 1000;
+  // Charged by time actually spent blocking in send_text_(), not by
+  // wall-clock time elapsed since loop() last ran. Entity state pushes can
+  // happen while loop() itself never runs at all: http_request's OTA
+  // install() defers flash() onto the scheduler, which then blocks the
+  // whole Application::loop() call — not just this component — for as long
+  // as the download takes, publishing update progress roughly once a
+  // second from inside that blocking call (see http_request's
+  // ota_http_request.cpp). A wall-clock budget reads "exhausted" for that
+  // entire window, so every progress push lands in tx_queue_ with nothing
+  // left to drain it — HA's progress bar stops moving. TX_BUDGET_IDLE_RESET_MS
+  // clears the counter after a gap this long since the last real send, so a
+  // later, unrelated burst still starts with a full 1200ms instead of
+  // inheriting a stale total.
   static constexpr uint32_t TX_LOOP_BUDGET_MS = 1200;
-  uint32_t tx_loop_start_ms_{0};
+  static constexpr uint32_t TX_BUDGET_IDLE_RESET_MS = 500;
+  uint32_t tx_budget_used_ms_{0};
+  uint32_t tx_budget_last_send_ms_{0};
 
   std::atomic<WsBridgeState> state_{WS_BRIDGE_DISCONNECTED};
   uint32_t msg_id_{0};


### PR DESCRIPTION
## Summary
- `TX_LOOP_BUDGET_MS` was measured from `millis()` at `loop()` entry, but entity state pushes can fire while `WsBridgeComponent::loop()` never runs at all: `http_request`'s OTA `install()` defers `flash()` onto the scheduler, which blocks the entire `Application::loop()` call for the whole download while publishing update progress about once a second from inside that blocking call.
- The wall-clock budget read "exhausted" for that entire window, so every progress push landed in `tx_queue_` with nothing left to drain it (the component that drains the queue is the very thing not running) — Home Assistant's update progress bar stopped moving after PR #309.
- Fix: charge the budget by milliseconds actually spent blocking inside `send_text_()` (a new thin wrapper both send sites now go through), and reset the accumulator after a real idle gap (`TX_BUDGET_IDLE_RESET_MS = 500`) since the last send. Congested-link protection is unchanged — a freshly reset budget still only allows about the same one or two blocking sends before the next call defers to the queue, so the worst-case single `loop()` blocking bound (~2s, well under the 5s task WDT) established in #309 is unaffected.

## Test plan
- [x] `python -m esphome compile tests/components/ws_bridge/test.esp32-idf.yaml` — succeeds (includes the `update: platform: ws_bridge` / `platform: http_request` entities exercising this code path).
- [ ] Manual: trigger an OTA `install` on a real device via HA and confirm the `update` entity's progress percentage updates continuously instead of freezing after the first push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)