### PR TITLE
test: enable high-verbosity logging in every component test config

### DIFF
--- a/components/divoom/divoom_display.cpp
+++ b/components/divoom/divoom_display.cpp
@@ -20,7 +20,7 @@ void DivoomDisplay::dump_config()
     ESP_LOGCONFIG(TAG, "  MAC address        : %s", this->parent_->address_str());
     ESP_LOGCONFIG(TAG, "  Service UUID       : %s", this->service_uuid_.to_str(uuid_buf));
     ESP_LOGCONFIG(TAG, "  Characteristic UUID: %s", this->char_uuid_.to_str(uuid_buf));
-    ESP_LOGCONFIG(TAG, "  Update Interval: %u ms", this->get_update_interval());
+    ESP_LOGCONFIG(TAG, "  Update Interval: %lu ms", (unsigned long) this->get_update_interval());
 }
 
 void DivoomDisplay::update()

--- a/tests/components/axp192/common.yaml
+++ b/tests/components/axp192/common.yaml
@@ -27,3 +27,6 @@ axp192:
     name: "Screen Brightness"
   poweroff:
     name: "Power Off Button"
+
+logger:
+  level: VERY_VERBOSE

--- a/tests/components/bbq10_keyboard/common.yaml
+++ b/tests/components/bbq10_keyboard/common.yaml
@@ -17,3 +17,6 @@ bbq10_keyboard:
     name: Key
   last_key:
     name: Last Key
+
+logger:
+  level: VERY_VERBOSE

--- a/tests/components/ble_elm327/test.esp32-idf.yaml
+++ b/tests/components/ble_elm327/test.esp32-idf.yaml
@@ -45,3 +45,6 @@ sensor:
     update_interval: 5s
     formula: "return (e * 256.0f + f + x[6]);"
     unit_of_measurement: "V"
+
+logger:
+  level: VERY_VERBOSE

--- a/tests/components/bmi270/common.yaml
+++ b/tests/components/bmi270/common.yaml
@@ -31,3 +31,6 @@ sensor:
       name: "BMI270 Gyro Z"
     temperature:
       name: "BMI270 Temperature"
+
+logger:
+  level: VERY_VERBOSE

--- a/tests/components/bmm150/common.yaml
+++ b/tests/components/bmm150/common.yaml
@@ -8,6 +8,7 @@ esphome:
   name: test-bmm150
 
 logger:
+  level: VERY_VERBOSE
 
 i2c:
   sda: ${sda}

--- a/tests/components/divoom/test.esp32-idf.yaml
+++ b/tests/components/divoom/test.esp32-idf.yaml
@@ -37,3 +37,6 @@ display:
 time:
   - platform: sntp
     id: sntp_time
+
+logger:
+  level: VERY_VERBOSE

--- a/tests/components/ip5306/common.yaml
+++ b/tests/components/ip5306/common.yaml
@@ -31,3 +31,6 @@ ip5306:
     on_release:
       then:
         - lambda: ESP_LOGD("TEST", "still charging");
+
+logger:
+  level: VERY_VERBOSE

--- a/tests/components/jaalee_jht/test.esp32-idf.yaml
+++ b/tests/components/jaalee_jht/test.esp32-idf.yaml
@@ -20,3 +20,6 @@ sensor:
       name: "Jaalee JHT Humidity"
     battery_level:
       name: "Jaalee JHT Battery Level"
+
+logger:
+  level: VERY_VERBOSE

--- a/tests/components/lilygo_t_keyboard/test.esp32-ard.yaml
+++ b/tests/components/lilygo_t_keyboard/test.esp32-ard.yaml
@@ -15,3 +15,6 @@ lilygo_t_keyboard:
     name: press key
   release_key:
     name: release key
+
+logger:
+  level: VERY_VERBOSE

--- a/tests/components/m5unit_scales/common.yaml
+++ b/tests/components/m5unit_scales/common.yaml
@@ -60,3 +60,6 @@ number:
       name: "Scale EMA Filter"
     gap:
       name: "Scale Gap Value"
+
+logger:
+  level: VERY_VERBOSE

--- a/tests/components/sip_client/test.esp32-idf.g722.yaml
+++ b/tests/components/sip_client/test.esp32-idf.g722.yaml
@@ -17,6 +17,7 @@ wifi:
   password: "test_password"
 
 logger:
+  level: VERY_VERBOSE
 
 i2s_audio:
   - id: i2s_in

--- a/tests/components/sip_client/test.esp32-idf.mic-only.yaml
+++ b/tests/components/sip_client/test.esp32-idf.mic-only.yaml
@@ -17,6 +17,7 @@ wifi:
   password: "test_password"
 
 logger:
+  level: VERY_VERBOSE
 
 i2s_audio:
   - id: i2s_in

--- a/tests/components/sip_client/test.esp32-idf.speaker-only.yaml
+++ b/tests/components/sip_client/test.esp32-idf.speaker-only.yaml
@@ -17,6 +17,7 @@ wifi:
   password: "test_password"
 
 logger:
+  level: VERY_VERBOSE
 
 i2s_audio:
   - id: i2s_out

--- a/tests/components/sip_client/test.esp32-idf.yaml
+++ b/tests/components/sip_client/test.esp32-idf.yaml
@@ -17,6 +17,7 @@ wifi:
   password: "test_password"
 
 logger:
+  level: VERY_VERBOSE
 
 # Microphone/speaker can be any ESPHome platform (e.g. i2s_audio)
 i2s_audio:

--- a/tests/components/tca8418_keyboard/common.yaml
+++ b/tests/components/tca8418_keyboard/common.yaml
@@ -29,3 +29,6 @@ tca8418_keyboard:
     name: press key
   release_key:
     name: release key
+
+logger:
+  level: VERY_VERBOSE

--- a/tests/components/tcp_server/test.esp32-idf.yaml
+++ b/tests/components/tcp_server/test.esp32-idf.yaml
@@ -25,3 +25,6 @@ tcp_server:
     then:
       - lambda: |-
           ESP_LOGI("tcp", "Read %d bytes", len);
+
+logger:
+  level: VERY_VERBOSE

--- a/tests/components/uartex/common.yaml
+++ b/tests/components/uartex/common.yaml
@@ -430,3 +430,6 @@ media_player:
     command_pause:
       data: [0x02, 0x03, 0x00]
       ack: [0x02, 0x13, 0x00]
+
+logger:
+  level: VERY_VERBOSE

--- a/tests/components/uartex/common_rx_features.yaml
+++ b/tests/components/uartex/common_rx_features.yaml
@@ -7,6 +7,9 @@ external_components:
 esphome:
   name: test-uartex-rx-features
 
+logger:
+  level: VERY_VERBOSE
+
 uart:
   baud_rate: 9600
   data_bits: 8

--- a/tests/components/ws_bridge/test.esp32-idf.yaml
+++ b/tests/components/ws_bridge/test.esp32-idf.yaml
@@ -17,6 +17,7 @@ wifi:
   password: "test_password"
 
 logger:
+  level: VERY_VERBOSE
 
 ws_bridge:
   id: my_ws_bridge


### PR DESCRIPTION
## Summary
- #315 fixed a build break that only surfaced in production, not in CI, because no component test config declares a `logger:` component — ESPHome silently strips `ESP_LOGCONFIG`/`ESP_LOGW` calls down to no-ops in that case and never type-checks their arguments. This PR closes that gap so it can't happen again.
- Adds `logger: level: VERY_VERBOSE` to every component's test config (in the shared `common.yaml`/`common_rx_features.yaml` where one exists, so all variants of a component inherit it in one place).
- Recompiling everything with this change caught one more real bug it was hiding: a `%u` format specifier vs. `uint32_t` argument mismatch in `divoom_display.cpp`'s `dump_config()` (same class of issue already fixed in `ble_elm327` in #314) — fixed here too.

## Test plan
- [x] `esphome compile` for all 16 esp32-idf/esp32-ard test configs across every component — all `Successfully compiled program.`, zero warnings in our code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)