### PR TITLE
feat(ws_bridge): accept lambdas for gateway_id, name, sw_version, manufacturer, model, hw_version

### DIFF
--- a/components/ws_bridge/README.md
+++ b/components/ws_bridge/README.md
@@ -46,6 +46,7 @@ ws_bridge:
   gateway_id: my_esp         # (default: this device's name)
   name: "My ESP"             # (default: this device's friendly_name)
   # sw_version: "1.2.3"      # optional; default is ESPHome version + compile time
+  # sw_version: !lambda return std::string(FIRMWARE_VERSION); # templatable, e.g. from a define
   # manufacturer: Espressif  # optional; HA default is ws_bridge
   # model: ESP32-S3          # optional; HA default is Gateway
   # hw_version: "1.0"        # optional
@@ -205,12 +206,12 @@ update:
 | `port` | | 8123 | Port |
 | `ssl` | | `true` | Use `wss://`. Only disable for LAN-only testing — the access token is sent in plain text over `ws://` |
 | `token` | ✓ | - | Home Assistant long-lived access token |
-| `gateway_id` | | device name | Unique client identifier (becomes the HA gateway device) |
-| `name` | | device friendly name | Display name for the gateway device |
-| `sw_version` | | ESPHome version + compile time | Firmware version sent on `ws_bridge/connect` (HA gateway device `sw_version`). Default looks like `2025.8.0 (Aug 14 2026, 07:31:00)`. Set this to send a custom version instead |
-| `manufacturer` | | omitted | Gateway device manufacturer. Omitted: HA shows `ws_bridge` |
-| `model` | | omitted | Gateway device model. Omitted: HA shows `Gateway` |
-| `hw_version` | | omitted | Gateway hardware version. Omitted: left unset. Each of these fields is independent |
+| `gateway_id` | | device name | Unique client identifier (becomes the HA gateway device). Templatable |
+| `name` | | device friendly name | Display name for the gateway device. Templatable |
+| `sw_version` | | ESPHome version + compile time | Firmware version sent on `ws_bridge/connect` (HA gateway device `sw_version`). Default looks like `2025.8.0 (Aug 14 2026, 07:31:00)`. Set this to send a custom version instead. Templatable |
+| `manufacturer` | | omitted | Gateway device manufacturer. Omitted: HA shows `ws_bridge`. Templatable |
+| `model` | | omitted | Gateway device model. Omitted: HA shows `Gateway`. Templatable |
+| `hw_version` | | omitted | Gateway hardware version. Omitted: left unset. Each of these fields is independent. Templatable |
 | `keep_last_state_on_disconnect` | | `false` | If `true`, this gateway's entities keep their last state in HA instead of going `unavailable` when the connection drops (including an ungraceful disconnect) |
 | `sync_entities` | | `false` | If `true`, sends `ws_bridge/sync` with every declared `unique_id` right after connecting, so HA removes entities this gateway no longer provides. Entities still declared keep their `entity_id`, history and long-term statistics — nothing is wiped and recreated. See [Removing stale entities](#removing-stale-entities) |
 | `ping_interval` | | `60s` | How often to send an app-level `ping` once connected, to detect a peer that dropped without a clean WebSocket close |
@@ -219,6 +220,8 @@ update:
 | `reannounce_interval` | | `60s` | How often to resend `ws_bridge/connect` + all entity/state declarations while nominally connected. Guards against the HA-side integration losing track of this gateway (e.g. its config entry reloaded) while the raw connection and ping/pong stay healthy — that scenario is otherwise invisible, since HA answers pings regardless of our integration's state. If a re-announce goes unanswered, forces a full reconnect rather than repeating the same no-op |
 | `trackers` | | - | List of GPS `device_tracker` entities — see [GPS device trackers](#gps-device-trackers) below |
 | `entities` | | - | Existing ESPHome entities to expose without a parallel `platform: ws_bridge` entity — see [Exposing existing entities](#exposing-existing-entities) |
+
+"Templatable" fields accept a plain string or a `!lambda return std::string(...);` — the lambda is re-evaluated on every `ws_bridge/connect` (the initial connect and each `reannounce_interval`), not just once at boot.
 
 ### Platform options (all of `sensor`/`binary_sensor`/`text_sensor`/`switch`/`number`/`select`/`button`/`update`/`light`/`cover`/`climate`/`fan`/`text`/`lock`/`valve`/`event`/`datetime`)
 

--- a/components/ws_bridge/__init__.py
+++ b/components/ws_bridge/__init__.py
@@ -191,14 +191,19 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_PORT, default=8123): cv.port,
             cv.Optional(CONF_SSL, default=True): cv.boolean,
             cv.Required(CONF_TOKEN): cv.string_strict,
-            cv.Optional(CONF_GATEWAY_ID, default=lambda: CORE.name): cv.string_strict,
-            cv.Optional(CONF_NAME, default=lambda: CORE.friendly_name or CORE.name): cv.string_strict,
+            # Each of these six also accepts `!lambda return std::string("...");`
+            # — see WsBridgeComponent's set_gateway_id()/set_sw_version()/etc.
+            # in ws_bridge.h for when a lambda is (re-)evaluated.
+            cv.Optional(CONF_GATEWAY_ID, default=lambda: CORE.name): cv.templatable(cv.string_strict),
+            cv.Optional(
+                CONF_NAME, default=lambda: CORE.friendly_name or CORE.name
+            ): cv.templatable(cv.string_strict),
             # Sent as ws_bridge/connect sw_version (HA gateway sw_version).
             # Omitted: ESPHome version + compilation time, e.g. "2025.8.0 (Aug 14 2026, 07:31:00)".
-            cv.Optional(CONF_SW_VERSION): cv.string,
-            cv.Optional(CONF_MANUFACTURER): cv.string,
-            cv.Optional(CONF_MODEL): cv.string,
-            cv.Optional(CONF_HW_VERSION): cv.string,
+            cv.Optional(CONF_SW_VERSION): cv.templatable(cv.string),
+            cv.Optional(CONF_MANUFACTURER): cv.templatable(cv.string),
+            cv.Optional(CONF_MODEL): cv.templatable(cv.string),
+            cv.Optional(CONF_HW_VERSION): cv.templatable(cv.string),
             cv.Optional(CONF_KEEP_LAST_STATE_ON_DISCONNECT, default=False): cv.boolean,
             # After declaring everything on connect, send ws_bridge/sync with the
             # full set of unique_ids so HA drops entities this gateway no longer
@@ -292,16 +297,22 @@ async def to_code(config):
     cg.add(var.set_port(config[CONF_PORT]))
     cg.add(var.set_ssl(config[CONF_SSL]))
     cg.add(var.set_token(config[CONF_TOKEN]))
-    cg.add(var.set_gateway_id(config[CONF_GATEWAY_ID]))
-    cg.add(var.set_gateway_name(config[CONF_NAME]))
+    gateway_id = await cg.templatable(config[CONF_GATEWAY_ID], [], cg.std_string)
+    cg.add(var.set_gateway_id(gateway_id))
+    gateway_name = await cg.templatable(config[CONF_NAME], [], cg.std_string)
+    cg.add(var.set_gateway_name(gateway_name))
     if CONF_SW_VERSION in config:
-        cg.add(var.set_sw_version(config[CONF_SW_VERSION]))
+        sw_version = await cg.templatable(config[CONF_SW_VERSION], [], cg.std_string)
+        cg.add(var.set_sw_version(sw_version))
     if CONF_MANUFACTURER in config:
-        cg.add(var.set_manufacturer(config[CONF_MANUFACTURER]))
+        manufacturer = await cg.templatable(config[CONF_MANUFACTURER], [], cg.std_string)
+        cg.add(var.set_manufacturer(manufacturer))
     if CONF_MODEL in config:
-        cg.add(var.set_model(config[CONF_MODEL]))
+        model = await cg.templatable(config[CONF_MODEL], [], cg.std_string)
+        cg.add(var.set_model(model))
     if CONF_HW_VERSION in config:
-        cg.add(var.set_hw_version(config[CONF_HW_VERSION]))
+        hw_version = await cg.templatable(config[CONF_HW_VERSION], [], cg.std_string)
+        cg.add(var.set_hw_version(hw_version))
     cg.add(var.set_keep_last_state_on_disconnect(config[CONF_KEEP_LAST_STATE_ON_DISCONNECT]))
     cg.add(var.set_sync_entities(config[CONF_SYNC_ENTITIES]))
     cg.add(var.set_ping_interval(config[CONF_PING_INTERVAL].total_milliseconds))

--- a/components/ws_bridge/ws_bridge.cpp
+++ b/components/ws_bridge/ws_bridge.cpp
@@ -168,7 +168,8 @@ int WsBridgeComponent::send_text_(const std::string &msg) {
 }
 
 std::string WsBridgeComponent::effective_sw_version_() {
-  if (!this->sw_version_.empty()) return this->sw_version_;
+  std::string v = this->sw_version_.value();
+  if (!v.empty()) return v;
 #if ESPHOME_VERSION_CODE >= VERSION_CODE(2026, 1, 0)
   char build_time[Application::BUILD_TIME_STR_SIZE];
   App.get_build_time_string(build_time);
@@ -179,9 +180,12 @@ std::string WsBridgeComponent::effective_sw_version_() {
 }
 
 bool WsBridgeComponent::send_connect_(uint32_t id) {
-  return this->send_raw_(build_connect(id, this->gateway_id_, this->gateway_name_,
+  // .value() re-evaluates a lambda-backed field every call, so a periodic
+  // re-announce (see check_liveness_) picks up whatever these currently
+  // report, not just what setup() saw.
+  return this->send_raw_(build_connect(id, this->gateway_id_.value(), this->gateway_name_.value(),
                                        this->keep_last_state_on_disconnect_, this->effective_sw_version_(),
-                                       this->manufacturer_, this->model_, this->hw_version_));
+                                       this->manufacturer_.value(), this->model_.value(), this->hw_version_.value()));
 }
 
 // Actively probes the connection with HA's standard "ping"/"pong" websocket_api
@@ -264,14 +268,20 @@ void WsBridgeComponent::dump_config() {
   ESP_LOGCONFIG(TAG, "WS Bridge:");
   ESP_LOGCONFIG(TAG, "  Server: %s://%s:%u/api/websocket", this->ssl_ ? "wss" : "ws", this->host_.c_str(),
                 this->port_);
-  ESP_LOGCONFIG(TAG, "  Gateway ID: %s", this->gateway_id_.c_str());
+  // .value() evaluates a lambda-backed field here too — same as every other
+  // call site, this just reflects whatever it reports right now, at setup
+  // time, not what a later re-announce might see.
+  ESP_LOGCONFIG(TAG, "  Gateway ID: %s", this->gateway_id_.value().c_str());
   ESP_LOGCONFIG(TAG, "  Software version: %s", this->effective_sw_version_().c_str());
-  if (!this->manufacturer_.empty())
-    ESP_LOGCONFIG(TAG, "  Manufacturer: %s", this->manufacturer_.c_str());
-  if (!this->model_.empty())
-    ESP_LOGCONFIG(TAG, "  Model: %s", this->model_.c_str());
-  if (!this->hw_version_.empty())
-    ESP_LOGCONFIG(TAG, "  Hardware version: %s", this->hw_version_.c_str());
+  std::string manufacturer = this->manufacturer_.value();
+  if (!manufacturer.empty())
+    ESP_LOGCONFIG(TAG, "  Manufacturer: %s", manufacturer.c_str());
+  std::string model = this->model_.value();
+  if (!model.empty())
+    ESP_LOGCONFIG(TAG, "  Model: %s", model.c_str());
+  std::string hw_version = this->hw_version_.value();
+  if (!hw_version.empty())
+    ESP_LOGCONFIG(TAG, "  Hardware version: %s", hw_version.c_str());
   ESP_LOGCONFIG(TAG, "  Keep last state on disconnect: %s", YESNO(this->keep_last_state_on_disconnect_));
   ESP_LOGCONFIG(TAG, "  Ping interval: %u ms", static_cast<unsigned>(this->ping_interval_ms_));
   ESP_LOGCONFIG(TAG, "  Pong timeout: %u ms", static_cast<unsigned>(this->pong_timeout_ms_));

--- a/components/ws_bridge/ws_bridge.h
+++ b/components/ws_bridge/ws_bridge.h
@@ -49,14 +49,19 @@ class WsBridgeComponent : public Component {
   void set_port(uint16_t port) { this->port_ = port; }
   void set_ssl(bool ssl) { this->ssl_ = ssl; }
   void set_token(const std::string &token) { this->token_ = token; }
-  void set_gateway_id(const std::string &id) { this->gateway_id_ = id; }
-  void set_gateway_name(const std::string &name) { this->gateway_name_ = name; }
+  // These six accept either a plain string or a `!lambda return
+  // std::string{...};`. The lambda form is re-evaluated on every
+  // ws_bridge/connect — the initial connect and every periodic re-announce
+  // (see reannounce_interval_ms_) — not just once at setup(), so it can
+  // reflect state that changes at runtime.
+  template<typename V> void set_gateway_id(V id) { this->gateway_id_ = id; }
+  template<typename V> void set_gateway_name(V name) { this->gateway_name_ = name; }
   // Empty = default: ESPHome version + compilation time. A non-empty value is
   // sent as-is on ws_bridge/connect (HA gateway device sw_version).
-  void set_sw_version(const std::string &v) { this->sw_version_ = v; }
-  void set_manufacturer(const std::string &v) { this->manufacturer_ = v; }
-  void set_model(const std::string &v) { this->model_ = v; }
-  void set_hw_version(const std::string &v) { this->hw_version_ = v; }
+  template<typename V> void set_sw_version(V v) { this->sw_version_ = v; }
+  template<typename V> void set_manufacturer(V v) { this->manufacturer_ = v; }
+  template<typename V> void set_model(V v) { this->model_ = v; }
+  template<typename V> void set_hw_version(V v) { this->hw_version_ = v; }
   void set_keep_last_state_on_disconnect(bool v) { this->keep_last_state_on_disconnect_ = v; }
   void set_sync_entities(bool v) { this->sync_entities_ = v; }
   // See check_liveness_() for what these govern.
@@ -146,12 +151,14 @@ class WsBridgeComponent : public Component {
   uint16_t port_{8123};
   bool ssl_{true};
   std::string token_;
-  std::string gateway_id_;
-  std::string gateway_name_;
-  std::string sw_version_;
-  std::string manufacturer_;
-  std::string model_;
-  std::string hw_version_;
+  // Templatable so a lambda can be re-evaluated on every ws_bridge/connect —
+  // see the set_*() declarations above.
+  TemplatableValue<std::string> gateway_id_;
+  TemplatableValue<std::string> gateway_name_;
+  TemplatableValue<std::string> sw_version_;
+  TemplatableValue<std::string> manufacturer_;
+  TemplatableValue<std::string> model_;
+  TemplatableValue<std::string> hw_version_;
   bool keep_last_state_on_disconnect_{false};
 
   // Opt-in (sync_entities:). After declaring everything on connect, tell HA the

--- a/tests/components/ws_bridge/test.esp32-idf.yaml
+++ b/tests/components/ws_bridge/test.esp32-idf.yaml
@@ -24,10 +24,12 @@ ws_bridge:
   token: "test_token"
   gateway_id: my_esp
   name: "My ESP"
-  sw_version: "1.0.0-test"
+  # sw_version / hw_version exercise the lambda form (compile coverage for
+  # the templatable string setters); manufacturer / model stay plain strings.
+  sw_version: !lambda return std::string("1.0.0-test");
   manufacturer: Espressif
   model: ESP32
-  hw_version: "1.0"
+  hw_version: !lambda return std::string("1.0");
   keep_last_state_on_disconnect: true
   sync_entities: true
   on_connected:


### PR DESCRIPTION
## Summary
- `gateway_id`, `name`, `sw_version`, `manufacturer`, `model`, and `hw_version` — the six identity fields sent on `ws_bridge/connect` — previously only accepted a plain YAML string.
- Switched their C++ storage from `std::string` to `TemplatableValue<std::string>` (the same mechanism the hub's `trackers:` already uses for `latitude`/`longitude`/`gps_accuracy`) and the setters to templated `set_x(V)`, so a `!lambda return std::string(...);` now works alongside a plain string.
- Python side: `cv.templatable(...)` on the six schema entries, `cg.templatable(...)` in `to_code()` before each `set_*` call.
- The lambda form is re-evaluated on every `ws_bridge/connect` — both the initial connect and each periodic re-announce (`reannounce_interval`, default 60s) — not just once at setup(), so it can reflect state that changes at runtime (e.g. a value read from another entity).
- `host`/`port`/`ssl` stay plain: they configure the static `esp_websocket_client` transport in `setup()`, before "evaluate a lambda" is a meaningful operation. `token` is untouched — out of scope for this request.
- README: table entries marked "Templatable", one commented lambda example added, and a short explanatory line added under the options table.

## Test plan
- [x] `tests/components/ws_bridge/test.esp32-idf.yaml` updated: `sw_version` and `hw_version` now use the lambda form, `manufacturer`/`model` stay plain strings — mixed coverage of both paths.
- [x] Verified the generated `main.cpp` for both paths: plain strings emit `ESPHOME_F("...")` (binds to `TemplatableValue<std::string>`'s `const char*` constructor) and lambdas emit a stateless `[]() -> std::string { ... }` (binds to the stateless-lambda constructor) — both are constructor overloads already exercised successfully by the existing `TemplatableValue<float>` tracker fields in this same codebase.
- [ ] A local from-scratch `esphome compile` hit an unrelated ESP-IDF component-discovery/network issue in the sandbox (stuck regenerating CMakeLists without invoking the actual build) and could not produce a binary locally this round; CI's `esphome-compile` job is the authoritative check here (it succeeded on the prior `ws_bridge` PR #310 in this same repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)