### PR TITLE
fix: ESPBTUUID::to_str() requires a buffer argument, not zero

### DIFF
--- a/components/ble_elm327/ble_elm327.cpp
+++ b/components/ble_elm327/ble_elm327.cpp
@@ -121,11 +121,12 @@ void BleElm327Component::loop() {
 }
 
 void BleElm327Component::dump_config() {
+  char uuid_buf[espbt::UUID_STR_LEN];
   ESP_LOGCONFIG(TAG, "BLE ELM327:");
   ESP_LOGCONFIG(TAG, "  MAC address        : %s", this->parent_->address_str());
-  ESP_LOGCONFIG(TAG, "  Service UUID       : %s", service_uuid_.to_str().c_str());
-  ESP_LOGCONFIG(TAG, "  RX Char UUID       : %s", rx_char_uuid_.to_str().c_str());
-  ESP_LOGCONFIG(TAG, "  TX Char UUID       : %s", tx_char_uuid_.to_str().c_str());
+  ESP_LOGCONFIG(TAG, "  Service UUID       : %s", service_uuid_.to_str(uuid_buf));
+  ESP_LOGCONFIG(TAG, "  RX Char UUID       : %s", rx_char_uuid_.to_str(uuid_buf));
+  ESP_LOGCONFIG(TAG, "  TX Char UUID       : %s", tx_char_uuid_.to_str(uuid_buf));
   ESP_LOGCONFIG(TAG, "  TX delay           : %lums", (unsigned long) tx_delay_ms_);
   ESP_LOGCONFIG(TAG, "  Base init commands : ATZ, ATE0, ATL0, ATS0, ATH0, ATSP0");
   ESP_LOGCONFIG(TAG, "  Extra init commands: %u", (unsigned)extra_init_commands_.size());

--- a/components/divoom/divoom_display.cpp
+++ b/components/divoom/divoom_display.cpp
@@ -14,11 +14,12 @@ static const char *const TAG = "divoom";
 
 void DivoomDisplay::dump_config()
 {
+    char uuid_buf[espbt::UUID_STR_LEN];
     LOG_DISPLAY("", "divoom", this);
     ESP_LOGCONFIG(TAG, "  Width: %d, Height: %d", this->width_, this->height_);
-    ESP_LOGCONFIG(TAG, "  MAC address        : %s", this->parent_->address_str().c_str());
-    ESP_LOGCONFIG(TAG, "  Service UUID       : %s", this->service_uuid_.to_str().c_str());
-    ESP_LOGCONFIG(TAG, "  Characteristic UUID: %s", this->char_uuid_.to_str().c_str());
+    ESP_LOGCONFIG(TAG, "  MAC address        : %s", this->parent_->address_str());
+    ESP_LOGCONFIG(TAG, "  Service UUID       : %s", this->service_uuid_.to_str(uuid_buf));
+    ESP_LOGCONFIG(TAG, "  Characteristic UUID: %s", this->char_uuid_.to_str(uuid_buf));
     ESP_LOGCONFIG(TAG, "  Update Interval: %u ms", this->get_update_interval());
 }
 
@@ -58,20 +59,21 @@ void DivoomDisplay::loop()
 
 void DivoomDisplay::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if, esp_ble_gattc_cb_param_t *param)
 {
-    switch (event) 
+    char uuid_buf[espbt::UUID_STR_LEN];
+    switch (event)
     {
     case ESP_GATTC_OPEN_EVT:
         connected_ = true;
         if (this->bt_connected_) this->bt_connected_->publish_state(connected_);
         this->client_state_ = espbt::ClientState::ESTABLISHED;
-        ESP_LOGW(TAG, "[%s] Connected successfully!", this->char_uuid_.to_str().c_str());
+        ESP_LOGW(TAG, "[%s] Connected successfully!", this->char_uuid_.to_str(uuid_buf));
         break;
     case ESP_GATTC_DISCONNECT_EVT:
         connected_ = false;
         synced_time_ = false;
         old_image_buffer_.clear();
         if (this->bt_connected_) this->bt_connected_->publish_state(connected_);
-        ESP_LOGW(TAG, "[%s] Disconnected", this->char_uuid_.to_str().c_str());
+        ESP_LOGW(TAG, "[%s] Disconnected", this->char_uuid_.to_str(uuid_buf));
         this->client_state_ = espbt::ClientState::IDLE;
         break;
     case ESP_GATTC_WRITE_CHAR_EVT:
@@ -83,12 +85,12 @@ void DivoomDisplay::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_
         auto *chr = this->parent()->get_characteristic(this->service_uuid_, this->char_uuid_);
         if (chr == nullptr)
         {
-            ESP_LOGW(TAG, "[%s] Characteristic not found.", this->char_uuid_.to_str().c_str());
+            ESP_LOGW(TAG, "[%s] Characteristic not found.", this->char_uuid_.to_str(uuid_buf));
             break;
         }
         if (param->write.handle == chr->handle)
         {
-            ESP_LOGW(TAG, "[%s] Write error, status=%d", this->char_uuid_.to_str().c_str(), param->write.status);
+            ESP_LOGW(TAG, "[%s] Write error, status=%d", this->char_uuid_.to_str(uuid_buf), param->write.status);
         }
         break;
     }
@@ -282,15 +284,16 @@ void DivoomDisplay::add_color_point(ColorPoint point)
 
 bool DivoomDisplay::write_data(std::vector<uint8_t> &data)
 {
+    char uuid_buf[espbt::UUID_STR_LEN];
     if (this->client_state_ != espbt::ClientState::ESTABLISHED)
     {
-        ESP_LOGW(TAG, "[%s] Not connected to BLE client.  State update can not be written.", this->char_uuid_.to_str().c_str());
+        ESP_LOGW(TAG, "[%s] Not connected to BLE client.  State update can not be written.", this->char_uuid_.to_str(uuid_buf));
         return false;
     }
     auto *chr = this->parent()->get_characteristic(this->service_uuid_, this->char_uuid_);
     if (chr == nullptr)
     {
-        ESP_LOGW(TAG, "[%s] Characteristic not found.  State update can not be written.", this->char_uuid_.to_str().c_str());
+        ESP_LOGW(TAG, "[%s] Characteristic not found.  State update can not be written.", this->char_uuid_.to_str(uuid_buf));
         return false;
     }
     if (this->require_response_)
@@ -447,7 +450,7 @@ void DivoomDisplay::sync_time_()
     auto time = this->time_->now();
     if (!time.is_valid())
     {
-        ESP_LOGW(TAG, "[%s] Time is not yet valid.  Time can not be synced.", this->parent_->address_str().c_str());
+        ESP_LOGW(TAG, "[%s] Time is not yet valid.  Time can not be synced.", this->parent_->address_str());
         return;
     }
     time.recalc_timestamp_utc(true);  // calculate timestamp of local time


### PR DESCRIPTION
## Summary
- Fixes a real build break in production: `esphome compile` on a real device config (`logger: level: DEBUG`) fails with `error: no matching function for call to 'ESPBTUUID::to_str()'` — `to_str()` takes a `std::span<char, 37>` output buffer, it doesn't return `std::string`.
- This is a follow-up to #314's `to_string()` → `to_str()` migration, which passed our own component tests only because none of them declare a `logger:` component — ESPHome silently strips `ESP_LOGCONFIG`/`ESP_LOGW` to no-ops in that case and never type-checks their arguments. Root-caused via the user's actual build log.
- Also fixes a second, previously-hidden bug in `divoom_display.cpp` the same gap was masking: `address_str()` already returns `const char*`, so chaining `.c_str()` on it doesn't compile either.

## Test plan
- [x] `esphome compile` for `ble_elm327` and `divoom` (esp32-idf) with `logger: level: DEBUG`/`VERY_VERBOSE` explicitly added — zero errors, zero warnings in our code.
- Test-hardening (adding `logger:` to every component's test config so this class of bug can't hide again) is a separate PR, since it's orthogonal to this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)